### PR TITLE
fix: filesystem caching issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,211 +1,154 @@
-repo:
-  - ./*
-
-@roots/bud:
+'@roots/bud':
   - packages/@roots/bud/*
-  - packages/@roots/bud/**/*
-
-@roots/bud-api:
+  - packages/@roots/bud/**
+'@roots/bud-api':
   - packages/@roots/bud-api/*
-  - packages/@roots/bud-api/**
-
-@roots/bud-babel:
+  - packages/@roots/bud-api/*
+'@roots/bud-babel':
   - packages/@roots/bud-babel/*
   - packages/@roots/bud-babel/**
-
-@roots/bud-build:
+'@roots/bud-build':
   - packages/@roots/bud-build/*
   - packages/@roots/bud-build/**
-
-@roots/bud-cache:
+'@roots/bud-cache':
   - packages/@roots/bud-cache/*
   - packages/@roots/bud-cache/**
-
-@roots/bud-cli:
+'@roots/bud-cli':
   - packages/@roots/bud-cli/*
   - packages/@roots/bud-cli/**
-
-@roots/bud-compiler:
+'@roots/bud-compiler':
   - packages/@roots/bud-compiler/*
   - packages/@roots/bud-compiler/**
-
-@roots/bud-criticalcss:
+'@roots/bud-criticalcss':
   - packages/@roots/bud-criticalcss/*
   - packages/@roots/bud-criticalcss/**
-
-@roots/bud-dashboard:
+'@roots/bud-dashboard':
   - packages/@roots/bud-dashboard/*
   - packages/@roots/bud-dashboard/**
-
-@roots/bud-emotion:
+'@roots/bud-emotion':
   - packages/@roots/bud-emotion/*
   - packages/@roots/bud-emotion/**
-
-@roots/bud-entrypoints:
+'@roots/bud-entrypoints':
   - packages/@roots/bud-entrypoints/*
   - packages/@roots/bud-entrypoints/**
-
-@roots/bud-esbuild:
+'@roots/bud-esbuild':
   - packages/@roots/bud-esbuild/*
   - packages/@roots/bud-esbuild/**
-
-@roots/bud-eslint:
+'@roots/bud-eslint':
   - packages/@roots/bud-eslint/*
   - packages/@roots/bud-eslint/**
-
-@roots/bud-extensions:
+'@roots/bud-extensions':
   - packages/@roots/bud-extensions/*
   - packages/@roots/bud-extensions/**
-
-@roots/bud-framework:
+'@roots/bud-framework':
   - packages/@roots/bud-framework/*
   - packages/@roots/bud-framework/**
-
-@roots/bud-hooks:
+'@roots/bud-hooks':
   - packages/@roots/bud-hooks/*
   - packages/@roots/bud-hooks/**
-
-@roots/bud-imagemin:
+'@roots/bud-imagemin':
   - packages/@roots/bud-imagemin/*
   - packages/@roots/bud-imagemin/**
-
-@roots/bud-library:
+'@roots/bud-library':
   - packages/@roots/bud-library/*
   - packages/@roots/bud-library/**
-
-@roots/bud-mdx:
+'@roots/bud-mdx':
   - packages/@roots/bud-mdx/*
   - packages/@roots/bud-mdx/**
-
-@roots/bud-postcss:
+'@roots/bud-postcss':
   - packages/@roots/bud-postcss/*
   - packages/@roots/bud-postcss/**
-
-@roots/bud-preset-recommend:
+'@roots/bud-preset-recommend':
   - packages/@roots/bud-preset-recommend/*
   - packages/@roots/bud-preset-recommend/**
-
-@roots/bud-prettier:
+'@roots/bud-prettier':
   - packages/@roots/bud-prettier/*
   - packages/@roots/bud-prettier/**
-
-@roots/bud-purgecss:
+'@roots/bud-purgecss':
   - packages/@roots/bud-purgecss/*
   - packages/@roots/bud-purgecss/**
-
-@roots/bud-react:
+'@roots/bud-react':
   - packages/@roots/bud-react/*
   - packages/@roots/bud-react/**
-
-@roots/bud-sass:
+'@roots/bud-sass':
   - packages/@roots/bud-sass/*
   - packages/@roots/bud-sass/**
-
-@roots/bud-server:
+'@roots/bud-server':
   - packages/@roots/bud-server/*
   - packages/@roots/bud-server/**
-
-@roots/bud-stylelint:
+'@roots/bud-stylelint':
   - packages/@roots/bud-stylelint/*
   - packages/@roots/bud-stylelint/**
-
-@roots/bud-support:
+'@roots/bud-support':
   - packages/@roots/bud-support/*
   - packages/@roots/bud-support/**
-
-@roots/bud-tailwindcss:
+'@roots/bud-tailwindcss':
   - packages/@roots/bud-tailwindcss/*
   - packages/@roots/bud-tailwindcss/**
-
-@roots/bud-terser:
+'@roots/bud-terser':
   - packages/@roots/bud-terser/*
   - packages/@roots/bud-terser/**
-
-@roots/bud-typescript:
+'@roots/bud-typescript':
   - packages/@roots/bud-typescript/*
   - packages/@roots/bud-typescript/**
-
-@roots/bud-typings:
+'@roots/bud-typings':
   - packages/@roots/bud-typings/*
   - packages/@roots/bud-typings/**
-
-@roots/bud-vue:
+'@roots/bud-vue':
   - packages/@roots/bud-vue/*
   - packages/@roots/bud-vue/**
-
-@roots/bud-wordpress-dependencies:
+'@roots/bud-wordpress-dependencies':
   - packages/@roots/bud-wordpress-dependencies/*
   - packages/@roots/bud-wordpress-dependencies/**
-
-@roots/bud-wordpress-externals:
+'@roots/bud-wordpress-externals':
   - packages/@roots/bud-wordpress-externals/*
   - packages/@roots/bud-wordpress-externals/**
-
-@roots/bud-wordpress-manifests:
+'@roots/bud-wordpress-manifests':
   - packages/@roots/bud-wordpress-manifests/*
   - packages/@roots/bud-wordpress-manifests/**
-
-@roots/container:
+'@roots/container':
   - packages/@roots/container/*
   - packages/@roots/container/**
-
-@roots/critical-css-webpack-plugin:
+'@roots/critical-css-webpack-plugin':
   - packages/@roots/critical-css-webpack-plugin/*
   - packages/@roots/critical-css-webpack-plugin/**
-
-@roots/dependencies:
+'@roots/dependencies':
   - packages/@roots/dependencies/*
   - packages/@roots/dependencies/**
-
-@roots/entrypoints-webpack-plugin:
+'@roots/entrypoints-webpack-plugin':
   - packages/@roots/entrypoints-webpack-plugin/*
   - packages/@roots/entrypoints-webpack-plugin/**
-
-@roots/filesystem:
+'@roots/filesystem':
   - packages/@roots/filesystem/*
   - packages/@roots/filesystem/**
-
-@roots/ink-prettier:
+'@roots/ink-prettier':
   - packages/@roots/ink-prettier/*
   - packages/@roots/ink-prettier/**
-
-@roots/ink-use-style:
+'@roots/ink-use-style':
   - packages/@roots/ink-use-style/*
   - packages/@roots/ink-use-style/**
-
-@roots/merged-manifest-webpack-plugin:
+'@roots/merged-manifest-webpack-plugin':
   - packages/@roots/merged-manifest-webpack-plugin/*
   - packages/@roots/merged-manifest-webpack-plugin/**
-
-@roots/sage:
+'@roots/sage':
   - packages/@roots/sage/*
   - packages/@roots/sage/**
-
-@roots/wordpress-dependencies-webpack-plugin:
+'@roots/wordpress-dependencies-webpack-plugin':
   - packages/@roots/wordpress-dependencies-webpack-plugin/*
   - packages/@roots/wordpress-dependencies-webpack-plugin/**
-
-@roots/wordpress-externals-webpack-plugin:
+'@roots/wordpress-externals-webpack-plugin':
   - packages/@roots/wordpress-externals-webpack-plugin/*
   - packages/@roots/wordpress-externals-webpack-plugin/**
-
-examples:
+'examples':
   - examples/*
   - examples/**
-
-docs:
+'docs':
   - docs/*
   - docs/**
   - packages/**/docs/*
   - packages/**/docs/**/*
