### PR TITLE
improve(eslint) modularize eslint configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,7 +58,7 @@ module.exports = {
     {
       files: ['examples/**/*.js'],
       rules: {
-        'tsdoc/syntax': 'off',
+        'tsdoc/syntax': OFF,
       },
     },
   ],

--- a/examples/eslint/.eslintrc.js
+++ b/examples/eslint/.eslintrc.js
@@ -1,43 +1,6 @@
 module.exports = {
   root: true,
-  extends: ['eslint:recommended'],
-  env: {
-    node: true,
-    es6: true,
-    amd: true,
-    browser: true,
-    jquery: true,
-  },
-  parserOptions: {
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-      globalReturn: true,
-      generators: false,
-      impliedStrict: true,
-      objectLiteralDuplicateProperties: false,
-    },
-    ecmaVersion: 2017,
-    sourceType: 'module',
-  },
-  plugins: ['import'],
-  settings: {
-    'import/core-modules': [],
-    'import/ignore': [
-      'node_modules',
-      '\\.(coffee|scss|css|less|hbs|svg|json)$',
-    ],
-  },
-  rules: {
-    'no-console': 0,
-    'comma-dangle': [
-      'error',
-      {
-        arrays: 'always-multiline',
-        objects: 'always-multiline',
-        imports: 'always-multiline',
-        exports: 'always-multiline',
-        functions: 'ignore',
-      },
-    ],
-  },
+  extends: [
+    require.resolve('@roots/bud-preset-recommend/eslint-config'),
+  ],
 }

--- a/examples/eslint/package.json
+++ b/examples/eslint/package.json
@@ -15,7 +15,11 @@
   },
   "devDependencies": {
     "@roots/bud": "workspace:packages/@roots/bud",
-    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint",
-    "@roots/bud-preset-recommend": "workspace:*"
+    "@roots/bud-preset-recommend": "workspace:packages/@roots/bud-preset-recommend",
+    "eslint": "8.5.0",
+    "postcss": "8.4.5",
+    "postcss-import": "14.0.2",
+    "postcss-nested": "5.0.6",
+    "postcss-preset-env": "7.1.0"
   }
 }

--- a/examples/preset-recommend/.eslintrc.js
+++ b/examples/preset-recommend/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  root: true,
+  extends: [
+    require.resolve('@roots/bud-preset-recommend/eslint-config'),
+  ],
+}

--- a/examples/sage/.eslintrc.js
+++ b/examples/sage/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['@roots/sage/eslint-config'],
+  extends: [require.resolve('@roots/sage/eslint-config')],
 };

--- a/examples/wordpress-theme/.eslintrc.js
+++ b/examples/wordpress-theme/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  root: true,
+  extends: [
+    require.resolve('@roots/bud-preset-wordpress/eslint-config'),
+  ],
+}

--- a/packages/@roots/bud-babel/eslint-config/index.js
+++ b/packages/@roots/bud-babel/eslint-config/index.js
@@ -1,0 +1,21 @@
+/**
+ * Babel default eslint config
+ *
+ * @public
+ */
+module.exports = {
+  parser: '@babel/eslint-parser',
+  parserOptions: {
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      globalReturn: true,
+      generators: false,
+      impliedStrict: true,
+      jsx: true,
+      objectLiteralDuplicateProperties: false,
+    },
+    ecmaVersion: 2017,
+    requireConfigFile: false,
+    sourceType: 'module',
+  },
+}

--- a/packages/@roots/bud-babel/package.json
+++ b/packages/@roots/bud-babel/package.json
@@ -34,6 +34,7 @@
     "node": ">=14"
   },
   "files": [
+    "eslint-config/",
     "lib/",
     "types/"
   ],
@@ -41,8 +42,8 @@
   "module": "./lib/esm/index.js",
   "types": "./types/index.d.ts",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js"
