### PR TITLE
feat(sage): dont run imagemin by default

### DIFF
--- a/packages/@roots/sage/package.json
+++ b/packages/@roots/sage/package.json
@@ -70,7 +70,6 @@
     "@roots/bud-preset-recommend": "^3.0.82-alpha.0",
     "@roots/bud-prettier": "^3.0.82-alpha.0",
     "@roots/bud-react": "^3.0.82-alpha.0",
-    "@roots/bud-sass": "^3.0.82-alpha.0",
     "@roots/bud-stylelint": "^3.0.82-alpha.0",
     "@roots/bud-tailwindcss": "^3.0.82-alpha.0",
     "@roots/bud-typescript": "^3.0.82-alpha.0",

--- a/packages/@roots/sage/package.json
+++ b/packages/@roots/sage/package.json
@@ -70,6 +70,7 @@
     "@roots/bud-preset-recommend": "^3.0.82-alpha.0",
     "@roots/bud-prettier": "^3.0.82-alpha.0",
     "@roots/bud-react": "^3.0.82-alpha.0",
+    "@roots/bud-sass": "^3.0.82-alpha.0",
     "@roots/bud-stylelint": "^3.0.82-alpha.0",
     "@roots/bud-tailwindcss": "^3.0.82-alpha.0",
     "@roots/bud-typescript": "^3.0.82-alpha.0",

--- a/packages/@roots/sage/src/sage/index.ts
+++ b/packages/@roots/sage/src/sage/index.ts
@@ -12,7 +12,6 @@ import * as entrypoints from '@roots/bud-entrypoints'
 import * as dependencies from '@roots/bud-wordpress-dependencies'
 import * as externals from '@roots/bud-wordpress-externals'
 import * as manifests from '@roots/bud-wordpress-manifests'
-import * as imagemin from '@roots/bud-imagemin'
 
 /**
  * Bud preset: @roots/sage
@@ -124,7 +123,7 @@ export const sage: Sage = (sage =>
        * Production
        */
       (sage: Sage) => {
-        sage.use(imagemin).minify().hash().vendor().runtime()
+        sage.minify().hash().vendor().runtime('single')
       },
 
       /**


### PR DESCRIPTION
## Type of change

- [x] MINOR: feature

## Affected packages

- [@roots/sage](https://github.com/roots/bud/tree/stable/packages/%40roots/sage)

## Dependencies added

- ~~[@roots/bud-sass](https://github.com/roots/bud/tree/stable/packages/%40roots/bud-sass)~~

## Details

It is difficult to "un-use" an extension once it has already been `use()`d.

This PR removes `imagemin` by default.

It changes a couple of other defaults as well.

- ~~Install bud-sass.~~
- Use single runtime.
- Don't run imagemin.