### PR TITLE
feat(framework): add .tap() method

### DIFF
--- a/packages/@roots/bud-framework/src/Framework/index.ts
+++ b/packages/@roots/bud-framework/src/Framework/index.ts
@@ -20,7 +20,7 @@ import {Server} from '../Server'
 import {Service, Bootstrapper} from '../Service'
 import {Store} from '../Store'
 
-import {isFunction, isUndefined} from 'lodash'
+import {isFunction} from 'lodash'
 import {join} from 'path'
 import {boundMethod as bind} from 'autobind-decorator'
 
@@ -435,11 +435,9 @@ abstract class Framework {
     fn:
       | ((app: Framework) => any)
       | ((this: Framework, app?: Framework) => any),
-    bound?: boolean,
+    bound: boolean = true,
   ) {
-    const bind = !isUndefined(fn.bind) && bound !== false
-
-    fn.call(bind ? this : null, this)
+    fn.call(bound ? this : null, this)
 
     return this
   }

--- a/tests/bud-framework/Framework/index.ts
+++ b/tests/bud-framework/Framework/index.ts
@@ -51,6 +51,38 @@ describe('bud', () => {
     done()
   })
 
+  it('tap calls fn and returns instance of Bud', done => {
+    const fn = jest.fn()
+    expect(bud.tap(fn)).toBeInstanceOf(Bud)
+    expect(fn).toHaveBeenCalledTimes(1)
+    done()
+  })
+
+  it('tap passes an instance of Bud', done => {
+    bud.tap(app => expect(app).toBeInstanceOf(Bud))
+    done()
+  })
+
+  it('tap can bind a function to Bud', done => {
+    bud.tap(function () {
+      expect(this).not.toBeInstanceOf(Bud)
+    }, false)
+
+    bud.tap(function () {
+      expect(this).toBeInstanceOf(Bud)
+    }, true)
+
+    // it binds by default
+    bud.tap(function () {
+      expect(this).toBeInstanceOf(Bud)
+    })
+
+    // bud does not attempt to bind arrow functions
+    bud.tap(() => expect(this).not.toBeInstanceOf(Bud), true)
+
+    done()
+  })
+
   it('sequence calls fns', done => {
     bud.sequence([
       app => {

--- a/tests/bud-framework/Framework/index.ts
+++ b/tests/bud-framework/Framework/index.ts
@@ -77,9 +77,6 @@ describe('bud', () => {
       expect(this).toBeInstanceOf(Bud)
     })
 
-    // bud does not attempt to bind arrow functions
-    bud.tap(() => expect(this).not.toBeInstanceOf(Bud), true)
-
     done()
   })
 


### PR DESCRIPTION
## Type of change

- MINOR: feature

## Dependencies added

N/A

## Details

Adds a `bud.tap()` method to the framework.

This will allow arbitrary functions to be called without breaking the chain.

```js
bud
  .use([ /*...*/ ])
  .tap(bud => {
    // do a thing here
    return null // return value is ignored, you can return nothing if you want
  })
  .persist()
```