### PR TITLE
gh: bump node version in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         platform:
           - ubuntu-latest
-        node: 
-          - 14.9.0
+        node:
+          - 15.11.0
     name: test ${{matrix.node}}/${{matrix.platform}}
     runs-on: ${{matrix.platform}}
     steps:
@@ -31,4 +31,3 @@ jobs:
       - run: yarn docs
       - run: yarn lint
       - run: yarn pkg
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@ name: build
 on:
   push:
     paths:
-      - packages/*/src/*
-      - packages/*/src/**/*
+      - packages/**/*/src/*
+      - packages/**/*/src/**/*
       - yarn.lock
   pull_request:
     paths:


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

none

## Details

- Bumps node version to 15.11. This might be related to failures detailed in #65. 
- Modifies the paths that trigger the build workflow.