-
-dev:
-- any: ['dev/**/*']
-  all: ['!dev/docs/src/**/*', '!dev/docs/src/*']
-
-dependencies:
+'dependencies':
   - package.lock
-
-test:
+'test':
   - src/**/*.spec.js
 

--- a/examples/sage/bud.config.yml
+++ b/examples/sage/bud.config.yml
@@ -6,4 +6,3 @@ entry:
   customizer: '**/customizer.{ts,css}'
 assets:
   - assets/images
-persist: false

--- a/packages/@roots/bud-api/src/docs/path.md
+++ b/packages/@roots/bud-api/src/docs/path.md
@@ -6,7 +6,7 @@
 
 - The second is an optional string which will be joined on the path returned from the first param.
 
-Paths can be redefined using [bud.setPath](config-setPath.md).
+Paths can be redefined using [bud.setPath](docs:config/setPath).
 
 ## Usage
 

--- a/packages/@roots/bud-api/src/docs/use.md
+++ b/packages/@roots/bud-api/src/docs/use.md
@@ -4,7 +4,7 @@ description: Extend Bud with additional packaged functionality.
 
 # bud.use
 
-Registers a [Bud extension](extending-using-extensions.md).
+Registers a [Bud extension](config:extending).
 
 ## Usage
 

--- a/packages/@roots/bud-build/src/Build/config.ts
+++ b/packages/@roots/bud-build/src/Build/config.ts
@@ -1,4 +1,5 @@
 import type {Framework} from '@roots/bud-framework'
