### PR TITLE
fix(api) bind extension api entries as facades

### DIFF
--- a/packages/@roots/bud-extensions/src/Controller/controller.service.ts
+++ b/packages/@roots/bud-extensions/src/Controller/controller.service.ts
@@ -413,14 +413,30 @@ export class Controller {
         ? await this._module.api(this.app)
         : this._module.api
 
-    await this.app.api.processQueue()
-
     if (!isObject(methodMap))
       throw new Error(
         `${this.name}] api must be an object or return an object`,
       )
 
-    this.app.bindMethod(methodMap)
+    Object.entries(methodMap).forEach(([name, method]) => {
+      if (!isFunction(method))
+        throw new Error(`${name} must be a function`)
+
+      this.app.api.set(
+        name,
+        method.bind ? method.bind(this.app) : method,
+      )
+
+      this.app.api.bindFacade(name)
+
+      if (
+        isUndefined(this.app[name]) ||
+        !isFunction(this.app[name])
+      )
+        throw new Error(
+          `there was a problem binding the ${name} fn to bud (${this.name})`,
+        )
+    })
 
     return this
   }

--- a/packages/@roots/bud-framework/src/Api.ts
+++ b/packages/@roots/bud-framework/src/Api.ts
@@ -26,4 +26,11 @@ export interface Api<
    * @internal
    */
   processQueue: () => Promise<void>
+
+  /**
+   * @internal
+   */
+  bindFacade: (
+    key: `${keyof Api['repository'] & string}`,
+  ) => void
 }

--- a/packages/@roots/bud-imagemin/src/imagemin.extension.ts
+++ b/packages/@roots/bud-imagemin/src/imagemin.extension.ts
@@ -2,6 +2,7 @@ import type {Extension, Framework} from '@roots/bud-framework'
 import ImageMinimizerPlugin, {
   squooshGenerate,
   squooshMinify,
+  SquooshOptions,
 } from 'image-minimizer-webpack-plugin'
 
 import {imagemin} from './imagemin.config'
@@ -9,7 +10,9 @@ import {imagemin} from './imagemin.config'
 export const name: Extension.Module['name'] =
   '@roots/bud-imagemin'
 
