### PR TITLE
fix: @roots/bud-cache version hash generation

### DIFF
--- a/examples/preset-recommend/bud.config.yml
+++ b/examples/preset-recommend/bud.config.yml
@@ -1,2 +1,2 @@
-extensions:
-  - '@roots/bud-preset-recommend'
+  extensions:
+    - '@roots/bud-preset-recommend'  

--- a/tests/bud-framework/Framework/index.ts
+++ b/tests/bud-framework/Framework/index.ts
@@ -7,12 +7,10 @@ describe('bud', () => {
 
   beforeAll(() => {
     bud = setupBud()
-    return
   })
 
   afterAll(() => {
     bud = teardownBud(bud)
-    return
   })
 
   it('mode', () => {


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

- Fixes an issue with cache version generation.

This would have primarily effected `.yml` configs. Maybe `.json` as well.

I'm not sure how to automate testing for this. But the version string obviously updates and the cache is evidently invalidated when: 
- a change is made to the config file, and; 
- a build is run (use `--debug` flag in order to see compiled config)


