### PR TITLE
remove last @roots/bud-typings definitions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@
   - packages/@roots/bud/**
 '@roots/bud-api':
   - packages/@roots/bud-api/*
-  - packages/@roots/bud-api/*
+  - packages/@roots/bud-api/**
 '@roots/bud-babel':
   - packages/@roots/bud-babel/*
   - packages/@roots/bud-babel/**
@@ -150,4 +150,6 @@
 'dependencies':
   - package.lock
 'test':
-  - src/**/*.spec.js
+  - src/**/*.test.js
+  - tests/*
+  - tests/**/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,20 +24,22 @@ jobs:
     name: test node@${{matrix.node}}/${{matrix.platform}}
     runs-on: ${{matrix.platform}}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Setup node
+      - name: Setup
         uses: actions/setup-node@v1
         with:
           node-version: ${{matrix.node}}
 
-      - name: Tap cache
+      - name: Cache
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      - uses: actions/cache@v2
+      - name: Restore
+        uses: actions/cache@v2
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -45,10 +47,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install dependenies
-        run: yarn --immutable
+      - name: Install
+        run: yarn
 
-      - name: Build project
+      - name: Build
         run: yarn build:ci
         env:
           NODE_OPTIONS: '--max-old-space-size=2048'

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ minimize: true
 devtool: "eval-source-map"
 ```
 
-For more on configuring [**@roots/bud**](https://github.com/roots/bud) check out the [dedicated documentation](https://github.com/roots/bud/tree/stable/docs/config/README.md).
+For more on configuring [**@roots/bud**](https://github.com/roots/bud/tree/stable/packages/@roots/bud) check out the [dedicated documentation](https://github.com/roots/bud/tree/stable/docs/config/README.md).
 
 ## Running a build
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,24 +1,25 @@
 ## Methods
 
-| Tool              | Description                     | Documentation                                                                 |
-| ----------------- | ------------------------------- | ----------------------------------------------------------------------------- |
-| bud.alias         | Easy module imports             | [docs](https://github.com/roots/bud/tree/stable/docs/config/alias.md)         |
-| bud.assets        | Copy static assets              | [docs](https://github.com/roots/bud/tree/stable/docs/config/assets.md)        |
-| bud.define        | Define global constants         | [docs](https://github.com/roots/bud/tree/stable/docs/config/define.md)        |
-| bud.dev           | Configure dev server            | [docs](https://github.com/roots/bud/tree/stable/docs/config/dev.md)           |
-| bud.devtool       | Configure sourcemaps            | [docs](https://github.com/roots/bud/tree/stable/docs/config/devtool.md)       |
-| bud.entry         | Add source files                | [docs](https://github.com/roots/bud/tree/stable/docs/config/entry.md)         |
-| bud.hash          | Add version string to assets    | [docs](https://github.com/roots/bud/tree/stable/docs/config/hash.md)          |
-| bud.minimize      | Minize assets                   | [docs](https://github.com/roots/bud/tree/stable/docs/config/minimize.md)      |
-| bud.path          | Get paths to project files/dirs | [docs](https://github.com/roots/bud/tree/stable/docs/config/path.md)          |
-| bud.provide       | Define global vars              | [docs](https://github.com/roots/bud/tree/stable/docs/config/provide.md)       |
-| bud.proxy         | Configure proxy server          | [docs](https://github.com/roots/bud/tree/stable/docs/config/proxy.md)         |
-| bud.publicPath    | Get public path                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/publicPath.md)    |
-| bud.runtime       | Extract boilerplate             | [docs](https://github.com/roots/bud/tree/stable/docs/config/runtime.md)       |
-| bud.setPath       | Set paths to project files/dirs | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPath.md)       |
-| bud.setPublicPath | Set public path                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPublicPath.md) |
-| bud.splitChunks   | Split code (vendor)             | [docs](https://github.com/roots/bud/tree/stable/docs/config/vendor.md)        |
-| bud.storage       | Define artifacts dir            | [docs](https://github.com/roots/bud/tree/stable/docs/config/storage.md)       |
-| bud.template      | Set an HTML template            | [docs](https://github.com/roots/bud/tree/stable/docs/config/template.md)      |
-| bud.use           | Extend Bud with modules         | [docs](https://github.com/roots/bud/tree/stable/docs/config/use.md)           |
-| bud.watch         | Configure watch mode            | [docs](https://github.com/roots/bud/tree/stable/docs/config/watch.md)         |
+| Tool              | Description                                   | Documentation                                                                 |
+| ----------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| bud.alias         | Easy module imports                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/alias.md)         |
+| bud.assets        | Copy static assets                            | [docs](https://github.com/roots/bud/tree/stable/docs/config/assets.md)        |
+| bud.define        | Define global constants                       | [docs](https://github.com/roots/bud/tree/stable/docs/config/define.md)        |
+| bud.dev           | Configure dev server                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/dev.md)           |
+| bud.devtool       | Configure sourcemaps                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/devtool.md)       |
+| bud.entry         | Add source files                              | [docs](https://github.com/roots/bud/tree/stable/docs/config/entry.md)         |
+| bud.hash          | Add version string to assets                  | [docs](https://github.com/roots/bud/tree/stable/docs/config/hash.md)          |
+| bud.minimize      | Minize assets                                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/minimize.md)      |
+| bud.override      | Override webpack configuration prior to build | [docs](https://github.com/roots/bud/tree/stable/docs/config/override.md)      |
+| bud.path          | Get paths to project files/dirs               | [docs](https://github.com/roots/bud/tree/stable/docs/config/path.md)          |
+| bud.provide       | Define global vars                            | [docs](https://github.com/roots/bud/tree/stable/docs/config/provide.md)       |
+| bud.proxy         | Configure proxy server                        | [docs](https://github.com/roots/bud/tree/stable/docs/config/proxy.md)         |
+| bud.publicPath    | Get public path                               | [docs](https://github.com/roots/bud/tree/stable/docs/config/publicPath.md)    |
+| bud.runtime       | Extract boilerplate                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/runtime.md)       |
+| bud.setPath       | Set paths to project files/dirs               | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPath.md)       |
+| bud.setPublicPath | Set public path                               | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPublicPath.md) |
+| bud.splitChunks   | Split code (vendor)                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/vendor.md)        |
+| bud.storage       | Define artifacts dir                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/storage.md)       |
+| bud.template      | Set an HTML template                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/template.md)      |
+| bud.use           | Extend Bud with modules                       | [docs](https://github.com/roots/bud/tree/stable/docs/config/use.md)           |
+| bud.watch         | Configure watch mode                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/watch.md)         |

--- a/packages/@roots/bud-api/README.md
+++ b/packages/@roots/bud-api/README.md
@@ -34,28 +34,29 @@
 
 ## Methods
 
-| Tool              | Description                     | Documentation                                                                 |
-| ----------------- | ------------------------------- | ----------------------------------------------------------------------------- |
-| bud.alias         | Easy module imports             | [docs](https://github.com/roots/bud/tree/stable/docs/config/alias.md)         |
-| bud.assets        | Copy static assets              | [docs](https://github.com/roots/bud/tree/stable/docs/config/assets.md)        |
-| bud.define        | Define global constants         | [docs](https://github.com/roots/bud/tree/stable/docs/config/define.md)        |
-| bud.dev           | Configure dev server            | [docs](https://github.com/roots/bud/tree/stable/docs/config/dev.md)           |
-| bud.devtool       | Configure sourcemaps            | [docs](https://github.com/roots/bud/tree/stable/docs/config/devtool.md)       |
-| bud.entry         | Add source files                | [docs](https://github.com/roots/bud/tree/stable/docs/config/entry.md)         |
-| bud.hash          | Add version string to assets    | [docs](https://github.com/roots/bud/tree/stable/docs/config/hash.md)          |
-| bud.minimize      | Minize assets                   | [docs](https://github.com/roots/bud/tree/stable/docs/config/minimize.md)      |
-| bud.path          | Get paths to project files/dirs | [docs](https://github.com/roots/bud/tree/stable/docs/config/path.md)          |
-| bud.provide       | Define global vars              | [docs](https://github.com/roots/bud/tree/stable/docs/config/provide.md)       |
-| bud.proxy         | Configure proxy server          | [docs](https://github.com/roots/bud/tree/stable/docs/config/proxy.md)         |
-| bud.publicPath    | Get public path                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/publicPath.md)    |
-| bud.runtime       | Extract boilerplate             | [docs](https://github.com/roots/bud/tree/stable/docs/config/runtime.md)       |
-| bud.setPath       | Set paths to project files/dirs | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPath.md)       |
-| bud.setPublicPath | Set public path                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPublicPath.md) |
-| bud.splitChunks   | Split code (vendor)             | [docs](https://github.com/roots/bud/tree/stable/docs/config/vendor.md)        |
-| bud.storage       | Define artifacts dir            | [docs](https://github.com/roots/bud/tree/stable/docs/config/storage.md)       |
-| bud.template      | Set an HTML template            | [docs](https://github.com/roots/bud/tree/stable/docs/config/template.md)      |
-| bud.use           | Extend Bud with modules         | [docs](https://github.com/roots/bud/tree/stable/docs/config/use.md)           |
-| bud.watch         | Configure watch mode            | [docs](https://github.com/roots/bud/tree/stable/docs/config/watch.md)         |
+| Tool              | Description                                   | Documentation                                                                 |
+| ----------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| bud.alias         | Easy module imports                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/alias.md)         |
+| bud.assets        | Copy static assets                            | [docs](https://github.com/roots/bud/tree/stable/docs/config/assets.md)        |
+| bud.define        | Define global constants                       | [docs](https://github.com/roots/bud/tree/stable/docs/config/define.md)        |
+| bud.dev           | Configure dev server                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/dev.md)           |
+| bud.devtool       | Configure sourcemaps                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/devtool.md)       |
+| bud.entry         | Add source files                              | [docs](https://github.com/roots/bud/tree/stable/docs/config/entry.md)         |
+| bud.hash          | Add version string to assets                  | [docs](https://github.com/roots/bud/tree/stable/docs/config/hash.md)          |
+| bud.minimize      | Minize assets                                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/minimize.md)      |
+| bud.override      | Override webpack configuration prior to build | [docs](https://github.com/roots/bud/tree/stable/docs/config/override.md)      |
+| bud.path          | Get paths to project files/dirs               | [docs](https://github.com/roots/bud/tree/stable/docs/config/path.md)          |
+| bud.provide       | Define global vars                            | [docs](https://github.com/roots/bud/tree/stable/docs/config/provide.md)       |
+| bud.proxy         | Configure proxy server                        | [docs](https://github.com/roots/bud/tree/stable/docs/config/proxy.md)         |
+| bud.publicPath    | Get public path                               | [docs](https://github.com/roots/bud/tree/stable/docs/config/publicPath.md)    |
+| bud.runtime       | Extract boilerplate                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/runtime.md)       |
+| bud.setPath       | Set paths to project files/dirs               | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPath.md)       |
+| bud.setPublicPath | Set public path                               | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPublicPath.md) |
+| bud.splitChunks   | Split code (vendor)                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/vendor.md)        |
+| bud.storage       | Define artifacts dir                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/storage.md)       |
+| bud.template      | Set an HTML template                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/template.md)      |
+| bud.use           | Extend Bud with modules                       | [docs](https://github.com/roots/bud/tree/stable/docs/config/use.md)           |
+| bud.watch         | Configure watch mode                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/watch.md)         |
 
 ## Contributing
 

--- a/packages/@roots/bud-api/docs/README.md
+++ b/packages/@roots/bud-api/docs/README.md
@@ -34,28 +34,29 @@
 
 ## Methods
 
-| Tool              | Description                     | Documentation                                                                 |
-| ----------------- | ------------------------------- | ----------------------------------------------------------------------------- |
-| bud.alias         | Easy module imports             | [docs](https://github.com/roots/bud/tree/stable/docs/config/alias.md)         |
-| bud.assets        | Copy static assets              | [docs](https://github.com/roots/bud/tree/stable/docs/config/assets.md)        |
-| bud.define        | Define global constants         | [docs](https://github.com/roots/bud/tree/stable/docs/config/define.md)        |
-| bud.dev           | Configure dev server            | [docs](https://github.com/roots/bud/tree/stable/docs/config/dev.md)           |
-| bud.devtool       | Configure sourcemaps            | [docs](https://github.com/roots/bud/tree/stable/docs/config/devtool.md)       |
-| bud.entry         | Add source files                | [docs](https://github.com/roots/bud/tree/stable/docs/config/entry.md)         |
-| bud.hash          | Add version string to assets    | [docs](https://github.com/roots/bud/tree/stable/docs/config/hash.md)          |
-| bud.minimize      | Minize assets                   | [docs](https://github.com/roots/bud/tree/stable/docs/config/minimize.md)      |
-| bud.path          | Get paths to project files/dirs | [docs](https://github.com/roots/bud/tree/stable/docs/config/path.md)          |
-| bud.provide       | Define global vars              | [docs](https://github.com/roots/bud/tree/stable/docs/config/provide.md)       |
-| bud.proxy         | Configure proxy server          | [docs](https://github.com/roots/bud/tree/stable/docs/config/proxy.md)         |
-| bud.publicPath    | Get public path                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/publicPath.md)    |
-| bud.runtime       | Extract boilerplate             | [docs](https://github.com/roots/bud/tree/stable/docs/config/runtime.md)       |
-| bud.setPath       | Set paths to project files/dirs | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPath.md)       |
-| bud.setPublicPath | Set public path                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPublicPath.md) |
-| bud.splitChunks   | Split code (vendor)             | [docs](https://github.com/roots/bud/tree/stable/docs/config/vendor.md)        |
-| bud.storage       | Define artifacts dir            | [docs](https://github.com/roots/bud/tree/stable/docs/config/storage.md)       |
-| bud.template      | Set an HTML template            | [docs](https://github.com/roots/bud/tree/stable/docs/config/template.md)      |
-| bud.use           | Extend Bud with modules         | [docs](https://github.com/roots/bud/tree/stable/docs/config/use.md)           |
-| bud.watch         | Configure watch mode            | [docs](https://github.com/roots/bud/tree/stable/docs/config/watch.md)         |
+| Tool              | Description                                   | Documentation                                                                 |
+| ----------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| bud.alias         | Easy module imports                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/alias.md)         |
+| bud.assets        | Copy static assets                            | [docs](https://github.com/roots/bud/tree/stable/docs/config/assets.md)        |
+| bud.define        | Define global constants                       | [docs](https://github.com/roots/bud/tree/stable/docs/config/define.md)        |
+| bud.dev           | Configure dev server                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/dev.md)           |
+| bud.devtool       | Configure sourcemaps                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/devtool.md)       |
+| bud.entry         | Add source files                              | [docs](https://github.com/roots/bud/tree/stable/docs/config/entry.md)         |
+| bud.hash          | Add version string to assets                  | [docs](https://github.com/roots/bud/tree/stable/docs/config/hash.md)          |
+| bud.minimize      | Minize assets                                 | [docs](https://github.com/roots/bud/tree/stable/docs/config/minimize.md)      |
+| bud.override      | Override webpack configuration prior to build | [docs](https://github.com/roots/bud/tree/stable/docs/config/override.md)      |
+| bud.path          | Get paths to project files/dirs               | [docs](https://github.com/roots/bud/tree/stable/docs/config/path.md)          |
+| bud.provide       | Define global vars                            | [docs](https://github.com/roots/bud/tree/stable/docs/config/provide.md)       |
+| bud.proxy         | Configure proxy server                        | [docs](https://github.com/roots/bud/tree/stable/docs/config/proxy.md)         |
+| bud.publicPath    | Get public path                               | [docs](https://github.com/roots/bud/tree/stable/docs/config/publicPath.md)    |
+| bud.runtime       | Extract boilerplate                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/runtime.md)       |
+| bud.setPath       | Set paths to project files/dirs               | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPath.md)       |
+| bud.setPublicPath | Set public path                               | [docs](https://github.com/roots/bud/tree/stable/docs/config/setPublicPath.md) |
+| bud.splitChunks   | Split code (vendor)                           | [docs](https://github.com/roots/bud/tree/stable/docs/config/vendor.md)        |
+| bud.storage       | Define artifacts dir                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/storage.md)       |
+| bud.template      | Set an HTML template                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/template.md)      |
+| bud.use           | Extend Bud with modules                       | [docs](https://github.com/roots/bud/tree/stable/docs/config/use.md)           |
+| bud.watch         | Configure watch mode                          | [docs](https://github.com/roots/bud/tree/stable/docs/config/watch.md)         |
 
 ## Contributing
 

--- a/packages/@roots/bud-api/package.json
+++ b/packages/@roots/bud-api/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework",
-    "@roots/bud-typings": "workspace:packages/@roots/bud-typings",
     "@types/lodash": "^4.14.168",
     "@types/node": "^15.0.0",
     "globby": "^11.0.3",

--- a/packages/@roots/bud-api/src/docs/README.md
+++ b/packages/@roots/bud-api/src/docs/README.md
@@ -1,24 +1,25 @@
 ## Methods
 
-| Tool              | Description                     | Documentation                     |
-| ----------------- | ------------------------------- | --------------------------------- |
-| bud.alias         | Easy module imports             | [docs](docs:config/alias)         |
-| bud.assets        | Copy static assets              | [docs](docs:config/assets)        |
-| bud.define        | Define global constants         | [docs](docs:config/define)        |
-| bud.dev           | Configure dev server            | [docs](docs:config/dev)           |
-| bud.devtool       | Configure sourcemaps            | [docs](docs:config/devtool)       |
-| bud.entry         | Add source files                | [docs](docs:config/entry)         |
-| bud.hash          | Add version string to assets    | [docs](docs:config/hash)          |
-| bud.minimize      | Minize assets                   | [docs](docs:config/minimize)      |
-| bud.path          | Get paths to project files/dirs | [docs](docs:config/path)          |
-| bud.provide       | Define global vars              | [docs](docs:config/provide)       |
-| bud.proxy         | Configure proxy server          | [docs](docs:config/proxy)         |
-| bud.publicPath    | Get public path                 | [docs](docs:config/publicPath)    |
-| bud.runtime       | Extract boilerplate             | [docs](docs:config/runtime)       |
-| bud.setPath       | Set paths to project files/dirs | [docs](docs:config/setPath)       |
-| bud.setPublicPath | Set public path                 | [docs](docs:config/setPublicPath) |
-| bud.splitChunks   | Split code (vendor)             | [docs](docs:config/vendor)        |
-| bud.storage       | Define artifacts dir            | [docs](docs:config/storage)       |
-| bud.template      | Set an HTML template            | [docs](docs:config/template)      |
-| bud.use           | Extend Bud with modules         | [docs](docs:config/use)           |
-| bud.watch         | Configure watch mode            | [docs](docs:config/watch)         |
+| Tool              | Description                                   | Documentation                     |
+| ----------------- | --------------------------------------------- | --------------------------------- |
+| bud.alias         | Easy module imports                           | [docs](docs:config/alias)         |
+| bud.assets        | Copy static assets                            | [docs](docs:config/assets)        |
+| bud.define        | Define global constants                       | [docs](docs:config/define)        |
+| bud.dev           | Configure dev server                          | [docs](docs:config/dev)           |
+| bud.devtool       | Configure sourcemaps                          | [docs](docs:config/devtool)       |
+| bud.entry         | Add source files                              | [docs](docs:config/entry)         |
+| bud.hash          | Add version string to assets                  | [docs](docs:config/hash)          |
+| bud.minimize      | Minize assets                                 | [docs](docs:config/minimize)      |
+| bud.override      | Override webpack configuration prior to build | [docs](docs:config/override)      |
+| bud.path          | Get paths to project files/dirs               | [docs](docs:config/path)          |
+| bud.provide       | Define global vars                            | [docs](docs:config/provide)       |
+| bud.proxy         | Configure proxy server                        | [docs](docs:config/proxy)         |
+| bud.publicPath    | Get public path                               | [docs](docs:config/publicPath)    |
+| bud.runtime       | Extract boilerplate                           | [docs](docs:config/runtime)       |
+| bud.setPath       | Set paths to project files/dirs               | [docs](docs:config/setPath)       |
+| bud.setPublicPath | Set public path                               | [docs](docs:config/setPublicPath) |
+| bud.splitChunks   | Split code (vendor)                           | [docs](docs:config/vendor)        |
+| bud.storage       | Define artifacts dir                          | [docs](docs:config/storage)       |
+| bud.template      | Set an HTML template                          | [docs](docs:config/template)      |
+| bud.use           | Extend Bud with modules                       | [docs](docs:config/use)           |
+| bud.watch         | Configure watch mode                          | [docs](docs:config/watch)         |

--- a/packages/@roots/bud-cache/package.json
+++ b/packages/@roots/bud-cache/package.json
@@ -57,7 +57,6 @@
     "pkg:format": "yarn g:pkg:format"
   },
   "devDependencies": {
-    "@roots/bud-typings": "workspace:packages/@roots/bud-typings",
     "@types/fs-extra": "^9.0.11",
     "@types/node": "^15.0.0"
   },

--- a/packages/@roots/bud-cli/README.md
+++ b/packages/@roots/bud-cli/README.md
@@ -99,7 +99,7 @@ Try the `--install` flag to install packages flagged as required by various exte
 
 ## Running the build in CI
 
-It is possible, depending on your environment, that Bud's CLI output causes issues. In particular, it's usage of tty `raw mode` can cause issues with CI tools.
+It is possible, depending on your environment, that Bud's CLI output causes issues. In particular, it's usage of tty `raw mode` can cause issues in CI.
 
 To run the build but not use the [**@roots/bud-cli**](https://github.com/roots/bud/tree/stable/packages/@roots/bud-cli) renderer, there is a `--ci` flag which indicates you want to run the build for these environments.
 

--- a/packages/@roots/bud-cli/docs/README.md
+++ b/packages/@roots/bud-cli/docs/README.md
@@ -99,7 +99,7 @@ Try the `--install` flag to install packages flagged as required by various exte
 
 ## Running the build in CI
 
-It is possible, depending on your environment, that Bud's CLI output causes issues. In particular, it's usage of tty `raw mode` can cause issues with CI tools.
+It is possible, depending on your environment, that Bud's CLI output causes issues. In particular, it's usage of tty `raw mode` can cause issues in CI.
 
 To run the build but not use the [**@roots/bud-cli**](https://github.com/roots/bud/tree/stable/packages/@roots/bud-cli) renderer, there is a `--ci` flag which indicates you want to run the build for these environments.
 

--- a/packages/@roots/bud-cli/src/docs/README.md
+++ b/packages/@roots/bud-cli/src/docs/README.md
@@ -58,7 +58,7 @@ Try the `--install` flag to install packages flagged as required by various exte
 
 ## Running the build in CI
 
-It is possible, depending on your environment, that Bud's CLI output causes issues. In particular, it's usage of tty `raw mode` can cause issues with CI tools.
+It is possible, depending on your environment, that Bud's CLI output causes issues. In particular, it's usage of tty `raw mode` can cause issues in CI.
 
 To run the build but not use the `@roots/bud-cli` renderer, there is a `--ci` flag which indicates you want to run the build for these environments.
 

--- a/packages/@roots/bud-compress/package.json
+++ b/packages/@roots/bud-compress/package.json
@@ -59,7 +59,6 @@
     "pkg:format": "yarn g:pkg:format"
   },
   "devDependencies": {
-    "@roots/bud-typings": "workspace:packages/@roots/bud-typings",
     "@types/node": "^15.0.0",
     "webpack": "^5.36.0"
   },

--- a/packages/@roots/bud-typings/README.md
+++ b/packages/@roots/bud-typings/README.md
@@ -15,12 +15,13 @@
 
 ## Overview
 
-This package contains typescript deifnitions for the core Framework packages.
+This package contains typings for the core Framework packages.
 
 ## Details
 
-These types are included separately to allow framework packages and the core
-framework to reference types bi-directionally without producing cyclical dependency issues.
+This package is not currently used by the framework (since v4.0.0).
+
+You can import types from the packages directly. Core interfaces are exported from `@roots/bud-framework`.
 
 ## Contributing
 

--- a/packages/@roots/bud-typings/package.json
+++ b/packages/@roots/bud-typings/package.json
@@ -30,17 +30,6 @@
   ],
   "types": "./contracts/index.d.ts",
   "devDependencies": {
-    "@roots/bud-framework": "workspace:packages/@roots/bud-framework",
-    "@types/express": "^4.17.11",
-    "@types/node": "^15.0.0",
-    "@types/webpack-dev-middleware": "^4.1.2",
-    "chokidar": "^3.5.1",
-    "dotenv": "^8.2.0",
-    "express": "^4.17.1",
-    "http-proxy-middleware": "^1.3.0",
-    "type-fest": "^1.0.2",
-    "typescript": "^4.2.4",
-    "webpack": "^5.36.0",
-    "webpack-dev-middleware": "^4.1.0"
+    "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
   }
 }

--- a/packages/@roots/bud/README.md
+++ b/packages/@roots/bud/README.md
@@ -122,7 +122,7 @@ minimize: true
 devtool: "eval-source-map"
 ```
 