+    ".": "./lib/cjs/index.js",
+    "./eslint-config": "./eslint-config/index.js"
   },
   "scripts": {
     "build": "yarn g:build",

--- a/packages/@roots/bud-eslint/eslint-config/index.js
+++ b/packages/@roots/bud-eslint/eslint-config/index.js
@@ -1,0 +1,21 @@
+/**
+ * Default eslint config
+ *
+ * @public
+ */
+module.exports = {
+  extends: ['eslint:recommended'],
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  plugins: ['import'],
+  settings: {
+    'import/core-modules': [],
+    'import/ignore': [
+      'node_modules',
+      '\\.(coffee|scss|css|less|hbs|svg|json)$',
+    ],
+  },
+}

--- a/packages/@roots/bud-eslint/package.json
+++ b/packages/@roots/bud-eslint/package.json
@@ -30,6 +30,7 @@
     "node": ">=14"
   },
   "files": [
+    "eslint-config/",
     "lib/",
     "types/",
     "template/"
@@ -38,8 +39,8 @@
   "module": "./lib/esm/index.js",
   "types": "./types/index.d.ts",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js"
+    ".": "./lib/cjs/index.js",
+    "./eslint-config": "./eslint-config/index.js"
   },
   "scripts": {
     "build": "yarn g:build",
@@ -70,12 +71,7 @@
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.16.5",
-    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.3",
-    "eslint-plugin-jsx-a11y": "^6.5.1",
-    "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "^7.27.1",
-    "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-webpack-plugin": "^3.1.1",
     "tslib": "^2.3.1"
   },

--- a/packages/@roots/bud-preset-recommend/eslint-config/index.js
+++ b/packages/@roots/bud-preset-recommend/eslint-config/index.js
@@ -1,0 +1,11 @@
+/**
+ * Recommended preset default eslint config
+ *
+ * @public
+ */
+module.exports = {
+  extends: [
+    require.resolve('@roots/bud-eslint/eslint-config'),
+    require.resolve('@roots/bud-babel/eslint-config'),
+  ],
+}

--- a/packages/@roots/bud-preset-recommend/package.json
+++ b/packages/@roots/bud-preset-recommend/package.json
@@ -37,6 +37,7 @@
     "node": ">=14"
   },
   "files": [
+    "eslint-config/",
     "lib/",
     "types/",
     "index.d.ts"
@@ -45,8 +46,8 @@
   "module": "./lib/esm/index.js",
   "types": "./types/index.d.ts",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js"
+    ".": "./lib/cjs/index.js",
+    "./eslint-config": "./eslint-config/index.js"
   },
   "scripts": {
     "build": "yarn g:build",
@@ -71,6 +72,7 @@
     "peers": [
       "@roots/bud-babel",
       "@roots/bud-entrypoints",
+      "@roots/bud-eslint",
       "@roots/bud-postcss"
     ]
   },
@@ -82,6 +84,7 @@
   "dependencies": {
     "@roots/bud-babel": "workspace:packages/@roots/bud-babel",
     "@roots/bud-entrypoints": "workspace:packages/@roots/bud-entrypoints",
+    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint",
     "@roots/bud-postcss": "workspace:packages/@roots/bud-postcss",
     "tslib": "2.3.1"
   }

--- a/packages/@roots/bud-preset-wordpress/eslint-config/index.js
+++ b/packages/@roots/bud-preset-wordpress/eslint-config/index.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress preset default eslint config
+ *
+ * @public
+ */
+module.exports = {
+  extends: [
+    require.resolve('@roots/bud-preset-recommend/eslint-config'),
+    require.resolve('@roots/bud-react/eslint-config'),
+  ],
+  env: {jquery: true},
+  globals: {wp: true},
+}

--- a/packages/@roots/bud-preset-wordpress/package.json
+++ b/packages/@roots/bud-preset-wordpress/package.json
@@ -29,6 +29,7 @@
     "node": ">=14"
   },
   "files": [
+    "eslint-config/",
     "lib/",
     "types/"
   ],
@@ -36,8 +37,8 @@
   "module": "./lib/esm/index.js",
   "types": "./types/index.d.ts",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js"
+    ".": "./lib/cjs/index.js",
+    "./eslint-config": "./eslint-config/index.js"
   },
   "scripts": {
     "build": "yarn g:build",

--- a/packages/@roots/bud-prettier/eslint-config/index.js
+++ b/packages/@roots/bud-prettier/eslint-config/index.js
@@ -1,0 +1,8 @@
+/**
+ * Prettier default eslint config
+ *
+ * @public
+ */
+module.exports = {
+  extends: ['plugin:prettier/recommended'],
+}

--- a/packages/@roots/bud-prettier/package.json
+++ b/packages/@roots/bud-prettier/package.json
@@ -35,6 +35,7 @@
     "node": ">=14"
   },
   "files": [
+    "eslint-config/",
     "lib/",
     "types/"
   ],
@@ -42,8 +43,8 @@
   "module": "./lib/esm/index.js",
   "types": "./types/index.d.ts",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js"
