### PR TITLE
feat(server): update req headers

### DIFF
--- a/packages/@roots/bud-server/src/middleware/proxy/req.interceptor.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/req.interceptor.ts
@@ -5,6 +5,7 @@ import {
   IncomingMessage,
   ServerResponse,
 } from 'http'
+import {URL as nodeUrl} from 'url'
 
 import {URL} from './url'
 
@@ -50,10 +51,10 @@ export class RequestInterceptorFactory {
     res: ServerResponse,
   ) {
     try {
-      proxyReq.setHeader('x-bud-forward-href', req.url)
+      proxyReq.setHeader('x-bud-dev-origin', this.url.dev.origin)
       proxyReq.setHeader(
-        'x-bud-forward-origin',
-        this.url.dev.origin,
+        'x-bud-dev-pathname',
+        new nodeUrl(req.url).pathname,
       )
     } catch (err) {
       process.stderr.write(`${err}\n`)


### PR DESCRIPTION
## Dependencies added

- none

## Details

sets headers on initial proxy req:

- `'x-bud-dev-origin'` (e.g. `http://example:3000`)
- `'x-bud-dev-pathname'` (e.g. `/path-segment/path-segment`)
