### PR TITLE
fix: @roots/bud-imagemin default svgo options

### DIFF
--- a/packages/@roots/bud-imagemin/src/Extension.ts
+++ b/packages/@roots/bud-imagemin/src/Extension.ts
@@ -16,7 +16,7 @@ const Extension: Imagemin.Extension = {
       ['gifsicle', {interlaced: true}],
       ['jpegtran', {progressive: true}],
       ['optipng', {optimizationLevel: 7}],
-      ['svgo', {plugins: [{removeViewBox: false}]}],
+      ['svgo', {removeViewBox: false}],
     ]
 
     imagemin.plugins(

--- a/tests/bud-imagemin/index.ts
+++ b/tests/bud-imagemin/index.ts
@@ -78,7 +78,7 @@ describe('@roots/bud-imagemin', () => {
       bud.extensions.get(PLUGIN_HANDLE).get('options'),
     ).toEqual({
       minimizerOptions: {
-        plugins: [['svgo', {plugins: [{removeViewBox: false}]}]],
+        plugins: [['svgo', {removeViewBox: false}]],
       },
     })
   })
@@ -93,7 +93,7 @@ describe('@roots/bud-imagemin', () => {
       bud.hooks.filter(`extension/${PLUGIN_HANDLE}/options`),
     ).toEqual({
       minimizerOptions: {
-        plugins: [['svgo', {plugins: [{removeViewBox: false}]}]],
+        plugins: [['svgo', {removeViewBox: false}]],
       },
     })
   })
@@ -107,9 +107,7 @@ describe('@roots/bud-imagemin', () => {
 
   it('bud.imagemin.plugins registers plugin', () => {
     bud.use(imagemin)
-    bud.imagemin.plugins([
-      ['svgo', {plugins: [{removeViewBox: false}]}],
-    ])
+    bud.imagemin.plugins([['svgo', {removeViewBox: false}]])
 
     const options = bud.extensions
       .get(PLUGIN_HANDLE)
@@ -117,7 +115,7 @@ describe('@roots/bud-imagemin', () => {
 
     expect(options).toEqual({
       minimizerOptions: {
-        plugins: [['svgo', {plugins: [{removeViewBox: false}]}]],
+        plugins: [['svgo', {removeViewBox: false}]],
       },
     })
   })
@@ -126,9 +124,7 @@ describe('@roots/bud-imagemin', () => {
     bud.use(imagemin)
 
     bud.imagemin.plugins([['foo', {options: 'boom'}]])
-    bud.imagemin.plugins([
-      ['bar', {plugins: [{removeViewBox: false}]}],
-    ])
+    bud.imagemin.plugins([['bar', {removeViewBox: false}]])
 
     const options = bud.extensions
       .get(PLUGIN_HANDLE)
@@ -136,7 +132,7 @@ describe('@roots/bud-imagemin', () => {
 
     expect(options).toEqual({
       minimizerOptions: {
-        plugins: [['bar', {plugins: [{removeViewBox: false}]}]],
+        plugins: [['bar', {removeViewBox: false}]],
       },
     })
   })


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

- They were invalid before. They are valid now.
- Updated specs.

Closes #131 