+    ".": "./lib/cjs/index.js",
+    "./eslint-config": "./eslint-config/index.js"
   },
   "scripts": {
     "build": "yarn g:build",
@@ -74,6 +75,8 @@
   },
   "dependencies": {
     "autobind-decorator": "2.4.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "prettier": "2.5.1",
     "tslib": "2.3.1"
   },

--- a/packages/@roots/bud-react/eslint-config/index.js
+++ b/packages/@roots/bud-react/eslint-config/index.js
@@ -1,0 +1,14 @@
+/**
+ * React default eslint config
+ *
+ * @public
+ */
+module.exports = {
+  extends: ['plugin:react/recommended'],
+  plugins: ['react-hooks', 'jsx-a11y'],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+}

--- a/packages/@roots/bud-react/package.json
+++ b/packages/@roots/bud-react/package.json
@@ -35,6 +35,7 @@
     "node": ">=14"
   },
   "files": [
+    "eslint-config/",
     "lib/",
     "types/"
   ],
@@ -42,8 +43,8 @@
   "module": "./lib/esm/index.js",
   "types": "./types/index.d.ts",
   "exports": {
-    "require": "./lib/cjs/index.js",
-    "import": "./lib/esm/index.js"
+    ".": "./lib/cjs/index.js",
+    "./eslint-config": "./eslint-config/index.js"
   },
   "scripts": {
     "build": "yarn g:build",
@@ -90,6 +91,9 @@
     "@babel/preset-react": "^7.16.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "autobind-decorator": "2.4.0",
+    "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-react": "^7.27.1",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "react-hot-loader": "4.13.0",
     "react-refresh": "0.11.0",
     "tslib": "2.3.1"

--- a/packages/@roots/sage/eslint-config/index.js
+++ b/packages/@roots/sage/eslint-config/index.js
@@ -1,44 +1,13 @@
 /**
  * Sage default eslint config
+ *
+ * @public
  */
-
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:react/recommended'],
-  globals: {
-    wp: true,
-  },
-  env: {
-    node: true,
-    es6: true,
-    amd: true,
-    browser: true,
-    jquery: true,
-  },
-  parser: '@babel/eslint-parser',
-  parserOptions: {
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-      globalReturn: true,
-      generators: false,
-      impliedStrict: true,
-      jsx: true,
-      objectLiteralDuplicateProperties: false,
-    },
-    ecmaVersion: 2017,
-    requireConfigFile: false,
-    sourceType: 'module',
-  },
-  plugins: ['import', 'react-hooks'],
-  settings: {
-    react: {
-      version: 'detect',
-    },
-    'import/core-modules': [],
-    'import/ignore': [
-      'node_modules',
-      '\\.(coffee|scss|css|less|hbs|svg|json)$',
-    ],
-  },
+  extends: [
+    require.resolve('@roots/bud-preset-wordpress/eslint-config'),
+    require.resolve('@roots/bud-prettier/eslint-config'),
+  ],
   rules: {
     'no-console': 0,
     'comma-dangle': [

--- a/packages/@roots/sage/package.json
+++ b/packages/@roots/sage/package.json
@@ -33,7 +33,7 @@
     "node": ">=14"
   },
   "files": [
-    "eslint/",
+    "eslint-config/",
     "lib/",
     "types/"
   ],

--- a/tests/unit/bud-build/__snapshots__/config.test.ts.snap
+++ b/tests/unit/bud-build/__snapshots__/config.test.ts.snap
@@ -162,7 +162,7 @@ Object {
 }
 `;
 
-exports[`bud.build.config has expected number of plugins 1`] = `4`;
+exports[`bud.build.config has expected number of plugins 1`] = `5`;
 
 exports[`bud.build.config has expected resolve.extensions default 1`] = `
 Array [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,12 +3447,7 @@ __metadata:
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
     "@types/node": 16.11.17
     eslint: 8.5.0
-    eslint-config-prettier: ^8.3.0
     eslint-plugin-import: ^2.25.3
-    eslint-plugin-jsx-a11y: ^6.5.1
-    eslint-plugin-prettier: ^4.0.0
-    eslint-plugin-react: ^7.27.1
-    eslint-plugin-react-hooks: ^4.3.0
     eslint-webpack-plugin: ^3.1.1
     tslib: ^2.3.1
     webpack: 5.65.0
@@ -3605,6 +3600,7 @@ __metadata:
     "@roots/bud-api": "workspace:packages/@roots/bud-api"
     "@roots/bud-babel": "workspace:packages/@roots/bud-babel"
     "@roots/bud-entrypoints": "workspace:packages/@roots/bud-entrypoints"
+    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint"
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
     "@roots/bud-postcss": "workspace:packages/@roots/bud-postcss"
     "@types/node": 16.11.17
@@ -3646,6 +3642,8 @@ __metadata:
     "@types/jest": 27.0.3
     "@types/node": 16.11.17
     autobind-decorator: 2.4.0
+    eslint-config-prettier: ^8.3.0
+    eslint-plugin-prettier: ^4.0.0
     jest: 27.4.5
     prettier: 2.5.1
     tslib: 2.3.1
@@ -3689,6 +3687,9 @@ __metadata:
     "@types/react": 17.0.38
     "@types/react-dom": 17.0.11
     autobind-decorator: 2.4.0
+    eslint-plugin-jsx-a11y: ^6.5.1
+    eslint-plugin-react: ^7.27.1
+    eslint-plugin-react-hooks: ^4.3.0
     jest: 27.4.5
     react: 17.0.2
     react-dom: 17.0.2
@@ -11587,8 +11588,12 @@ __metadata:
   resolution: "example-eslint@workspace:examples/eslint"
   dependencies:
     "@roots/bud": "workspace:packages/@roots/bud"
-    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint"
-    "@roots/bud-preset-recommend": "workspace:*"
+    "@roots/bud-preset-recommend": "workspace:packages/@roots/bud-preset-recommend"
+    eslint: 8.5.0
+    postcss: 8.4.5
+    postcss-import: 14.0.2
+    postcss-nested: 5.0.6
+    postcss-preset-env: 7.1.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- **@roots/bud-preset-recommend** includes **@roots/bud-eslint**

## Details

1. I was sporadically getting an error about eslint not being able to resolve the new config set up in #892. require.resolve seems to fix it. 

2. I am further modularizing the eslint configs in this PR. Now, each bud extension exports the configuration items it is responsible for. These smaller configs are composable and allow for a great deal more flexibility for people using bud and makes it a lot easier for us to change something like the base babel config across several extensions, in the future.

The simplest possible use case is: **@roots/bud** with **@roots/bud-eslint**. That project eslintrc might look like:

```js
module.exports = {
  root: true,
  extends: [
    require.resolve('@roots/bud-eslint/eslint-config'),
  ],
}
```

Later, we install **@roots/bud-babel** on and we want to support that syntax. So, we can add the new export:

```js
module.exports = {
  root: true,
  extends: [
    require.resolve('@roots/bud-eslint/eslint-config'),
    require.resolve('@roots/bud-babel/eslint-config'),
  ],
}
```

Ultimately it makes sense to install a preset instead of individual extensions, and the presets export their own configs to make that easy. Here is the `@roots/bud-preset-recommend` example's eslint config:

https://github.com/roots/bud/blob/b2033acd159a6e2f795a2a2fd196b29779f5b076/examples/eslint/.eslintrc.js#L1-L6

In the end, the Sage preset is actually the baseline wordpress preset (babel, react, wp global) combined with prettier and a couple custom rules:

https://github.com/roots/bud/blob/b2033acd159a6e2f795a2a2fd196b29779f5b076/packages/%40roots/sage/eslint-config/index.js#L6-L24

The project config remains unchanged:

```js
module.exports = {
  root: true,
  extends: [require.resolve('@roots/sage/eslint-config')],
};
```

And if we want to make a change to it we should ask "is this specific to Sage or should it apply to all X projects?"
- If the answer is "only sage" then we can make the change here exactly as before.
- If the answer is "all projects" then we can make the change to the underlying config. Now all projects will benefit from it.

**Here's how the different configs compose/inherit rules:**

- **@roots/bud-eslint** exports a barebones eslint config as our base (`@roots/bud-eslint/eslint-config`)
- **@roots/bud-babel** exports babel parser and config (`@roots/bud-babel/eslint-config`)
- **@roots/bud-prettier** exports prettier plugin and prettier recommended preset (`@roots/bud-prettier/eslint-config`)
- **@roots/bud-react** exports react plugins and config (`@roots/bud-react/eslint-config`)
- **@roots/bud-preset-recommend** configuration includes:
  - @roots/bud-eslint
  - @roots/bud-babel
 - **@roots/bud-preset-wordpress** configuration includes:
   - @roots/bud-preset-recommend
   - @roots/bud-react
 - **@roots/sage** includes:
   - @roots/bud-preset-wordpress
   - @roots/bud-prettier
   - sage rule overrides
 