-export const options: Extension.Module['options'] = {
+export const options:
+  | Extension.Module['options']
+  | SquooshOptions = {
   test: /.(jpe?g|png|gif|tif|webp|svg|avif)$/i,
   minimizer: {
     implementation: squooshMinify,
@@ -26,12 +29,8 @@ export const options: Extension.Module['options'] = {
   ],
 }
 
-export const register: Extension.Module['register'] = async (
-  app: Framework,
-) => {
-  app.api.set('imagemin', imagemin.bind(app))
-  // @ts-ignore
-  app.api.bindFacade('imagemin')
+export const api: {imagemin: imagemin} = {
+  imagemin,
 }
 
 export const boot = async (app: Framework): Promise<void> => {

--- a/packages/@roots/bud-imagemin/src/index.ts
+++ b/packages/@roots/bud-imagemin/src/index.ts
@@ -17,6 +17,8 @@
  * @packageDocumentation
  */
 
+import {Extension} from '@roots/bud-framework'
+
 import {imagemin} from './imagemin.config'
 import * as BudImagemin from './imagemin.extension'
 
@@ -30,4 +32,31 @@ declare module '@roots/bud-framework' {
   }
 }
 
-export const {name, options, register, boot} = BudImagemin
+/**
+ * Extension name
+ *
+ * @public
+ */
+export const name: Extension.Module['name'] = BudImagemin.name
+
+/**
+ * Extension options
+ *
+ * @public
+ */
+export const options: Extension.Module['options'] =
+  BudImagemin.options
+
+/**
+ * Extension api
+ *
+ * @public
+ */
+export const api: {imagemin: imagemin} = BudImagemin.api
+
+/**
+ * Extension boot
+ *
+ * @public
+ */
+export const boot: Extension.Module['boot'] = BudImagemin.boot

--- a/tests/unit/bud-extensions/controller.test.ts
+++ b/tests/unit/bud-extensions/controller.test.ts
@@ -1,10 +1,11 @@
-import {Bud, factory} from '@roots/bud'
 import {Controller} from '@roots/bud-extensions'
 import {Extension} from '@roots/bud-framework'
 import {WebpackPluginInstance} from 'webpack'
 
-describe.skip('@roots/bud-extensions Controller', function () {
-  let bud: Bud = null
+import {Bud, factory} from '../../util/bud'
+
+describe('@roots/bud-extensions Controller', function () {
+  let bud: Bud
 
   let mockWebpackPlugin: WebpackPluginInstance = {
     apply: jest.fn(),
@@ -17,7 +18,7 @@ describe.skip('@roots/bud-extensions Controller', function () {
     register: jest.fn(() => null),
     boot: jest.fn(() => null),
     api: {
-      foo: jest.fn(function (this: Bud) {
+      foo: jest.fn(async function (this: Bud) {
         return this
       }),
     },
@@ -69,8 +70,9 @@ describe.skip('@roots/bud-extensions Controller', function () {
     expect(controller._module.boot).toHaveBeenCalled()
   })
 
-  it('module options are registered', () => {
-    bud.use(mockModule)
+  it('module options are registered', async () => {
+    await bud.extensions.add(mockModule)
+    await bud.extensions.processQueue()
 
     expect(
       bud.extensions.get('@roots/bud-postcss').options.all(),
@@ -89,5 +91,15 @@ describe.skip('@roots/bud-extensions Controller', function () {
     const controller = new Controller(bud, mockModule)
 
     expect(controller.make()).toBe(mockWebpackPlugin)
+  })
+
+  it('controller.api', async () => {
+    const controller = new Controller(bud, mockModule)
+    await controller.api()
+    // @ts-ignore
+    expect(bud.foo).toBeInstanceOf(Function)
+    // @ts-ignore
+    expect(bud.foo()).toBeInstanceOf(Bud)
+    expect(bud.api.get('foo')()).toBeInstanceOf(Promise)
   })
 })

--- a/tests/unit/bud-imagemin/extension.test.ts
+++ b/tests/unit/bud-imagemin/extension.test.ts
@@ -3,7 +3,8 @@ import * as imagemin from '@roots/bud-imagemin'
 describe('@roots/bud-imagemin', () => {
   it('has expected exports', () => {
     expect(imagemin.name).toBe('@roots/bud-imagemin')
-    expect(imagemin.register).toBeInstanceOf(Function)
+    // @ts-ignore
+    expect(imagemin.api.imagemin).toBeInstanceOf(Function)
     expect(imagemin.boot).toBeInstanceOf(Function)
   })
 })


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

As of 5.0.0 our out-of-the-box functions are added to the `bud.api` container rather than `bud` itself. instead we bind a facade to `bud` for each function -- this is what people call in their config files. When a function is called, like `bud.entry` (any api function), it adds the method name and passed parameters to `bud.api.queue`. later on this queue is iterated over and the actual functions are called.

The advantage is we remove the need to worry about async operations from user configs. `bud.entry` is a great example. the actual `bud.entry` function is async, but the facade we expose is synchronous. everyone wins: we don't block the thread and the user can enjoy the fluent api without worrying about awaiting promises.

Extensions can bind new functions to bud with the `api` callback. these functions were still being bound directly to `bud` even after we had moved all the internal config functions to use facades. it works fine until we started to have extensions which had async functions to register. I had kind of hacked a workaround on the `register` callback for those cases:

```ts
export const register: Extension.Module['register'] = async (
  app: Framework,
) => {
  app.api.set('imagemin', imagemin.bind(app)) // add the fn to the bud.api container
  app.api.bindFacade('imagemin') // bind the bud.api entry to bud (as a facade)
}
```

This change moves that back into the extension controller [`next...api-bind-facade?expand=1`#diff-3749b73842](https://github.com/roots/bud/compare/next...api-bind-facade?expand=1#diff-3749b7384252f4d26786b430755a50b9da5afca74cebf0cee04a8cce0270a794R421-R439)

## Changelog

- binds extension api objects/callbacks to `bud` as `bud.api` facades
- removes code used to handle this from extensions which were handling it themselves
- adds tests for the bud extensions controller