### PR TITLE
Tests

### DIFF
--- a/packages/@roots/bud-framework/src/Framework/index.ts
+++ b/packages/@roots/bud-framework/src/Framework/index.ts
@@ -181,7 +181,7 @@ interface Framework {
    */
   path(
     key: `${keyof Hooks.Locale.Definitions & string}`,
-    path?: string,
+    ...path: string[]
   ): string
 
   /**
@@ -434,7 +434,7 @@ abstract class Framework {
   @bind
   public path(
     key: `${keyof Hooks.Locale.Definitions & string}`,
-    path?: string,
+    ...path: string[]
   ): string {
     return join(
       ...[
@@ -442,7 +442,7 @@ abstract class Framework {
           ? this.hooks.filter('location/project')
           : false,
         this.hooks.filter(`location/${key}` as Hooks.Name),
-        path ?? false,
+        ...(path ?? []),
       ].filter(Boolean),
     )
   }

--- a/tests/bud-api/methods/alias.ts
+++ b/tests/bud-api/methods/alias.ts
@@ -3,12 +3,16 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('webpack.resolve.alias', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
+  })
+
+  it('is a function', () => {
+    expect(bud.alias).toBeInstanceOf(Function)
   })
 
   it('is configurable by bud.alias', () => {

--- a/tests/bud-api/methods/config.ts
+++ b/tests/bud-api/methods/config.ts
@@ -3,12 +3,14 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.config', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
+    return
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
+    return
   })
 
   it('is a function', () => {

--- a/tests/bud-api/methods/dev.ts
+++ b/tests/bud-api/methods/dev.ts
@@ -3,12 +3,14 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.dev', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
+    return
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
+    return
   })
 
   it('sets host', () => {

--- a/tests/bud-api/methods/entry.ts
+++ b/tests/bud-api/methods/entry.ts
@@ -1,0 +1,114 @@
+import {
+  Framework,
+  setupBud,
+  config,
+  teardownBud,
+} from '../../util'
+
+describe('bud.entry', function () {
+  let bud: Framework
+
+  beforeAll(() => {
+    bud = setupBud('production', {
+      ...config,
+      location: {
+        ...config.location,
+        project: `${process.cwd()}/examples/sage`,
+        src: 'resources',
+      },
+    })
+    return
+  })
+
+  afterAll(() => {
+    teardownBud(bud)
+    return
+  })
+
+  beforeEach(() => {
+    bud.hooks.on('build/entry', {})
+  })
+
+  it('sets an entrypoint using (string, string) fn signature', () => {
+    bud.entry('app', 'scripts/app.js')
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: ['scripts/app.js'],
+      },
+    })
+  })
+
+  it('sets an entrypoint using (string, string) fn signature with globbing', () => {
+    bud.entry('app', '**/app.{css,js}')
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: ['scripts/app.js', 'styles/app.css'],
+      },
+    })
+  })
+
+  it('sets an entrypoint using (string, string[]) fn signature', () => {
+    bud.entry('app', ['scripts/app.js', 'styles/app.css'])
+
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: ['scripts/app.js', 'styles/app.css'],
+      },
+    })
+  })
+
+  it('sets an entrypoint using (string, string[]) fn signature with globbing', () => {
+    bud.entry('app', ['**/app.js', '**/editor.css'])
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: ['scripts/app.js', 'styles/editor.css'],
+      },
+    })
+  })
+
+  it('sets a single entrypoint using k, v fn signature', () => {
+    bud.entry({
+      app: ['scripts/app.js', 'styles/app.css'],
+    })
+
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: ['scripts/app.js', 'styles/app.css'],
+      },
+    })
+  })
+
+  it('sets a single entrypoint using k, v fn signature with globbing', () => {
+    bud.entry({
+      app: ['**/app.js', 'styles/*.css'],
+    })
+
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: [
+          'scripts/app.js',
+          'styles/app.css',
+          'styles/editor.css',
+        ],
+      },
+    })
+  })
+
+  it('sets multiple entrypoints using k, v fn signature', () => {
+    bud.entry({
+      app: ['scripts/app.js', 'styles/app.css'],
+      editor: ['scripts/editor.js', 'styles/editor.css'],
+    })
+
+    expect(bud.build.config.entry).toEqual({
+      app: {
+        import: ['scripts/app.js', 'styles/app.css'],
+      },
+      editor: {
+        import: ['scripts/editor.js', 'styles/editor.css'],
+      },
+    })
+  })
+})
+
+export {}

