### PR TITLE
feature: support direct webpack plugin usage

### DIFF
--- a/packages/@roots/bud-api/package.json
+++ b/packages/@roots/bud-api/package.json
@@ -71,6 +71,7 @@
     "autobind-decorator": "^2.4.0",
     "chalk": "^4.1.1",
     "html-webpack-plugin": "^5.3.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "nanoid": "^3.1.23"
   }
 }

--- a/packages/@roots/bud-api/src/methods/use/index.ts
+++ b/packages/@roots/bud-api/src/methods/use/index.ts
@@ -1,39 +1,87 @@
-import type {Api} from '@roots/bud-framework'
-import {isArray} from 'lodash'
+import type {Api, Module} from '@roots/bud-framework'
+import {isArray, isEqual, isFunction} from 'lodash'
+import {nanoid} from 'nanoid'
 
 declare module '@roots/bud-framework' {
   interface Framework {
     /**
-     * ## bud.use [💁 Fluent]
+     * ## bud.use
      *
      * Register an extension or set of extensions
      *
      * ### Usage
      *
+     * Add packaged bud extensions:
+     *
      * ```js
      * bud.use([
-     *   '@roots/bud-babel',
-     *   '@roots/bud-react',
+     *   require('@roots/bud-babel'),
+     *   require('@roots/bud-react'),
      * ])
+     * ```
+     *
+     * Add an extension inline (also works with an array of extensions):
+     *
+     * ```js
+     * bud.use({
+     *  name: 'my-webpack-plugin',
+     *  make: () => new MyWebpackPlugin(),
+     * })
+     * ```
+     *
+     * Add a webpack plugin inline (also work with an array of plugins):
+     *
+     * ```js
+     * bud.use(new MyWebpackPlugin())
      * ```
      */
     use: Api.Use
   }
 
   namespace Api {
-    type Use = (source: any | Array<any>) => Framework
+    type Input = Module | Module[]
+    type Use = (source: Input) => Framework
   }
 }
 
