### PR TITLE
README: Fix typo in Installation command

### DIFF
--- a/packages/@roots/bud-preset-recommend/README.md
+++ b/packages/@roots/bud-preset-recommend/README.md
@@ -51,7 +51,7 @@ yarn add @roots/bud @roots/bud-cli --dev
 ## Installation
 
 ```sh
-yarn add @roots/bud-preset-recommended --dev
+yarn add @roots/bud-preset-recommend --dev
 ```
 
 The preset requires `postcss` to be installed in your project. You can install it automatically using [**@roots/bud-cli**](https://github.com/roots/bud/tree/stable/packages/@roots/bud-cli).


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

## Details

The README gave the wrong command to install this package