### PR TITLE
fix: catch fatal errors for non git projects and git repos without commits

### DIFF
--- a/packages/@roots/bud-dashboard/src/hooks/useGit.ts
+++ b/packages/@roots/bud-dashboard/src/hooks/useGit.ts
@@ -34,14 +34,14 @@ export const useGit = (): Dashboard.UseGit.Status => {
             '--short',
           ])
 
-          const status = stdout.toString()
+          const statusRes = stdout.toString()
             ? '0'
             : stdout
                 .toString()
                 .split('\n')
                 .filter(item => item !== '').length
 
-          !isEqual(status, status) && setStatus(status)
+          !isEqual(status, statusRes) && setStatus(statusRes)
         } catch (err) {
           return
         }

--- a/packages/@roots/bud-dashboard/src/hooks/useGit.ts
+++ b/packages/@roots/bud-dashboard/src/hooks/useGit.ts
@@ -1,59 +1,91 @@
 import {useState, useEffect} from 'react'
 import execa from 'execa'
 import {Dashboard} from '@roots/bud-framework'
+import {isEqual} from 'lodash'
 
 export const useGit = (): Dashboard.UseGit.Status => {
+  const [isRepo, setIsRepo] = useState(null)
   const [head, setHead] = useState(null)
   const [branch, setBranch] = useState(null)
   const [status, setStatus] = useState(null)
 
   useEffect(() => {
-    setInterval(async () => {
-      const update = await execa('git', ['status', '--short'])
+    isEqual(isRepo, null) &&
+      (async () => {
+        try {
+          await execa('git', [
+            'rev-parse',
+            '--is-inside-work-tree',
+          ])
 
-      if (update !== status) {
-        setStatus(update)
-      }
-    }, 1000)
+          setIsRepo(true)
+        } catch (err) {
+          setIsRepo(false)
+        }
+      })()
   }, [])
 
   useEffect(() => {
-    setInterval(async () => {
-      const revision = await execa('git', [
-        'rev-parse',
-        '--short',
-        'HEAD',
-        '--no-color',
-      ])
+    isRepo &&
+      setInterval(async () => {
+        try {
+          const {stdout} = await execa('git', [
+            'status',
+            '--short',
+          ])
 
-      setHead(revision)
-    })
-  }, [])
+          const status = stdout.toString()
+            ? '0'
+            : stdout
+                .toString()
+                .split('\n')
+                .filter(item => item !== '').length
+
+          !isEqual(status, status) && setStatus(status)
+        } catch (err) {
+          return
+        }
+      }, 1000)
+  }, [isRepo])
 
   useEffect(() => {
-    setInterval(async () => {
-      const branch = await execa('git', [
-        'branch',
-        '--show-current',
-        '--no-color',
-      ])
+    isRepo &&
+      setInterval(async () => {
+        const {stdout} = await execa('git', [
+          'branch',
+          '--show-current',
+          '--no-color',
+        ])
 
-      setBranch(branch)
-    })
-  }, [])
+        setBranch(stdout.toString())
+      })
+  }, [isRepo])
+
+  useEffect(() => {
+    isRepo &&
+      setInterval(async () => {
+        try {
+          const {stdout} = await execa('git', [
+            'rev-parse',
+            '--short',
+            'HEAD',
+            '--no-color',
+          ])
+          setHead(stdout.toString())
+        } catch (err) {
+          return
+        }
+      })
+  }, [isRepo])
 
   const hasError: boolean =
     [head, branch, status].filter(res => res?.stderr)?.length > 0
 
   return {
-    head: head?.stdout?.toString() ?? null,
-    branch: branch?.stdout?.toString() ?? null,
-    status: !status?.stdout?.toString()
-      ? '0'
-      : status.stdout
-          .toString()
-          .split('\n')
-          .filter(item => item !== '').length,
+    isRepo,
+    head,
+    branch,
+    status,
     hasError,
   }
 }

--- a/packages/@roots/bud-dashboard/src/interface.ts
+++ b/packages/@roots/bud-dashboard/src/interface.ts
@@ -77,6 +77,7 @@ declare module '@roots/bud-framework' {
 
     namespace UseGit {
       interface Status {
+        isRepo: boolean
         head: string
         branch: string
         status: string


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

none

## Issues fixed

- Fixes #61 

## Details

Uses try/catch syntax to catch errors when:
- the project is not a git repo
- the project is a git repo but has not had any commits

In both cases the git status will simply not display rather than erroring fatally.