+/**
+ * Helpers
+ */
+const isWebpackPlugin = (extension: Module): boolean =>
+  extension.apply &&
+  isFunction(extension.apply) &&
+  !isEqual(extension.apply.toString(), '[native code]')
+
+const hasValidConstructorName = ({
+  constructor,
+}: Module): boolean =>
+  constructor?.name &&
+  typeof constructor.name == 'string' &&
+  constructor.name !== 'default' &&
+  constructor.name !== 'Object'
+
+const generateName = (input: Module) =>
+  hasValidConstructorName(input)
+    ? input.constructor.name
+    : nanoid(4)
+
+/**
+ * bud.use method
+ */
 const use: Api.Use = function (source) {
-  if (!isArray(source)) {
-    this.extensions.add(source)
-    return this
+  const addExtension = (source: Module) => {
+    source.name = source.name ?? generateName(source)
+
+    this.extensions.add(
+      isWebpackPlugin(source)
+        ? {name: source.name, make: () => source}
+        : source,
+    )
   }
 
-  source.forEach(extension => {
-    this.extensions.add(extension)
-  })
+  !isArray(source)
+    ? addExtension(source)
+    : source.forEach(addExtension)
 
   return this
 }

--- a/packages/@roots/bud-api/src/methods/use/index.ts
+++ b/packages/@roots/bud-api/src/methods/use/index.ts
@@ -74,7 +74,7 @@ const use: Api.Use = function (source) {
 
     this.extensions.add(
       isWebpackPlugin(source)
-        ? {name: source.name, make: () => source}
+        ? {...source, make: () => source}
         : source,
     )
   }

--- a/packages/@roots/bud-framework/src/Extensions/Module.ts
+++ b/packages/@roots/bud-framework/src/Extensions/Module.ts
@@ -38,6 +38,11 @@ interface Module<Plugin = any, Options = any> {
    * compilation.
    */
   when?: Module.When<Options>
+
+  /**
+   * Webpack plugin apply.
+   */
+  apply?: CallableFunction
 }
 
 namespace Module {

--- a/packages/@roots/bud-framework/src/Extensions/Module.ts
+++ b/packages/@roots/bud-framework/src/Extensions/Module.ts
@@ -5,7 +5,7 @@ interface Module<Plugin = any, Options = any> {
   /**
    * The module name
    */
-  name: Module.Name
+  name?: Module.Name
 
   /**
    * Options registered with the extension

--- a/tests/bud-api/methods/use.ts
+++ b/tests/bud-api/methods/use.ts
@@ -1,4 +1,4 @@
-import {Framework, setupBud, teardownBud, log} from '../../util'
+import {Framework, setupBud, teardownBud} from '../../util'
 import babel from '@roots/bud-babel'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 

--- a/tests/bud-api/methods/use.ts
+++ b/tests/bud-api/methods/use.ts
@@ -1,0 +1,72 @@
+import {Framework, setupBud, teardownBud, log} from '../../util'
+import babel from '@roots/bud-babel'
+import HtmlWebpackPlugin from 'html-webpack-plugin'
+
+describe('bud.use', function () {
+  let bud: Framework
+
+  beforeAll(() => {
+    bud = setupBud()
+  })
+
+  afterAll(() => {
+    bud = teardownBud(bud)
+  })
+
+  beforeEach(() => {
+    bud.extensions.setStore({})
+  })
+
+  it('is a function', () => {
+    expect(bud.use).toBeInstanceOf(Function)
+  })
+
+  it('registers an imported extension', () => {
+    bud.use(babel)
+
+    expect(bud.extensions.has('@roots/bud-babel'))
+  })
+
+  it('registers an inline extension', () => {
+    bud.use({
+      name: 'inline-extension',
+    })
+
+    expect(bud.extensions.has('inline-extension'))
+  })
+
+  it('registers an anonymous extension', () => {
+    bud.use({options: {}})
+
+    expect(bud.extensions.getEntries().length).toEqual(1)
+  })
+
+  it('registers a webpack plugin', () => {
+    bud.use(new HtmlWebpackPlugin())
+
+    expect(bud.extensions.getEntries().length).toEqual(1)
+  })
+
+  it('registers an inline webpack plugin', () => {
+    bud.use({
+      apply() {
+        return null
+      },
+    })
+
+    expect(bud.extensions.getEntries().length).toEqual(1)
+  })
+
+  it('registers an imported webpack plugin', () => {
+    bud.use(new HtmlWebpackPlugin())
+
+    expect(bud.extensions.has('HtmlWebpackPlugin')).toBe(true)
+  })
+
+  it('registers multiple extensions', () => {
+    bud.use([babel, new HtmlWebpackPlugin()])
+
+    expect(bud.extensions.has('@roots/bud-babel')).toBe(true)
+    expect(bud.extensions.has('HtmlWebpackPlugin')).toBe(true)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,6 +2595,7 @@ __metadata:
     globby: ^11.0.3
     html-webpack-plugin: ^5.3.1
     lodash: ^4.17.21
+    nanoid: ^3.1.23
     webpack: ^5.38.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Type of change

- MINOR: feature

## Dependencies added

- `nanoid` in `@roots/bud-api`

## Details

Now you can pass webpack plugins to `bud.use` directly.

---

## bud.use
     
Register an extension or set of extensions
     
### Usage
     
Add packaged bud extensions:
     
```js
bud.use([
  require('@roots/bud-babel'),
  require('@roots/bud-react'),
])
```
     
Add an extension inline (also works with an array of extensions):
     
```js
bud.use({
 name: 'my-webpack-plugin',
 make: () => new MyWebpackPlugin(),
})
```
     
Add a webpack plugin inline (also work with an array of plugins):
     
```js
bud.use(new MyWebpackPlugin())
```
    