--- a/tests/bud-api/methods/externals.ts
+++ b/tests/bud-api/methods/externals.ts
@@ -3,11 +3,11 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.externals', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
   })
 

--- a/tests/bud-api/methods/hash.ts
+++ b/tests/bud-api/methods/hash.ts
@@ -3,11 +3,11 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.hash', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
   })
 

--- a/tests/bud-api/methods/lazy.ts
+++ b/tests/bud-api/methods/lazy.ts
@@ -3,11 +3,11 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.lazy', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
   })
 

--- a/tests/bud-api/methods/minimize.ts
+++ b/tests/bud-api/methods/minimize.ts
@@ -1,0 +1,33 @@
+import {Framework, setupBud, teardownBud} from '../../util'
+
+describe('bud.minimize', function () {
+  let bud: Framework
+
+  beforeAll(() => {
+    bud = setupBud()
+    return
+  })
+
+  afterAll(() => {
+    teardownBud(bud)
+    return
+  })
+
+  it('is a function', () => {
+    expect(bud.minimize).toBeInstanceOf(Function)
+  })
+
+  it('enables minimizing when called', () => {
+    bud.minimize()
+
+    expect(bud.build.config.optimization.minimize).toEqual(true)
+  })
+
+  it('disables minimizing when false is passed as param', () => {
+    bud.minimize(false)
+
+    expect(bud.build.config.optimization.minimize).toEqual(false)
+  })
+})
+
+export {}

--- a/tests/bud-api/methods/path.ts
+++ b/tests/bud-api/methods/path.ts
@@ -1,0 +1,33 @@
+import {
+  Framework,
+  setupBud,
+  config,
+  teardownBud,
+} from '../../util'
+
+describe('bud.path', function () {
+  let bud: Framework
+
+  beforeAll(() => {
+    bud = setupBud('production')
+    return
+  })
+
+  afterAll(() => {
+    teardownBud(bud)
+    return
+  })
+
+  beforeEach(() => {
+    bud.hooks.on('location/project', config.location.project)
+  })
+
+  it('returns the correct project path', () => {
+    const path = bud.path('project')
+
+    expect(path).toEqual(config.location.project)
+    expect(bud.hooks.filter('location/project')).toEqual(path)
+  })
+})
+
+export {}

--- a/tests/bud-api/methods/publicPath.ts
+++ b/tests/bud-api/methods/publicPath.ts
@@ -3,11 +3,11 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.publicPath', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     bud = teardownBud(bud)
   })
 

