### PR TITLE
labeler: add docs label for docusaurus config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -194,6 +194,7 @@
   - examples/**
 
 'docs':
+  - docusaurus.config.js
   - docs/*
   - docs/**
   - packages/**/docs/*


### PR DESCRIPTION
## Type of change

MINOR: GitHub labeler - add documentation label for `docusaurus.config.js` changes
