### PR TITLE
fix(sage) public path

### DIFF
--- a/examples/sage/bud.config.js
+++ b/examples/sage/bud.config.js
@@ -14,6 +14,7 @@ module.exports = async (app) => {
     .copy(['resources/images'])
     .watch(['tailwind.config.js', 'resources/views/*.blade.php'])
     .setPath('dist', 'public')
+    .setPublicPath('/app/themes/sage/public/')
     .serve('http://example.test:3000')
     .proxy('http://example.test');
 };

--- a/packages/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -2,7 +2,6 @@ import {Framework} from '@roots/bud-framework'
 import {bind} from '@roots/bud-support'
 import {IncomingMessage, ServerResponse} from 'http'
 import {responseInterceptor} from 'http-proxy-middleware'
-import {URL as NodeURL} from 'url'
 
 import {URL} from './url'
 
@@ -19,33 +18,6 @@ export class ResponseInterceptorFactory {
    */
   public get app() {
     return this._app()
-  }
-
-  /**
-   * Provided by the proxy server to be used
-   * in place of the publicPath in the response
-   *
-   * @public
-   */
-  public proxyPath: NodeURL
-
-  /**
-   * Boolean indicating if the proxied server
-   * is handling the response body
-   *
-   * @public
-   */
-  public exitEarly: boolean
-
-  /**
-   * Asset base path (for dev server hosted assets)
-   *
-   * @public
-   */
-  public get assetBase() {
-    return `${this.url.dev.origin}${this.app.hooks.filter(
-      'build.output.publicPath',
-    )}`
   }
 
   /**
@@ -79,47 +51,14 @@ export class ResponseInterceptorFactory {
   @bind
   public async _interceptor(
     buffer: Buffer,
-    proxyRes: IncomingMessage,
-    req: IncomingMessage,
+    _proxyRes: IncomingMessage,
+    _req: IncomingMessage,
     res: ServerResponse,
   ): Promise<Buffer | string> {
     try {
       res.setHeader('x-proxy-by', '@roots/bud')
       res.setHeader('x-bud-proxy-origin', this.url.proxy.origin)
       res.setHeader('x-bud-dev-origin', this.url.dev.origin)
-
-      /**
-       * css is not handled by the proxy
-       */
-      if (req.headers['accept'].startsWith('text/css')) {
-        return `// this is a proxied connection for development. css is served from the js bundle.`
-      }
-
-      /**
-       * If this header is set the proxy is indicating
-       * that this should be used in lieue of the
-       * publicPath.
-       */
-      if (proxyRes.headers['x-bud-proxy-path']) {
-        res.setHeader(
-          'x-bud-proxy-path',
-          proxyRes.headers['x-bud-proxy-path'],
-        )
-
-        this.proxyPath = new NodeURL(
-          proxyRes.headers['x-bud-proxy-path'] as string,
-        )
-      }
-
-      /**
-       * If this header is set the proxy is indicating
-       * that no further replacements should be made
-       * to the body (it will handle modifying page links, etc.)
-       */
-      if (proxyRes.headers['x-bud-proxy-no-process']) {
-        res.setHeader('x-bud-proxy-path-no-process', 'true')
-        this.exitEarly = true
-      }
 
       /**
        * Attempt to convert the body to a string
@@ -129,44 +68,10 @@ export class ResponseInterceptorFactory {
       if (!body) return buffer
 
       /**
-       * If proxy is overriding the publicPath...
-       */
-      if (this.proxyPath) {
-        res.setHeader(
-          'x-bud-proxy-origin',
-          this.proxyPath.origin,
-        )
-        res.setHeader(
-          'x-bud-proxy-path',
-          this.proxyPath.pathname,
-        )
-
-        /**
-         * ...make the replacements as requested by proxy
-         */
-        if (typeof body === 'string') {
-          body = body.replaceAll(
-            new RegExp(this.proxyPath.href, 'g'),
-            `${this.assetBase}`,
-          )
-        }
-
-        /**
-         * ...and return early (if requested)
-         */
-        if (this.exitEarly) return body
-
-        /**
-         * Otherwise, proceedwith the default asset replacement strategy
-         */
-      }
-
-      /**
        * Process replacements
        */
       body = this.replacements?.reduce(
-        (html, [from, to]: [string | RegExp, string]) =>
-          html.replaceAll(from, to),
+        (html: string, [from, to]) => html.replaceAll(from, to),
         body,
       )
 
@@ -204,22 +109,7 @@ export class ResponseInterceptorFactory {
    * @decorator `@bind`
    */
   public get replacements() {
-    const replacements = []
-
-    if (
-      this.app.store.is('server.proxy.replace.publicPath', true)
-    ) {
-      replacements.push(this.replaceAssetPath())
-    }
-
-    if (this.app.store.is('server.proxy.replace.href', true)) {
-      replacements.push(this.replaceHref())
-    }
-
-    if (this.app.store.is('server.proxy.replace.window', true)) {
-      replacements.push(this.replaceWindow())
-    }
-
+    const replacements = [this.replaceAssetPath()]
     return this.app.hooks.filter('proxy.replace', replacements)
   }
 
@@ -231,44 +121,10 @@ export class ResponseInterceptorFactory {
    */
   @bind
   public replaceAssetPath(): [string | RegExp, string] {
-    const search = `${this.url.proxy.origin}${this.url.publicPath}(.*)?`
-    const replacement = `${this.assetBase}$1`
+    const search = `${this.url.proxyAssetUrlBase}(.*)?`
+    const replacement = `${this.url.devAssetUrlBase}$1`
 
     this.app.log(`Replacing '${search}' with '${replacement}'`)
     return [new RegExp(search, 'g'), replacement]
-  }
-
-  /**
-   * Replace window.location.href and the like in response body
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  @bind
-  public replaceWindow(): [string | RegExp, string] {
-    return [
-      new RegExp(
-        `window\\.location([\\[|\\.]['|"]?.*['|"]?\\]?)\\s*?=\\s*?['|"]${this.url.proxy.origin}(.*)['|"]`,
-        'g',
-      ),
-      `window.location$1 = "${this.url.dev.origin}$2"`,
-    ]
-  }
-
-  /**
-   * Replace anchor link href attributes in response body
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  @bind
-  public replaceHref(): [string | RegExp, string] {
-    return [
-      new RegExp(
-        `<a(.*)?href=['|"]${this.url.proxy.origin}(.*)?['|"]`,
-        'g',
-      ),
-      `<a$1href="${this.url.dev.origin}$2"`,
-    ]
   }
 }

--- a/packages/@roots/bud-server/src/middleware/proxy/url.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/url.ts
@@ -1,35 +1,82 @@
 import {Framework, Server} from '@roots/bud-framework'
 import {URL as nodeUrl} from 'url'
 
+/**
+ * URL helpers for proxy middleware
+ *
+ * @public
+ */
 export class URL {
+  /**
+   * Application instance
+   *
+   * @public
+   */
   public get app() {
     return this._app()
   }
 
+  /**
+   * Server config
+   *
+   * @public
+   */
   public get config(): Server.Configuration {
     return this.app.store.get('server')
   }
 
+  /**
+   * Node URL for dev
+   *
+   * @public
+   */
   public get dev(): nodeUrl {
     return new nodeUrl(this.config.dev.url)
   }
 
+  /**
+   * Node URL for proxy
+   *
+   * @public
+   */
   public get proxy(): nodeUrl {
     return new nodeUrl(this.config.proxy.url)
   }
 
+  /**
+   * Class constructor
+   *
+   * @public
+   */
   public constructor(public _app: () => Framework) {}
 
-  public get publicPath(): string {
-    return this.app.hooks.filter<'build.output.publicPath'>(
+  /**
+   * Asset public path
+   *
+   * @public
+   */
+  public get publicPath() {
+    const publicPath = this.app.hooks.filter(
       'build.output.publicPath',
-    ) as string
+    )
+    return publicPath !== 'auto' ? publicPath : '/'
   }
 
-  public hasPublicPath(): boolean {
-    return (
-      this.publicPath &&
-      ![undefined, null, '', 'auto'].includes(this.publicPath)
-    )
+  /**
+   * Asset base path for dev
+   *
+   * @public
+   */
+  public get devAssetUrlBase() {
+    return `${this.dev.origin}${this.publicPath}`
+  }
+
+  /**
+   * Asset base path for proxy
+   *
+   * @public
+   */
+  public get proxyAssetUrlBase() {
+    return `${this.proxy.origin}${this.publicPath}`
   }
 }

--- a/packages/@roots/sage/src/hooks/event.build.make.before.dev.ts
+++ b/packages/@roots/sage/src/hooks/event.build.make.before.dev.ts
@@ -1,0 +1,22 @@
+import {Bud} from '@roots/bud'
+
+/**
+ * event.build.make.before hook handler
+ *
+ * @remarks
+ * ran in development mode
+ *
+ * @public
+ */
+export async function eventBuildMakeBeforeDevelopment(app: Bud) {
+  app.extensions
+    .get('@roots/bud-entrypoints')
+    .setOption(
+      'publicPath',
+      `${app.store.get('server.dev.url')}${app.hooks.filter(
+        'build.output.publicPath',
+      )}`,
+    )
+
+  return app
+}

--- a/packages/@roots/sage/src/hooks/event.build.make.before.production.ts
+++ b/packages/@roots/sage/src/hooks/event.build.make.before.production.ts
@@ -1,0 +1,17 @@
+import {Bud} from '@roots/bud'
+
+/**
+ * event.build.make.before hook handler
+ *
+ * @remarks
+ * ran in development mode
+ *
+ * @public
+ */
+export async function eventBuildMakeBeforeProduction(app: Bud) {
+  app.extensions
+    .get('@roots/bud-entrypoints')
+    .setOption('publicPath', '')
+
+  return app
+}


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

- The proxy server no longer process anchor links when manipulating the response body. To continue having dev server anchor links point to the dev server (you stay on `localhost` when you click around rather than being sent to the site you are proxying) it will be necessary to either:
	- import `@roots/bud-server/client/proxy-click-interceptor` in the project (userland, opt-in)
	- add the `@roots/bud-server/client/proxy-click-interceptor` module before each entrypoint (budland, can still opt-out but harder)
	
- This will require `bud.setPublicPath()` to be called in roots/sage's `bud.config.js`

For a bedrock setup:

```ts
bud.setPublicPath('/app/themes/sage/public')
```

For a vanilla setup:

```ts
bud.setPublicPath('/wp-content/themes/sage/public')
```

- in development roots/sage receives the full URL of assets in `entrypoints.json`.
- in production roots/sage receives the relative asset path in `entrypoints.json`. 

ref: #822 