### PR TITLE
Docs: add analytics

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -28,6 +28,10 @@ const config = {
       id: 'announcementBar-1', // Increment on change
       content: `⭐️ If you like Bud.js, give it a star on <a target="_blank" rel="noopener noreferrer" href="${manifest.url.web}">GitHub</a>! ⭐`,
     },
+    googleAnalytics: {
+      trackingID: 'UA-71591-53',
+      anonymizeIP: true,
+    },
     hideableSidebar: true,
     prism: {
       additionalLanguages: ['php'],


### PR DESCRIPTION
## Type of change

- NA: site/docs only

## Dependencies added

None

## Details

Does the same thing as #192. 

Created this PR because all the docs moved to the `site` dir and we don't need to explicitly add the dependency (since we're using docusaurus-classic). I didn't want to rebase.

Hopefully credited @retlehs properly..
