### PR TITLE
fix(test): correct path import

### DIFF
--- a/tests/unit/bud-api/repository/hash.test.ts
+++ b/tests/unit/bud-api/repository/hash.test.ts
@@ -1,5 +1,5 @@
 import {Bud, factory} from '@roots/bud'
-import {join} from 'path/posix'
+import {join} from 'path'
 
 describe('bud.hash', function () {
   let bud: Bud


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

- `hash.test.ts` in the integration suite for `bud-api` was importing from `path/posix`. 
- nbd but it causes issues if you aren't on node 16
- sticking with `... from 'path'` throughout the repo will make migrating to esmodules easier. i think we'll want to use the `node:` import syntax eventually.