--- a/tests/bud-api/methods/setPath.ts
+++ b/tests/bud-api/methods/setPath.ts
@@ -7,10 +7,12 @@ describe('bud.setPath', function () {
 
   beforeAll(() => {
     bud = setupBud()
+    return
   })
 
   afterAll(() => {
     bud = teardownBud(bud)
+    return
   })
 
   it('is a function', () => {

--- a/tests/bud-api/methods/splitChunks.ts
+++ b/tests/bud-api/methods/splitChunks.ts
@@ -1,0 +1,82 @@
+import {Framework, setupBud, teardownBud} from '../../util'
+
+const DEFAULT_OPTIONS = {
+  cacheGroups: {
+    chunks: 'all',
+    vendors: {
+      chunks: 'all',
+      enforce: true,
+      test: /[\\/]node_modules[\\/]/,
+      reuseExistingChunk: true,
+      priority: -10,
+      name: function (
+        module: any,
+        _chunks: any,
+        cacheGroupKey: any,
+      ) {
+        const moduleFileNameParts = module
+          .identifier()
+          .split('/')
+          .reduceRight(item => item)
+          .split('.')
+
+        const file = moduleFileNameParts
+          .slice(0, moduleFileNameParts.length - 1)
+          .join('.')
+
+        return `${cacheGroupKey}/${file}`
+      },
+    },
+  },
+}
+
+describe('bud.splitChunks', function () {
+  let bud: Framework
+
+  beforeAll(() => {
+    bud = setupBud()
+    return
+  })
+
+  afterAll(() => {
+    bud = teardownBud(bud)
+    return
+  })
+
+  beforeEach(() => {
+    bud.hooks.on('build/optimization/splitChunks', undefined)
+  })
+
+  it('is disabled by default', () => {
+    expect(bud.build.config.optimization.splitChunks).toEqual(
+      undefined,
+    )
+  })
+
+  it('sets default options when called', () => {
+    bud.splitChunks()
+
+    expect(
+      JSON.stringify(bud.build.config.optimization.splitChunks),
+    ).toStrictEqual(JSON.stringify(DEFAULT_OPTIONS))
+
+    expect(
+      bud.hooks.filter('build/optimization/splitChunks')
+        .cacheGroups.vendors.name,
+    ).toBeInstanceOf(Function)
+  })
+
+  it('sets options when passed as parameters', () => {
+    const param = {
+      cacheGroups: {
+        chunks: 'all',
+      },
+    }
+
+    bud.splitChunks(param)
+
+    expect(
+      bud.hooks.filter('build/optimization/splitChunks'),
+    ).toBe(param)
+  })
+})

--- a/tests/bud-build/config.dev.ts
+++ b/tests/bud-build/config.dev.ts
@@ -3,12 +3,13 @@ import {Framework, setupBud, teardownBud} from '../util'
 describe('bud.build.config', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
     bud.mode = 'development'
+    return
   })
 
-  afterEach(() => {
+  afterAll(() => {
     teardownBud(bud)
   })
 

--- a/tests/bud-framework/Framework/index.ts
+++ b/tests/bud-framework/Framework/index.ts
@@ -5,14 +5,14 @@ import {noop} from 'lodash'
 describe('bud', () => {
   let bud: Framework
 
-  beforeAll(() => {
+  beforeAll(done => {
     bud = setupBud()
-    return
+    done()
   })
 
-  afterAll(() => {
+  afterAll(done => {
     bud = teardownBud(bud)
-    return
+    done()
   })
 
   it('mode', () => {

--- a/tests/bud-framework/Framework/path.ts
+++ b/tests/bud-framework/Framework/path.ts
@@ -3,11 +3,11 @@ import {Framework, setupBud, teardownBud} from '../../util'
 describe('bud.path', function () {
   let bud: Framework
 
-  beforeEach(() => {
+  beforeAll(() => {
     bud = setupBud()
   })
 
-  afterEach(() => {
+  afterAll(() => {
     bud = teardownBud(bud)
   })
 
@@ -22,6 +22,12 @@ describe('bud.path', function () {
   it('path: returns correct paths joined to context', () => {
     expect(bud.path('project', 'foo')).toEqual(
       `${process.cwd()}/foo`,
+    )
+  })
+
+  it('path: returns correct multipart paths joined to context', () => {
+    expect(bud.path('project', 'foo', 'bar')).toEqual(
+      `${process.cwd()}/foo/bar`,
     )
   })
 })

--- a/tests/bud-tailwindcss/index.ts
+++ b/tests/bud-tailwindcss/index.ts
@@ -19,8 +19,17 @@ describe(NAME, () => {
   describe('settings', () => {
     let bud: Framework = null
 
-    beforeEach(done => {
+    beforeAll(done => {
       bud = setupBud('production', CONFIG)
+      done()
+    })
+
+    afterAll(done => {
+      bud = teardownBud(bud)
+      done()
+    })
+
+    beforeEach(() => {
       bud.discovery.set('devDependencies', {
         postcss: '*',
         ['postcss-preset-env']: '*',
@@ -29,12 +38,6 @@ describe(NAME, () => {
       })
 
       bud.use([postcss, tailwindcss])
-      done()
-    })
-
-    afterEach(done => {
-      bud = teardownBud(bud)
-      done()
     })
 
     it('has name prop', () => {


### PR DESCRIPTION
## Type of change

- tests

## Dependencies added

- none

## Details

- small backwards-compatible change to `bud.path` so that it accepts a rest param for path parts. as in: `bud.path('project', 'src', 'foo', 'bar')`
