### PR TITLE
Fix dev server public path

### DIFF
--- a/examples/sage/tailwind.config.js
+++ b/examples/sage/tailwind.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   mode: 'jit',
-  purge: ['resources/**/*.{js,html}'],
-  darkMode: false, // or 'media' or 'class'
+  content: ['resources/**/*.{js,html}'],
   theme: {
     extend: {
       colors: {},

--- a/packages/@roots/bud-api/src/api/methods/proxy/index.ts
+++ b/packages/@roots/bud-api/src/api/methods/proxy/index.ts
@@ -38,19 +38,23 @@ export const proxy: proxy = function (
   ctx.store.set('server.middleware.proxy', true)
   ctx.api.log('log', 'enabling proxy')
 
+  if (typeof config === 'number') {
+    ctx.store.set(
+      'server.proxy.url',
+      `http://localhost:${config}`,
+    )
+    return ctx
+  }
+
   if (typeof config === 'string') {
     ctx.store.set('server.proxy.url', config)
-    ctx.api.log('log', {
-      message: 'proxy url set',
-      suffix: config,
-    })
-
     return ctx
   }
 
   ctx.store.set('server.proxy', config)
+
   ctx.api.log('log', {
-    message: 'proxy config set',
+    message: 'proxy url set',
     suffix: config,
   })
 

--- a/packages/@roots/bud-api/src/api/methods/serve/index.ts
+++ b/packages/@roots/bud-api/src/api/methods/serve/index.ts
@@ -1,7 +1,11 @@
 import type {Framework, Server} from '@roots/bud-framework'
 
 export interface serve {
-  (config: Server.Configuration['dev']['url']): Framework
+  (port: number): Framework
+}
+
+export interface serve {
+  (url: Server.Configuration['dev']['url']): Framework
 }
 
 export interface serve {
@@ -10,6 +14,11 @@ export interface serve {
 
 export const serve: serve = function (config) {
   const ctx = this as Framework
+
+  if (typeof config === 'number') {
+    ctx.store.set('server.dev.url', `http://localhost:${config}`)
+    return ctx
+  }
 
   if (typeof config === 'string') {
     ctx.store.set('server.dev.url', config)

--- a/packages/@roots/bud-server/src/client/index.ts
+++ b/packages/@roots/bud-server/src/client/index.ts
@@ -40,7 +40,7 @@ const resourceQuery = __resourceQuery as string
 
     // eslint-disable-next-line no-console
     console.log(
-      `%c [bud-server] %c %c ${payload.action}`,
+      `%c[bud]%c %c${payload.action}`,
       'background: #525ddc; color: #ffffff;',
       'background: transparent;',
       'background: white; color: #343a40;',

--- a/packages/@roots/bud-server/src/client/proxy-click-interceptor.js
+++ b/packages/@roots/bud-server/src/client/proxy-click-interceptor.js
@@ -1,0 +1,36 @@
+/* global __resourceQuery */
+/* eslint-disable no-console, no-extra-semi */
+
+;(async () => {
+  const main = async () => {
+    const {headers} = await fetch(window.location.origin, {
+      method: 'HEAD',
+      mode: 'cors',
+    })
+
+    const origin = {
+      proxy: headers.get('x-bud-proxy-origin'),
+      dev: headers.get('x-bud-dev-origin'),
+    }
+
+    if (!origin.proxy || !origin.dev) return
+
+    console.log(
+      `%c[bud]%c intercepting anchor links`,
+      'background: #525ddc; color: #ffffff;',
+      'background: transparent;',
+    )
+
+    document.addEventListener('click', e => {
+      const target = e.target.closest('a')
+      if (!target || target.href.includes(origin.dev)) return
+      target.href = target.href.replace(origin.proxy, origin.dev)
+    })
+  }
+
+  window.requestAnimationFrame(async function ready() {
+    return document.body
+      ? await main()
+      : window.requestAnimationFrame(ready)
+  })
+})()

--- a/packages/@roots/bud-server/src/middleware/dev/index.ts
+++ b/packages/@roots/bud-server/src/middleware/dev/index.ts
@@ -23,7 +23,7 @@ const makeOptions = (
   app: Framework,
 ): WebpackDevMiddleware.Options => ({
   writeToDisk: true,
-  publicPath: `/__bud/`,
+  publicPath: app.hooks.filter('build.output.publicPath'),
   stats: false,
   headers: {
     ['X-Server']: '@roots/bud',

--- a/packages/@roots/bud-server/src/middleware/proxy/proxy.middleware.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/proxy.middleware.ts
@@ -27,13 +27,6 @@ export const middleware = (app: Framework) => {
   )
 
   return createProxyMiddleware(
-    [
-      '*',
-      '/**/*',
-      '!/__bud/*',
-      '!/__bud/**/*',
-      '!/**/*.hot-update.*',
-    ],
     app.hooks.filter('proxy.options', options.make),
   )
 }

--- a/packages/@roots/bud-server/src/middleware/proxy/proxy.options.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/proxy.options.ts
@@ -1,5 +1,5 @@
 import {Framework} from '@roots/bud-framework'
-import {bind} from '@roots/bud-support'
+import {bind, prettyFormat} from '@roots/bud-support'
 import {Options as ProxyOptions} from 'http-proxy-middleware'
 import {Signale} from 'signale'
 
@@ -19,7 +19,7 @@ export class OptionsFactory {
   public options: Partial<ProxyOptions> = {
     autoRewrite: true,
     changeOrigin: true,
-    followRedirects: false,
+    followRedirects: true,
     selfHandleResponse: true,
     logLevel: 'debug',
     headers: {
@@ -49,8 +49,10 @@ export class OptionsFactory {
       [url.proxy.host]: url.dev.host,
     }
 
+    this.options.hostRewrite = url.dev.host
     this.options.onProxyReq = request
     this.options.onProxyRes = interceptor
+    this.options.secure = false
     this.options.target = url.proxy.href
     this.options.logLevel = app.store.is('features.log', true)
       ? 'debug'
@@ -60,6 +62,10 @@ export class OptionsFactory {
       let logger = new Signale()
       return logger.scope('server', 'proxy')
     }
+
+    Object.entries(this.options).forEach(([key, value]) => {
+      app.log(`proxy.${key}`, prettyFormat(value))
+    })
   }
 
   /**

--- a/packages/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -85,6 +85,8 @@ export class ResponseInterceptorFactory {
   ): Promise<Buffer | string> {
     try {
       res.setHeader('x-proxy-by', '@roots/bud')
+      res.setHeader('x-bud-proxy-origin', this.url.proxy.origin)
+      res.setHeader('x-bud-dev-origin', this.url.dev.origin)
 
       /**
        * css is not handled by the proxy

--- a/packages/@roots/bud-server/src/server/index.ts
+++ b/packages/@roots/bud-server/src/server/index.ts
@@ -142,9 +142,6 @@ export class Server
     this.app.hooks.on('config.override', config => {
       return config.map(compilerConfiguration => {
         compilerConfiguration.bail = false
-        compilerConfiguration.output.path = this.app.path('dist')
-        compilerConfiguration.optimization.emitOnErrors = true
-
         return compilerConfiguration
       })
     })
@@ -152,10 +149,6 @@ export class Server
     await this.app.compiler.compile()
     this.processMiddlewares()
 
-    /**
-     * __roots route
-     */
-    this.application.use('/__bud', __BudRouter)
     this.application.use((req, res, next) => {
       res.status(404).send("Sorry can't find that!")
     })

--- a/packages/@roots/bud-server/tsconfig.json
+++ b/packages/@roots/bud-server/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "extends": "../../../config/tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib/cjs",
     "declarationDir": "./types"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "references": [
     {
       "path": "./../bud-api/tsconfig.json"

--- a/packages/@roots/bud-tailwindcss/src/tailwind.extension.ts
+++ b/packages/@roots/bud-tailwindcss/src/tailwind.extension.ts
@@ -87,16 +87,19 @@ export const BudTailwindCssExtension: BudTailwindCssExtension = {
 
     try {
       const tailwindcss = await import('tailwindcss')
+      const {default: nesting} = await import(
+        'tailwindcss/nesting/index.js'
+      )
 
       const config: string | null =
         await getVerifiedUserConfigPath.bind(app)()
 
       app.postcss.setPlugins({
         'postcss-import': app.postcss.get('postcss-import'),
+        'tailwindcss-nesting': [nesting],
         tailwindcss: config
           ? [tailwindcss.default, config]
           : tailwindcss.default,
-        'postcss-nested': app.postcss.get('postcss-nested'),
         'postcss-preset-env': app.postcss.get(
           'postcss-preset-env',
         ),

--- a/packages/@roots/sage/src/Sage/index.ts
+++ b/packages/@roots/sage/src/Sage/index.ts
@@ -1,9 +1,4 @@
 import {Extension, Framework} from '@roots/bud-framework'
-import {fs} from '@roots/bud-support'
-import {ensureDir} from 'fs-extra'
-import {URL, urlToHttpOptions} from 'url'
-
-const {pathExistsSync, writeJson, removeSync} = fs
 
 /**
  * Development configuration
@@ -14,40 +9,8 @@ const inDevelopment = (app: Framework) => {
   app.devtool()
 
   app.extensions.get('@roots/bud-entrypoints').setOptions({
-    publicPath: '',
+    publicPath: 'auto',
   })
-
-  app.hooks
-    .async<'event.compiler.done'>(
-      'event.compiler.done',
-      async stats => {
-        const dev = new URL(app.store.get('server.dev.url'))
-        const proxy = new URL(app.store.get('server.proxy.url'))
-
-        try {
-          await ensureDir(app.path('dist'))
-          await writeJson(app.path('dist', 'hmr.json'), {
-            dev: urlToHttpOptions(dev),
-
-            proxy: app.store.is('server.middleware.proxy', true)
-              ? urlToHttpOptions(proxy)
-              : false,
-
-            publicPath: app.hooks.filter(
-              'build.output.publicPath',
-            ),
-          })
-        } catch (error) {
-          throw new Error(error)
-        }
-
-        return stats
-      },
-    )
-    .hooks.on('event.app.close', () => {
-      const path = app.path('dist', 'hmr.json')
-      pathExistsSync(path) && removeSync(path)
-    })
 }
 
 /**


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Notes

**don't** specify a port of `80` or `443` when calling `bud.serve` or `bud.proxy`. those ports are implied and it might break things (ideally it wouldn't but nonetheless it might).

**do** include the protocol when calling `bud.serve` or `bud.proxy`. 

```ts
❌ bud.serve('http://example.test:80')
❌ bud.serve('example.test:3000')
✅ bud.serve('http://example.test')
✅ bud.serve('http://example.test:3000')
```

i think that the node url api is actually pretty lenient towards all of these calls but i may have messed something up parsing the URLs somewhere. so, if it works for you, great! if not, start with this.

## Changelog

- updates tailwindcss to use `tailwindcss/nesting` export (instead of `postcss-nested`). this makes bud fully tailwind 3 compatible.
- allows setting proxy/dev solely with port number (if using localhost) 
- fixes proxy path (see note below on sage)
- adds optional import `@roots/bud-server/client/proxy-click-interceptor`. this script can be imported in `app.js`. it hijacks any anchor clicks and replaces the proxy hostname with the dev hostname. this already happens during the request proxying but without this client script any links inserted by JS (like the wp topbar) will still point at the proxy site. the script works by fetching itself and investigating the headers; it should not execute if the site is not proxied. it's included here because it's a serious nice-to-have, but it is experimental and strictly opt-in. eventually, i think this should be part of the sage or wordpress presets.
- `@roots/sage` no longer produces `hmr.json` artifact

## Note on proxy path for Sage

The plan is for Sage or Acorn to supply bud the publicPath for assets via a response header.

For now, this can be done manually in `./app/setup.php`: 

```php
header('x-bud-proxy-path: http://example.test/app/themes/sage/public/')
```