### PR TITLE
v4.2.0

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 **/*.map
 tsconfig.json
+dev/docs/src/templates/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,52 @@
+## v4.2.0
+
+v4.2.0 adds the [override](https://github.com/roots/bud/blob/stable/docs/config/override.md) method. Relatedly, there are two new hooks: `before` and `after`, which are called directly before and after the config is generated. Override is just a wrapper around `after`.
+
+You can now specify publicPath using a callback. See the [setPublicPath docs](https://github.com/roots/bud/blob/stable/docs/config/setPublicPath.md).
+
+By default, bud now uses a memory based cache implementation. Filesystem caching is still superior, but it is no longer the default implementation because of its inherent complexity (it may not work for all configs). We recommend that you try calling `bud.persist()` in your config file to see if filesystem caching works for your project. In the future, hopefully persistent caching can be made the default again.
+
+### Details
+
+- Add: `override` method (parity with mix api)
+- Add: `before` hook (parity with mix api, used by `override`)
+- Add: `after` hook (parity with mix api)
+- Improve: Allow for setting `publicPath` with a function callback
+- Improve: Allow for freely disabling/enabling `persist`
+- Improve: error display in the cli
+- Improve: `cache` interface
+- Remove: the last imports of definitions from `@roots/bud-typings`.
+- Fix: fatal errors for non git repos and git repos without commits
+- Fix: eslint extension caching when using `persist`
+- @roots/sage: add @roots/bud-eslint plugin
+
+## v4.1.0
+
+This release changes the default cache strategy to `memory`, which is slower but more broadly compatible. If your setup is compatible with `filesystem` caching it is much faster and worth trying.
+
+You can enable it by calling `bud.persist()` in your config or adding `persist: true` to your config yml/json, if configuring bud with a static config.
+
+### Details
+
+- allows variable expansion within `.env`
+- utilizes memory strategy by default. filesystem can be enabled by calling `bud.persist()` in config.
+- improved reliability of filesystem cache
+- improved validation of filesystem cache
+
 ## v4.0.0
 
 This release features breaking changes across all packages.
 
-- Using css-minimizer-webpack-plugin instead of optimize-css-assets-webpack-plugin. 
+- Using css-minimizer-webpack-plugin instead of optimize-css-assets-webpack-plugin.
   - `optimize-css-assets-webpack-plugin` throws warnings. Docs say to use `css-minimizer-webpack-plugin` instead.
-  -  Commits: 5255c68, 578833c, 361a732. 
-- Removed `bud.vendor` method from `@roots/bud-api`. Replaced with `bud.splitChunks`. 
-- Removed keys from hooks/config: 
+  - Commits: 5255c68, 578833c, 361a732.
+- Removed `bud.vendor` method from `@roots/bud-api`. Replaced with `bud.splitChunks`.
+- Removed keys from hooks/config:
   - `build/optimization/splitChunks/cacheGroups/vendor/...` (everything from here on is gone)
-  - This means that users who wish to modify the `vendor` chunk either need to include the config keys between `splitChunks` 
-  and `vendor` in the config param of `bud.splitChunks`, or overwrite the config in total using `bud.hooks.on('build/optimization/splitChunks')`. 
+  - This means that users who wish to modify the `vendor` chunk either need to include the config keys between `splitChunks`
+    and `vendor` in the config param of `bud.splitChunks`, or overwrite the config in total using `bud.hooks.on('build/optimization/splitChunks')`.
 - `build/parallelism` value of `os.cpus().length - 1` (previously set to `1`)
-- Removes `src`, `srcPath`, `dist`, `distPath`, `project` api fns in favor of a consolidated approach: `bud.path` and `bud.setPath`. 
+- Removes `src`, `srcPath`, `dist`, `distPath`, `project` api fns in favor of a consolidated approach: `bud.path` and `bud.setPath`.
 - Types are no longer exported explicitly from `@roots/bud-support` or `@roots/bud-typings`. Core interfaces/types can be exported from `@roots/bud-framework`.
 - `@roots/bud-compiler` no longer derives its type definition from `@roots/bud-typings`. See: #48.
 - `@roots/bud-build` no longer derives its type definition from `@roots/bud-typings`. See #48.
@@ -22,9 +57,10 @@ This release features breaking changes across all packages.
 - Enhances docs generation/maintenance scripts
 - Overhauls loader, rule interfaces
 
-Authored by: 
-  - kellymears <kelly@roots.io> 
-  - QWp6t <hi@qwp6t.me>
+Contributors:
+
+- kellymears <kelly@roots.io>
+- QWp6t <hi@qwp6t.me>
 
 ## v2.0.7
 

--- a/dev/docs/gen/cli.js
+++ b/dev/docs/gen/cli.js
@@ -3,4 +3,5 @@
 require('ts-node').register({
   project: require.resolve('../../../tsconfig.dev.json'),
 })
+
 require('./')

--- a/examples/typescript/bud.config.js
+++ b/examples/typescript/bud.config.js
@@ -1,8 +1,0 @@
-module.exports = bud =>
-  bud
-    .use([
-      require('@roots/bud-babel'),
-      require('@roots/bud-typescript'),
-    ])
-    .entry({app: ['app.ts']})
-    .html()

--- a/examples/typescript/bud.config.ts
+++ b/examples/typescript/bud.config.ts
@@ -1,0 +1,11 @@
+import {Framework} from '@roots/bud'
+
+import babel from '@roots/bud-babel'
+import typescript from '@roots/bud-typescript'
+
+export default (bud: Framework) =>
+  bud
+    .use([babel, typescript])
+    .entry({app: ['app.ts']})
+    .template()
+    .persist()

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -18,7 +18,7 @@
     ],
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/packages/@roots/bud-api/src/methods/persist.ts
+++ b/packages/@roots/bud-api/src/methods/persist.ts
@@ -19,7 +19,7 @@ declare module '@roots/bud-framework' {
   }
 
   namespace Api {
-    type Persist = (enabled: boolean) => Framework
+    type Persist = (enabled?: boolean) => Framework
   }
 }
 

--- a/packages/@roots/bud-hooks/README.md
+++ b/packages/@roots/bud-hooks/README.md
@@ -32,6 +32,7 @@
   - [hook usage](#hook-usage)
 - [bud.hooks.filter](#budhooksfilter)
   - [filter usage](#filter-usage)
+- [Hooks reference](#hooks-reference)
 - [Contributing](#contributing)
 - [Bud sponsors](#bud-sponsors)
 - [Community](#community)
@@ -108,6 +109,10 @@ now have access to this value and can modify it.
 ```js
 bud.hooks.on("some-key", (value) => value.shift());
 ```
+
+## Hooks reference
+
+There is a compiled list of hooks used by [**@roots/bud**](https://github.com/roots/bud) core [available here](https://github.com/roots/bud/tree/stable/packages/@roots/bud-hooks/docs/hooks.md).
 
 ## Contributing
 

--- a/packages/@roots/bud-hooks/docs/README.md
+++ b/packages/@roots/bud-hooks/docs/README.md
@@ -32,6 +32,7 @@
   - [hook usage](#hook-usage)
 - [bud.hooks.filter](#budhooksfilter)
   - [filter usage](#filter-usage)
+- [Hooks reference](#hooks-reference)
 - [Contributing](#contributing)
 - [Bud sponsors](#bud-sponsors)
 - [Community](#community)
@@ -108,6 +109,10 @@ now have access to this value and can modify it.
 ```js
 bud.hooks.on("some-key", (value) => value.shift());
 ```
+
+## Hooks reference
+
+There is a compiled list of hooks used by [**@roots/bud**](https://github.com/roots/bud) core [available here](https://github.com/roots/bud/tree/stable/packages/@roots/bud-hooks/docs/hooks.md).
 
 ## Contributing
 

--- a/packages/@roots/bud-hooks/docs/hooks.md
+++ b/packages/@roots/bud-hooks/docs/hooks.md
@@ -1,0 +1,57 @@
+# Hooks
+
+This is a work-in-progress index of all hooks registered by [**@roots/bud**](https://github.com/roots/bud/tree/stable/packages/@roots/bud) core packages.
+
+Most `build` related hooks can be found in [**@roots/bud-build**](https://github.com/roots/bud/tree/stable/packages/@roots/bud-build).
+
+Most extensions related hooks can be found in [**@roots/bud**](https://github.com/roots/bud/tree/stable/packages/@roots/bud).
+
+| key                             | notes                                                             |
+| ------------------------------- | ----------------------------------------------------------------- |
+| build                           | builds webpack config                                             |
+| before                          | called directly before build                                      |
+| after                           | called directly after build.                                      |
+| locations/project               | project path (absolute)                                           |
+| locations/src                   | source path (relative to `locations/project`)                     |
+| locations/dist                  | dist path (relative to `locations/project`)                       |
+| locations/publicPath            | public path (default: `/`)                                        |
+| locations/modules               | node_modules path (relative to `locations/project`)               |
+| locations/storage               | storage dir for artifacts/cache (relative to `locations/project`) |
+| locations/records               | webpack records json path (relative to `locations/storage`)       |
+| build/bail                      | webpack.bail                                                      |
+| build/cache                     | webpack.cache                                                     |
+| build/context                   | webpack.context                                                   |
+| build/devServer                 | webpack.devServer                                                 |
+| build/devtool                   | webpack.devtool                                                   |
+| build/entry                     | webpack.entry                                                     |
+| build/experiments               | webpack.experiments                                               |
+| build/externals                 | webpack.externals                                                 |
+| build/infrastructureLogging     | webpack.infrastructureLogging                                     |
+| build/mode                      | webpack.mode                                                      |
+| build/name                      | webpack.name                                                      |
+| build/node                      | webpack.node                                                      |
+| build/output                    | webpack.output                                                    |
+| build/output/path               | webpack.output.path                                               |
+| build/output/pathinfo           | webpack.output.pathinfo                                           |
+| build/output/publicPath         | webpack.output.publicPath                                         |
+| build/output/filename           | webpack.output.filename                                           |
+| build/optimization              | webpack.optimization                                              |
+| build/optimization/emitOnErrors | webpack.optimization.emitOnErrors                                 |
+| build/optimization/minimize     | webpack.optimization.minimize                                     |
+| build/optimization/minimizer    | webpack.optimization.minimizer                                    |
+| build/optimization/moduleIds    | webpack.optimization.moduleIds                                    |
+| build/optimization/runtimeChunk | webpack.optimization.runtimeChunk                                 |
+| build/optimization/splitChunks  | webpack.optimization.splitChunks                                  |
+| build/parallelism               | webpack.parallelism                                               |
+| build/performance               | webpack.performance                                               |
+| build/plugins                   | webpack.plugins                                                   |
+| build/profile                   | webpack.profile                                                   |
+| build/recordsPath               | webpack.recordsPath                                               |
+| build/resolve                   | webpack.resolve                                                   |
+| build/resolve/alias             | webpack.resolve.alias                                             |
+| build/resolve/extensions        | webpack.resolve.extensions                                        |
+| build/resolve/modules           | webpack.resolve.modules                                           |
+| build/stats                     | webpack.stats                                                     |
+| build/target                    | webpack.target                                                    |
+| build/watch                     | webpack.watch                                                     |
+| build/watchOptions              | webpack.watchOptions                                              |

--- a/packages/@roots/bud-hooks/src/docs/README.md
+++ b/packages/@roots/bud-hooks/src/docs/README.md
@@ -70,3 +70,7 @@ now have access to this value and can modify it.
 ```js
 bud.hooks.on('some-key', value => value.shift())
 ```
+
+## Hooks reference
+
+There is a compiled list of hooks used by @roots/bud core [available here](url:packages/@roots/bud-hooks/docs/hooks.md).

--- a/packages/@roots/bud-hooks/src/docs/hooks.md
+++ b/packages/@roots/bud-hooks/src/docs/hooks.md
@@ -1,0 +1,57 @@
+# Hooks
+
+Below is a work-in-progress index of all hooks registered by `@roots/bud` core packages.
+
+Most `build` related hooks can be found in `@roots/bud-build`.
+
+Most extensions related hooks can be found in `@roots/bud`.
+
+| key                             | notes                                                             |
+| ------------------------------- | ----------------------------------------------------------------- |
+| build                           | builds webpack config                                             |
+| before                          | called directly before build                                      |
+| after                           | called directly after build.                                      |
+| locations/project               | project path (absolute)                                           |
+| locations/src                   | source path (relative to `locations/project`)                     |
+| locations/dist                  | dist path (relative to `locations/project`)                       |
+| locations/publicPath            | public path (default: `/`)                                        |
+| locations/modules               | node_modules path (relative to `locations/project`)               |
+| locations/storage               | storage dir for artifacts/cache (relative to `locations/project`) |
+| locations/records               | webpack records json path (relative to `locations/storage`)       |
+| build/bail                      | webpack.bail                                                      |
+| build/cache                     | webpack.cache                                                     |
+| build/context                   | webpack.context                                                   |
+| build/devServer                 | webpack.devServer                                                 |
+| build/devtool                   | webpack.devtool                                                   |
+| build/entry                     | webpack.entry                                                     |
+| build/experiments               | webpack.experiments                                               |
+| build/externals                 | webpack.externals                                                 |
+| build/infrastructureLogging     | webpack.infrastructureLogging                                     |
+| build/mode                      | webpack.mode                                                      |
+| build/name                      | webpack.name                                                      |
+| build/node                      | webpack.node                                                      |
+| build/output                    | webpack.output                                                    |
+| build/output/path               | webpack.output.path                                               |
+| build/output/pathinfo           | webpack.output.pathinfo                                           |
+| build/output/publicPath         | webpack.output.publicPath                                         |
+| build/output/filename           | webpack.output.filename                                           |
+| build/optimization              | webpack.optimization                                              |
+| build/optimization/emitOnErrors | webpack.optimization.emitOnErrors                                 |
+| build/optimization/minimize     | webpack.optimization.minimize                                     |
+| build/optimization/minimizer    | webpack.optimization.minimizer                                    |
+| build/optimization/moduleIds    | webpack.optimization.moduleIds                                    |
+| build/optimization/runtimeChunk | webpack.optimization.runtimeChunk                                 |
+| build/optimization/splitChunks  | webpack.optimization.splitChunks                                  |
+| build/parallelism               | webpack.parallelism                                               |
+| build/performance               | webpack.performance                                               |
+| build/plugins                   | webpack.plugins                                                   |
+| build/profile                   | webpack.profile                                                   |
+| build/recordsPath               | webpack.recordsPath                                               |
+| build/resolve                   | webpack.resolve                                                   |
+| build/resolve/alias             | webpack.resolve.alias                                             |
+| build/resolve/extensions        | webpack.resolve.extensions                                        |
+| build/resolve/modules           | webpack.resolve.modules                                           |
+| build/stats                     | webpack.stats                                                     |
+| build/target                    | webpack.target                                                    |
+| build/watch                     | webpack.watch                                                     |
+| build/watchOptions              | webpack.watchOptions                                              |

--- a/packages/@roots/bud/src/extensions/html-webpack-plugin/index.ts
+++ b/packages/@roots/bud/src/extensions/html-webpack-plugin/index.ts
@@ -17,7 +17,7 @@ const extension: Extension = {
     publicPath: publicPath(),
     template: posix.resolve(
       require.resolve('@roots/bud-support'),
-      '../../../publish/template.html',
+      '../../../templates/template.html',
     ),
     ...(store.get('extension.htmlWebpackPlugin') ?? {}),
   }),


### PR DESCRIPTION
This is a preparatory release for v4.2.0.

## Type of change

- MINOR: feature

## Dependencies added

- none

## Details

- Updates some docs and fixes the default template path in `bud.template`.
