### PR TITLE
refactor(@roots/bud-react)

### DIFF
--- a/packages/extension-react/README.md
+++ b/packages/extension-react/README.md
@@ -36,6 +36,20 @@ When run in development mode `@pmmmwh/react-refresh-webpack-plugin` provides hot
 bud.use('@roots/bud-react')
 ```
 
+## Configuration
+
+You may configure `@pmmmwh/react-refresh-webpack-plugin` by passing plugin options to `bud.reactRefresh`, which is registered by this package.
+
+Default configuration:
+
+```js
+bud.reactRefresh({
+  overlay: {
+    sockIntegration: 'whm',
+  },
+})
+```
+
 ## Contributing
 
 Contributions are welcome from everyone.

--- a/packages/extension-react/package.json
+++ b/packages/extension-react/package.json
@@ -41,12 +41,12 @@
     "@roots/bud-typings": "^2.0.6"
   },
   "dependencies": {
-    "@babel/preset-react": "^7.12.1",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.2",
+    "@babel/preset-react": ">=7.12.7",
+    "@pmmmwh/react-refresh-webpack-plugin": ">=0.4.3",
     "@svgr/webpack": "^5.4.0",
-    "react": "latest",
-    "react-dom": "^17.0.1",
+    "react": ">=17.0.1",
+    "react-dom": ">=17.0.1",
     "react-refresh": "^0.9.0",
-    "type-fest": "^0.18.0"
+    "type-fest": ">=0.20.2"
   }
 }

--- a/packages/extension-react/src/@svgr/index.ts
+++ b/packages/extension-react/src/@svgr/index.ts
@@ -1,0 +1,35 @@
+import type {
+  RegisterLoader,
+  RegisterItem,
+  RegisterRule,
+} from '../types'
+
+/**
+ * @svgr-loader register loader
+ */
+export const registerLoader: RegisterLoader = [
+  '@svgr-loader',
+  require.resolve('@svgr/webpack'),
+]
+
+/**
+ * @svgr-loader register loader
+ */
+export const registerItem: RegisterItem = [
+  '@svgr',
+  {
+    ident: '@svgr',
+    loader: '@svgr-loader',
+  },
+]
+
+/**
+ * @svgr-loader register use
+ */
+export const registerRule: RegisterRule = [
+  '@svgr',
+  {
+    test: bud => bud.patterns.get('svg'),
+    use: bud => [bud.build.items.get('@svgr')],
+  },
+]

--- a/packages/extension-react/src/@svgr/rule.ts
+++ b/packages/extension-react/src/@svgr/rule.ts
@@ -1,0 +1,8 @@
+import type {RegisterRule} from '../types'
+
+export const test: RegisterRule.Test = ({patterns}) =>
+  patterns.get('svg')
+
+export const use: RegisterRule.Use = ({build}) => [
+  build.items.get('@svgr'),
+]

--- a/packages/extension-react/src/index.ts
+++ b/packages/extension-react/src/index.ts
@@ -1,52 +1,26 @@
-import {Bud} from '@roots/bud-typings'
-import ReactRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin'
+import type {Boot} from './types'
+
+import * as svgr from './@svgr'
+import * as refresh from './react-refresh'
 
 /**
- * Boot bud-jsx extension
+ * @roots/bud-react extension
  */
-export const boot = (bud: Bud.Contract): void => {
-  // Add babel preset
-  bud.build.items.set('babel.options.presets', [
+export const boot: Boot = ({build, use}) => {
+  /**
+   * Register @babel/preset-react
+   */
+  build.items.merge('babel.options.presets', [
     '@babel/preset-react',
   ])
 
   /**
-   * Everything else is dev only
+   * Register @pmmmwh/react-refresh-webpack-plugin
    */
-  if (!bud.mode.is('development')) return
+  use(['@pmmmwh/react-refresh-webpack-plugin', refresh])
 
-  // Add react-refresh webpack plugin
-  bud.extensions.set('react-reresh', {
-    make: opts => new ReactRefreshPlugin(opts.getStore()),
-    when: bud => bud.mode.is('development'),
-    options: {
-      overlay: {
-        sockIntegration: 'whm',
-      },
-    },
-  })
-
-  // Add react-refresh babel plugin
-  bud.build.items.set('babel.options.plugins', [
-    require.resolve('react-refresh/babel'),
-  ])
+  /**
+   * Register @svgr-loader
+   */
+  use(['@svgr', svgr])
 }
-
-/**
- * @svgr loader
- */
-export const registerLoader = [
-  '@svgr-loader',
-  require.resolve('@svgr/webpack'),
-]
-
-export const registerItem = [
-  '@svgr',
-  {
-    test: ({patterns}: Bud.Contract): RegExp =>
-      patterns.get('svg'),
-    use: ['@svgr-loader'],
-  },
-]
-
-export type RefreshOptions = ReactRefreshPlugin['options']

--- a/packages/extension-react/src/react-refresh/api.ts
+++ b/packages/extension-react/src/react-refresh/api.ts
@@ -1,0 +1,11 @@
+import type {API} from '../types'
+
+export const reactRefresh: API.ReactRefresh = function (
+  options,
+) {
+  this.extensions
+    .get('@pmmmwh/react-refresh-webpack-plugin')
+    .setStore(options)
+
+  return this
+}

--- a/packages/extension-react/src/react-refresh/index.ts
+++ b/packages/extension-react/src/react-refresh/index.ts
@@ -1,0 +1,39 @@
+import type {Boot, Make, Options, When} from '../types'
+import ReactRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin'
+
+/**
+ * Adds bud.reactRefresh() config handler.
+ */
+export * as api from './api'
+
+/**
+ * Register babel plugin: react-refresh/babel
+ *
+ * Only applied in development.
+ */
+export const boot: Boot = ({build, mode}) => {
+  !mode.is('development') &&
+    build.items.merge('babel.options.plugins', [
+      require.resolve('react-refresh/babel'),
+    ])
+}
+
+/**
+ * @pmmmwh/react-refresh-webpack-plugin implementation
+ */
+export const make: Make = opts =>
+  new ReactRefreshPlugin(opts.getStore())
+
+/**
+ * @pmmmwh/react-refresh-webpack-plugin conditions
+ */
+export const when: When = ({mode}) => mode.is('development')
+
+/**
+ * @pmmmwh/react-refresh-webpack-plugin options
+ */
+export const options: Options = {
+  overlay: {
+    sockIntegration: 'whm',
+  },
+}

--- a/packages/extension-react/src/react-refresh/index.ts
+++ b/packages/extension-react/src/react-refresh/index.ts
@@ -12,7 +12,7 @@ export * as api from './api'
  * Only applied in development.
  */
 export const boot: Boot = ({build, mode}) => {
-  !mode.is('development') &&
+  mode.is('development') &&
     build.items.merge('babel.options.plugins', [
       require.resolve('react-refresh/babel'),
     ])

--- a/packages/extension-react/src/types.ts
+++ b/packages/extension-react/src/types.ts
@@ -1,0 +1,69 @@
+import {
+  Bud,
+  Extension,
+  Item,
+  Loader,
+  Rule,
+} from '@roots/bud-typings'
+import ReactRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin'
+import {ReactRefreshPluginOptions} from '@pmmmwh/react-refresh-webpack-plugin/types/types'
+
+/**
+ * Make extension
+ */
+export type Make = Extension.Make<
+  ReactRefreshPlugin,
+  ReactRefreshPluginOptions
+>
+
+/**
+ * Extension options
+ */
+export type Options = Extension.RawOptions<
+  ReactRefreshPluginOptions
+>
+
+/**
+ * Extension conditions
+ */
+export type When = Extension.When
+
+/**
+ * Register Loader
+ */
+export type RegisterLoader = Extension.RegisterOne<Loader>
+
+/**
+ * Register Rule
+ */
+export type RegisterRule = [
+  string,
+  {
+    test: (bud: Bud.Bud) => RegExp
+    use: (bud: Bud.Bud) => Rule.Module['use']
+  },
+]
+export namespace RegisterRule {
+  export type Test = (bud: Bud.Bud) => RegExp
+  export type Use = (bud: Bud.Bud) => Rule.Module['use']
+}
+
+/**
+ * Register Item
+ */
+export type RegisterItem = Extension.RegisterOne<Item.Module>
+
+/**
+ * Extension Boot alias
+ */
+export type Boot = Extension.Boot
+
+/**
+ * API
+ */
+export namespace API {
+  export type ReactRefresh = (
+    this: Bud.Bud,
+    options: ReactRefreshPluginOptions,
+  ) => Bud.Bud
+}

--- a/packages/extension-react/src/types/index.d.ts
+++ b/packages/extension-react/src/types/index.d.ts
@@ -1,1 +1,0 @@
-export * from '@roots/bud-typings'


### PR DESCRIPTION
refactor @roots/bud-react. Add bud.reactRefresh  fn.

affects: @roots/bud-react

## Type of change

- [x] MINOR: feature

## Affected packages

- @roots/bud-react

## Details

Makes `@roots/bud-react` a lot easier to read.

Adds `bud.reactRefresh` method for configuring plugin behavior in userland.