+import {resolve} from 'path'
 
 export function config(this: Framework): void {
   this.hooks
@@ -40,15 +41,13 @@ export function config(this: Framework): void {
       'extensions',
       'modules',
     ])
-    .hooks.link('build/module', ['rules'])
+    .hooks.link('build/module', ['rules', 'unsafeCache'])
     .hooks.link('build/cache', [
       'name',
       'type',
-      'directory',
+      'cacheDirectory',
       'cacheLocation',
-      'buildDependencies',
       'version',
-      'type',
     ])
     .hooks.link('build/output', [
       'path',
@@ -60,22 +59,16 @@ export function config(this: Framework): void {
     .on('build/bail', true)
     .hooks.on(
       'build/cache/name',
-      () => `${this.name}-${this.cache.version}`,
+      () => `${this.name}-${this.mode}`,
     )
-    .hooks.on('build/cache/type', 'filesystem')
     .hooks.on('build/cache/version', () => this.cache.version)
+    .hooks.on('build/cache/type', () => 'filesystem')
+    .hooks.on('build/cache/cacheDirectory', () =>
+      this.path('storage'),
+    )
     .hooks.on('build/cache/cacheLocation', () =>
-      this.path('storage'),
+      resolve(this.path('storage'), 'pack'),
     )
-    .hooks.on('build/cache/directory', () =>
-      this.path('storage'),
-    )
-    .hooks.on('build/cache/buildDependencies', () => ({
-      project: [
-        this.path('project', `${this.name}.config.js`),
-        this.path('project', 'package.json'),
-      ],
-    }))
     .hooks.on('build/node', false)
     .hooks.on('build/context', () => this.path('project'))
     .hooks.on('build/devtool', false)
@@ -124,7 +117,7 @@ export function config(this: Framework): void {
     )
     .hooks.on('build/performance', () => ({}))
     .hooks.on('build/plugins', () => this.extensions.make())
-    .hooks.on('build/profile', false)
+    .hooks.on('build/profile', () => true)
     .hooks.on('build/recordsPath', () =>
       this.path('storage', 'records.json'),
     )
@@ -138,9 +131,9 @@ export function config(this: Framework): void {
       this.hooks.filter('location/modules'),
       ...this.discovery.resolveFrom,
     ])
-    .hooks.on('build/stats', false)
-    .hooks.on('build/target', 'web')
-    .hooks.on('build/watch', false)
+    .hooks.on('build/stats', () => ({}))
+    .hooks.on('build/target', () => 'web')
+    .hooks.on('build/watch', () => false)
     .hooks.on('build/watchOptions', () => ({
       ignored: [this.store.get('patterns.modules').toString()],
       poll: 1000,

--- a/packages/@roots/bud-cache/src/index.ts
+++ b/packages/@roots/bud-cache/src/index.ts
@@ -1,10 +1,10 @@
-import {Service} from '@roots/bud-framework'
+import {Service, Cache as Base} from '@roots/bud-framework'
 import crypto from 'crypto'
-import {readFileSync, mkdirSync, pathExistsSync} from 'fs-extra'
+import {mkdirSync, pathExistsSync, readFileSync} from 'fs-extra'
 import {boundMethod as bind} from 'autobind-decorator'
 import {sync} from 'globby'
 
-class Cache extends Service {
+class Cache extends Service implements Base {
   public name = '@roots/bud-cache'
 
   @bind
@@ -22,35 +22,23 @@ class Cache extends Service {
     )
   }
 
-  public get version() {
-    const conf =
-      JSON.stringify(
-        sync(
-          this.app.path('project', `\.?${this.app.name}*`),
-        ).reduce(
-          (a: string, c: string) =>
-            `${a}${readFileSync(c, 'utf8')}`,
-          '',
-        ),
-      ) ?? ''
-
+  public get version(): string {
     return crypto
       .createHash('md4')
-      .update(`${conf}${this.json}`)
+      .update(this.projectHash)
       .digest('hex')
   }
 
-  public get json() {
-    return pathExistsSync(
-      this.app.path('project', 'package.json'),
+  public get projectHash(): string {
+    return JSON.stringify(
+      sync([
+        this.app.path('project', `${this.app.name}.*`),
+        this.app.path('project', 'package.json'),
+      ]).reduce(
+        (all, file) => all.concat(readFileSync(file, 'utf8')),
+        '',
+      ) ?? '{}',
     )
-      ? JSON.stringify(
-          readFileSync(
-            this.app.path('project', 'package.json'),
-            'utf8',
-          ) ?? '',
-        )
-      : `{}`
   }
 }
 

--- a/packages/@roots/bud-compiler/src/Compiler/index.ts
+++ b/packages/@roots/bud-compiler/src/Compiler/index.ts
@@ -41,7 +41,7 @@ export default class extends Service implements Compiler {
   @bind
   public compile(
     config?: Compiler.Config,
-    cb?: (err?: Error, stats?: any) => void,
+    cb?: (err?: Error, stats?: any) => undefined,
   ): Compiler.Instance {
     if (this.isCompiled) {
       return this.instance

--- a/packages/@roots/bud-dashboard/src/Dashboard/Dashboard.tsx
+++ b/packages/@roots/bud-dashboard/src/Dashboard/Dashboard.tsx
@@ -5,14 +5,8 @@ import {Text, Static, Box, useInput} from 'ink'
 import {useStyle} from '@roots/ink-use-style'
 import {isEqual} from 'lodash'
 
-import {
-  Assets,
-  Time,
-  Git,
-  Progress,
-  Module,
-} from '../components/index'
-import {useCompilation, usePackageJson} from '../hooks/index'
+import {Assets, Time, Git, Progress, Module} from '../components'
+import {useCompilation, usePackageJson} from '../hooks'
 
 const Dashboard: Dashboard.Component = ({bud}) => {
   const compilation = useCompilation(bud)
@@ -28,17 +22,8 @@ const Dashboard: Dashboard.Component = ({bud}) => {
   })
 
   useEffect(() => {
-    if (!bud.isProduction) return
-
-    const isComplete = compilation?.progress?.decimal >= 1
-    const shouldExit = isComplete || compilation?.hasErrors
-
-    shouldExit && setTimeout(() => process.exit())
-  }, [
-    compilation.stats,
-    compilation.progress,
-    compilation.errors,
-  ])
+    compilation.closed && process.exit()
+  }, [compilation])
 
   const appProps: Dashboard.AppProps = {
     bud,

--- a/packages/@roots/bud-dashboard/src/Dashboard/index.tsx
+++ b/packages/@roots/bud-dashboard/src/Dashboard/index.tsx
@@ -29,10 +29,6 @@ export class Dashboard extends Base {
 
   @bind
   public run(): void {
-    if (this.app.store.get('ci')) {
-      return
-    }
-
     this.info('Initializing dashboard')
 
     if (this.app.store.isTrue('ci')) {

--- a/packages/@roots/bud-dashboard/src/interface.ts
+++ b/packages/@roots/bud-dashboard/src/interface.ts
@@ -1,4 +1,3 @@
-import '@roots/bud-compiler'
 import type {Styles} from '@roots/ink-use-style'
 import type React from 'react'
 import type {StatsCompilation} from 'webpack'
@@ -33,6 +32,7 @@ declare module '@roots/bud-framework' {
       hasErrors: boolean
       warnings?: Compilation.WebpackMessage[]
       hasWarnings: boolean
+      closed: boolean
     }
 
     namespace Compilation {

--- a/packages/@roots/bud-framework/src/Cache/index.ts
+++ b/packages/@roots/bud-framework/src/Cache/index.ts
@@ -1,11 +1,11 @@
 import {Service} from '../Service'
 
-export declare interface Cache extends Service {
+declare interface Cache extends Service {
   /**
    * ## cache.version
    *
-   * A hash created from the stringified contents of the project config
-   * and package.json
+   * A hash created from the stringified contents of the project config files
+   * and its dependencies.
    */
   version: string
 
@@ -24,3 +24,5 @@ export declare interface Cache extends Service {
    */
   enabled(): boolean
 }
+
+export {Cache}

--- a/packages/@roots/bud-framework/src/Compiler/index.ts
+++ b/packages/@roots/bud-framework/src/Compiler/index.ts
@@ -8,6 +8,11 @@ export interface Compiler extends Service {
   instance: Compiler.Instance
 
   /**
+   * Has already been ran
+   */
+  isCompiled: boolean
+
+  /**
    * Compiler stats output
    */
   stats: any

--- a/packages/@roots/bud-framework/src/Hooks/index.ts
+++ b/packages/@roots/bud-framework/src/Hooks/index.ts
@@ -275,11 +275,13 @@ namespace Hooks {
             'module/rules/oneOf'
           >
         | 'build/module/rules/parser'
+        | 'build/module/unsafeCache'
         | keyof Dive<Config['resolve'], 'resolve'>
         | keyof Dive<Config['resolveLoader'], 'resolveLoader'>
         | 'build/cache/name'
         | 'build/cache/cacheLocation'
-        | 'build/cache/directory'
+        | 'build/cache/cacheDirectory'
+        | 'build/cache/hashAlgorithm'
         | 'build/cache/version'
         | 'build/cache/type'
         | 'build/cache/buildDependencies'

--- a/packages/@roots/bud-server/src/util/injectClient.ts
+++ b/packages/@roots/bud-server/src/util/injectClient.ts
@@ -19,13 +19,12 @@ export const injectClient: InjectClient = (app, injection) => {
   app.hooks.on(
     'build/entry',
     (entry: Webpack.Entry): Webpack.Entry => ({
-      'bud-dev': injection,
       ...Object.entries(entry).reduce(
-        (entries, [name, assets]) => ({
+        (entries, [name, asset]) => ({
           ...entries,
           [name]: {
-            ...assets,
-            dependOn: ['bud-dev', ...(assets.dependOn ?? [])],
+            ...asset,
+            import: [...asset.import, ...injection],
           },
         }),
         {},

--- a/packages/@roots/bud/src/extensions/index.ts
+++ b/packages/@roots/bud/src/extensions/index.ts
@@ -4,7 +4,6 @@ import * as HotModuleReplacementPlugin from './webpack-hot-module-replacement-pl
 import * as WebpackManifestPlugin from './webpack-manifest-plugin'
 import * as CleanWebpackPlugin from './clean-webpack-plugin'
 import * as CopyWebpackPlugin from './copy-webpack-plugin'
-import * as HtmlHardDiskPlugin from './html-hard-disk-plugin'
 import * as CssMinimizerWebpackPlugin from './css-minimizer-webpack-plugin'
 import * as HtmlWebpackPlugin from './html-webpack-plugin'
 import * as IgnoreEmitWebpackPlugin from './ignore-emit-webpack-plugin'
@@ -21,7 +20,6 @@ export const extensions = {
   [DefineWebpackPlugin.name]: DefineWebpackPlugin,
   [HotModuleReplacementPlugin.name]: HotModuleReplacementPlugin,
   [HtmlWebpackPlugin.name]: HtmlWebpackPlugin,
-  [HtmlHardDiskPlugin.name]: HtmlHardDiskPlugin,
   [IgnoreEmitWebpackPlugin.name]: IgnoreEmitWebpackPlugin,
   [InterpolateHtmlPlugin.name]: InterpolateHtmlPlugin,
   [WebpackManifestPlugin.name]: WebpackManifestPlugin,


### PR DESCRIPTION
## Affected packages

- @roots/bud-api
- @roots/bud-build
- @roots/bud-cache
- @roots/bud-dashboard

## Details

Fixes issues related to filesystem persistent caching.

- Prevent process from exiting before cache is written to storage.
- Include `yml`, `json`, and `ts` configurations for cache versioning.

FS caching still seems slow. Post emit, webpack's progress message is `Caching`, and it almost feels like the process is hung. But, there is an actively animated spinner, which indicates that it is not. Eventually, the process will close and the cache will be written. Rebuilds will be snappy, as expected.

This issue does not effect building with the `--ci` flag.