-For more on configuring [**@roots/bud**](https://github.com/roots/bud) check out the [dedicated documentation](https://github.com/roots/bud/tree/stable/docs/config/README.md).
+For more on configuring [**@roots/bud**](https://github.com/roots/bud/tree/stable/packages/@roots/bud) check out the [dedicated documentation](https://github.com/roots/bud/tree/stable/docs/config/README.md).
 
 ## Running a build
 

--- a/packages/@roots/bud/docs/README.md
+++ b/packages/@roots/bud/docs/README.md
@@ -122,7 +122,7 @@ minimize: true
 devtool: "eval-source-map"
 ```
 
-For more on configuring [**@roots/bud**](https://github.com/roots/bud) check out the [dedicated documentation](https://github.com/roots/bud/tree/stable/docs/config/README.md).
+For more on configuring [**@roots/bud**](https://github.com/roots/bud/tree/stable/packages/@roots/bud) check out the [dedicated documentation](https://github.com/roots/bud/tree/stable/docs/config/README.md).
 
 ## Running a build
 

--- a/packages/@roots/bud/src/config.ts
+++ b/packages/@roots/bud/src/config.ts
@@ -1,11 +1,11 @@
-import {Hooks, Server} from '@roots/bud-typings'
+import {Hooks, Server} from '@roots/bud-framework'
 import {Theme} from '@roots/ink-use-style'
 import Webpack from 'webpack/types'
 import {cpus} from 'os'
 
 interface Configuration {
   /**
-   * Regular expression library
+   * Regular expressions for convenience when doing pattern matching.
    *
    * @example
    *
@@ -22,6 +22,7 @@ interface Configuration {
 
   /**
    * Feature: CI mode
+   *
    * @default false
    */
   ci: boolean

--- a/packages/@roots/bud/src/docs/README.md
+++ b/packages/@roots/bud/src/docs/README.md
@@ -79,7 +79,7 @@ minimize: true
 devtool: 'eval-source-map'
 ```
 
-For more on configuring @roots/bud check out the [dedicated documentation](docs:config/README).
+For more on configuring `@roots/bud` check out the [dedicated documentation](docs:config/README).
 
 ## Running a build
 

--- a/packages/@roots/bud/src/extensions/webpack-manifest-plugin/index.ts
+++ b/packages/@roots/bud/src/extensions/webpack-manifest-plugin/index.ts
@@ -3,9 +3,8 @@ import {
   Options,
 } from 'webpack-manifest-plugin'
 import {Module} from '@roots/bud-framework'
-import {WebpackPluginInstance} from 'webpack/types'
 
-const extension: Module<WebpackPluginInstance, Options> = {
+const extension: Module = {
   name: 'webpack-manifest-plugin',
 
   options: app =>
@@ -17,7 +16,9 @@ const extension: Module<WebpackPluginInstance, Options> = {
       ...options.all(),
     }
 
-    return new WebpackManifestPlugin(pluginOptions)
+    const plugin = new WebpackManifestPlugin(pluginOptions)
+
+    return plugin
   },
 
   when: app => app.store.enabled('manifest'),

--- a/packages/@roots/bud/src/extensions/webpack-provide-plugin/index.ts
+++ b/packages/@roots/bud/src/extensions/webpack-provide-plugin/index.ts
@@ -1,6 +1,9 @@
 import {ProvidePlugin as Plugin} from 'webpack'
 import type {Module} from '@roots/bud-framework'
-import type {Index} from '@roots/bud-typings'
+
+interface Index<T> {
+  [key: string]: T
+}
 
 const extension: Module<Plugin, Index<{[key: string]: any}>> = {
   name: 'webpack-provide-plugin',

--- a/packages/@roots/bud/src/services/index.ts
+++ b/packages/@roots/bud/src/services/index.ts
@@ -3,7 +3,6 @@ import {
   Service,
   Bootstrapper,
 } from '@roots/bud-framework'
-import {Index} from '@roots/bud-typings'
 import {Api} from '@roots/bud-api'
 import {Build} from '@roots/bud-build'
 import {Cache} from '@roots/bud-cache'
@@ -18,9 +17,11 @@ import {Hooks} from './Hooks/index'
 import {Logger} from './Logger/index'
 import {Server} from './Server/index'
 
-type Services = Index<
-  new (app: Framework['get']) => Service | Bootstrapper
->
+interface Services {
+  [key: string]: new (app: Framework['get']) =>
+    | Service
+    | Bootstrapper
+}
 
 export const services: Services = {
   api: Api,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,17 +2806,6 @@ __metadata:
   resolution: "@roots/bud-typings@workspace:packages/@roots/bud-typings"
   dependencies:
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
-    "@types/express": ^4.17.11
-    "@types/node": ^15.0.0
-    "@types/webpack-dev-middleware": ^4.1.2
-    chokidar: ^3.5.1
-    dotenv: ^8.2.0
-    express: ^4.17.1
-    http-proxy-middleware: ^1.3.0
-    type-fest: ^1.0.2
-    typescript: ^4.2.4
-    webpack: ^5.36.0
-    webpack-dev-middleware: ^4.1.0
   languageName: unknown
   linkType: soft
 
@@ -4002,16 +3991,6 @@ __metadata:
     "@types/expect": ^1.20.4
     "@types/node": "*"
   checksum: 4fb0ea747cbe11b5b0ef74647b19a93b630c0fda424dd40774c696f10cf7a7b8c4867d74940964ebd5194b2f374330ecab8e9720000ecc362d94e5faf53738b7
-  languageName: node
-  linkType: hard
-
-"@types/webpack-dev-middleware@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "@types/webpack-dev-middleware@npm:4.1.2"
-  dependencies:
-    "@types/connect": "*"
-    "@types/webpack": ^4
-  checksum: 1912e2de5cd188acb1a4cba223a5f3e62415e265334ecd1dcb213869bbdcdaad2edbcd66b325d23ce5af665587852f3926dda930b387dd228f2ff453b0a4fc9b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2279,7 +2279,6 @@ __metadata:
   resolution: "@roots/bud-api@workspace:packages/@roots/bud-api"
   dependencies:
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
-    "@roots/bud-typings": "workspace:packages/@roots/bud-typings"
     "@types/lodash": ^4.14.168
     "@types/node": ^15.0.0
     autobind-decorator: ^2.4.0
@@ -2340,7 +2339,6 @@ __metadata:
   resolution: "@roots/bud-cache@workspace:packages/@roots/bud-cache"
   dependencies:
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
-    "@roots/bud-typings": "workspace:packages/@roots/bud-typings"
     "@types/fs-extra": ^9.0.11
     "@types/node": ^15.0.0
     autobind-decorator: ^2.4.0
@@ -2398,7 +2396,6 @@ __metadata:
   dependencies:
     "@roots/bud-extensions": "workspace:packages/@roots/bud-extensions"
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
-    "@roots/bud-typings": "workspace:packages/@roots/bud-typings"
     "@types/node": ^15.0.0
     autobind-decorator: ^2.4.0
     compression-webpack-plugin: ^7.1.2


### PR DESCRIPTION
## Type of change

Typings

## Dependencies added

- none

## Details

Removes the last imports of definitions from `@roots/bud-typings`. Import core defs directly from `@roots/bud-framework`.