### PR TITLE
fix(cli): nerf `bud install`

### DIFF
--- a/packages/@roots/bud/src/cli/commands/build.ts
+++ b/packages/@roots/bud/src/cli/commands/build.ts
@@ -78,11 +78,6 @@ export default class Build extends Command {
       description: 'automatically register & boot extensions',
     }),
 
-    install: oclif.Flags.boolean({
-      description: 'ensure peer dependencies are installed',
-      default: false,
-    }),
-
     manifest: oclif.Flags.boolean({
       allowNo: true,
       default: true,

--- a/tests/unit/bud/cli/commands/__snapshots__/build.test.ts.snap
+++ b/tests/unit/bud/cli/commands/__snapshots__/build.test.ts.snap
@@ -75,13 +75,6 @@ Object {
     "parse": [Function],
     "type": "boolean",
   },
-  "install": Object {
-    "allowNo": false,
-    "default": false,
-    "description": "ensure peer dependencies are installed",
-    "parse": [Function],
-    "type": "boolean",
-  },
   "location.dist": Object {
     "description": "distribution directory",
     "input": Array [],


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

Temporarily nerfs `bud install`. Writes missing dependencies to `package.json`.  Instructs user to run `yarn/npm` install. 