### PR TITLE
fix: omit bundled packages from @roots/wordpress-externals-webpack-plugin

### DIFF
--- a/packages/@roots/bud-support/src/util/wordpressPkgs.ts
+++ b/packages/@roots/bud-support/src/util/wordpressPkgs.ts
@@ -17,6 +17,15 @@ export interface Externals {
 export type PackageMapEntry = [string, Record<string, string>]
 
 /**
+ * Packages in the `@wordpress` namespace which
+ * are should not be considered as external
+ */
+const OMIT_PACKAGE_MATCHES = [
+  '@wordpress/icons',
+  '@wordpress/interface',
+]
+
+/**
  * Pkg map
  */
 const packageMap = new Map([
@@ -70,7 +79,8 @@ const transformPackageName = (packageName: string) =>
 export const isProvided: (
   packageName: string,
 ) => boolean = packageName => {
-  if (!packageName) return false
+  if (!packageName || OMIT_PACKAGE_MATCHES.includes(packageName))
+    return false
 
   return (
     packageName.includes('@wordpress') ||

--- a/packages/@roots/bud-support/src/util/wordpressPkgs.ts
+++ b/packages/@roots/bud-support/src/util/wordpressPkgs.ts
@@ -18,7 +18,7 @@ export type PackageMapEntry = [string, Record<string, string>]
 
 /**
  * Packages in the `@wordpress` namespace which
- * are should not be considered as external
+ * should not be considered as external
  */
 const OMIT_PACKAGE_MATCHES = [
   '@wordpress/icons',


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

Everything in the `@wordpress` namespace can be safely considered a webpack external except:

- @wordpress/icons
- @wordpress/interface

These are not provided by wordpress as window variables (even if requested) and need to be provided by the theme/plugin author.

This fix excludes them from being considered a match in the `@roots/wordpress-externals-webpack-plugin` package.

ref: #719