### PR TITLE
3.0.113

### DIFF
--- a/packages/@roots/bud-typings/contracts/Extensions.d.ts
+++ b/packages/@roots/bud-typings/contracts/Extensions.d.ts
@@ -13,6 +13,8 @@ import {Framework, Hooks, MappedType, Service} from './'
 export declare interface Extensions extends Service {
   add(extension): void
 
+  get(name: string): Extension
+
   set<Extension>(name: string, extension: Extension): this
 
   use(pkg: string): this
@@ -31,17 +33,70 @@ export declare interface Extensions extends Service {
  * [🧑‍💻 roots/bud](https://git.io/Jkli3)
  */
 export interface Extension extends Framework.Service {
+  /**
+   * Module
+   */
+  readonly module: Module
+
+  /**
+   * App
+   */
   readonly app: Framework
 
-  make(): Webpack.Plugin
+  /**
+   * Logging
+   */
+  readonly logger: Framework['logger']
 
-  isPlugin(): boolean
+  /**
+   * Name
+   */
+  name: Module['name']
 
-  isPluginEnabled(): boolean
+  /**
+   * Options
+   */
+  options: Module['options']
 
-  setOptions(options: Framework.Index<any>): void
+  /**
+   * Development Dependencies
+   */
+  dependencies: Module['dependencies']
 
-  setBuilders(builders: [string, CallableFunction][]): void
+  /**
+   * Development Dependencies
+   */
+  devDependencies: Module['devDependencies']
+
+  /**
+   * When
+   */
+  when: Module['when']
+
+  /**
+   * Make
+   */
+  make: Module['make']
+
+  /**
+   * Install package dependencies
+   */
+  install(): void
+
+  /**
+   * Make hook key from module property
+   */
+  makeKey(key: ModuleKey): Framework.Hooks.Name
+
+  /**
+   * Get module properties (hooked)
+   */
+  get(key: ModuleKey): any
+
+  /**
+   * Set module properties (hooked)
+   */
+  set(key: ModuleKey, value: any): void
 }
 
 /**

--- a/packages/@roots/bud/src/services/Logger/index.ts
+++ b/packages/@roots/bud/src/services/Logger/index.ts
@@ -105,10 +105,7 @@ export class Logger implements Contract, Bootstrapper {
    * Framework lifecycle: registered
    */
   public registered(app: Framework) {
-    if (
-      app.store.enabled('options.log') ||
-      app.store.enabled('options.ci')
-    ) {
+    if (app.store.enabled('options.log')) {
       app.logger.instance.enable()
     }
   }


### PR DESCRIPTION
## Type of change

- [x] PATCH: bugfix

## Affected packages

- @roots/bud
- @roots/bud-typings

## Dependencies added

None

## Issues fixed

None

## Details

Previously, `--ci` would enable logging. This change reverts that behavior to how it was originally. Users who want to use webpack cli output with logging will need to pass both `--ci` and `--log` flags.

Also, snuck in some updated Framework.Extension typings 🤷‍♀️

~~If this looks good I think we're probably ready to ship it as `3.1` after I've updated the changelog and done a couple other maintenance tasks.~~ 

Let's also add the feature where `bud.assets` adds globs to `server.watch.files` before 3.1 release.