### PR TITLE
improve(server) always treat server/proxy url as node URL

### DIFF
--- a/packages/@roots/bud-api/src/api/methods/proxy/index.ts
+++ b/packages/@roots/bud-api/src/api/methods/proxy/index.ts
@@ -32,7 +32,8 @@ export const proxy: proxy = function (
 
   if (typeof config === 'undefined') {
     ctx.api.log('log', 'enabling proxy')
-    ctx.store.set('server.middleware.proxy', true)
+    ctx.store.set('features.proxy', true)
+    return ctx
   }
 
   if (typeof config === 'boolean') {
@@ -41,11 +42,11 @@ export const proxy: proxy = function (
       config ? 'enabling' : 'disabling',
       'proxy',
     )
-    ctx.store.set('server.middleware.proxy', config)
+    ctx.store.set('features.proxy', config)
     return ctx
   }
 
-  ctx.store.set('server.middleware.proxy', true)
+  ctx.store.set('features.proxy', true)
   ctx.api.log('log', 'enabling proxy')
 
   if (typeof config === 'number') {
@@ -61,7 +62,7 @@ export const proxy: proxy = function (
   }
 
   if (config instanceof URL) {
-    ctx.store.set('server.dev.url', config)
+    ctx.store.set('server.proxy.url', config)
     return ctx
   }
 

--- a/packages/@roots/bud-api/src/api/methods/proxy/index.ts
+++ b/packages/@roots/bud-api/src/api/methods/proxy/index.ts
@@ -66,10 +66,8 @@ export const proxy: proxy = function (
     return ctx
   }
 
-  ctx.store.set('server.proxy', config)
-
-  ctx.api.log('log', {
-    message: 'proxy url set',
+  ctx.api.log('error', {
+    message: 'proxy fallthrough! maybe misconfiguration.',
     suffix: config,
   })
 

--- a/packages/@roots/bud-api/src/api/methods/proxy/index.ts
+++ b/packages/@roots/bud-api/src/api/methods/proxy/index.ts
@@ -1,4 +1,5 @@
 import type {Framework, Server} from '@roots/bud-framework'
+import {URL} from 'url'
 
 export interface proxy {
   (config?: Server.Configuration['proxy']['url']): Framework
@@ -9,14 +10,23 @@ export interface proxy {
 }
 
 export interface proxy {
+  (config?: number): Framework
+}
+
+export interface proxy {
+  (url?: URL): Framework
+}
+
+export interface proxy {
   (config?: Partial<Server.Configuration['proxy']>): Framework
 }
 
 export const proxy: proxy = function (
   config:
-    | Server.Configuration['proxy']['url']
+    | URL
     | Partial<Server.Configuration['proxy']>
-    | boolean,
+    | boolean
+    | number,
 ) {
   const ctx = this as Framework
 
@@ -39,15 +49,19 @@ export const proxy: proxy = function (
   ctx.api.log('log', 'enabling proxy')
 
   if (typeof config === 'number') {
-    ctx.store.set(
-      'server.proxy.url',
-      `http://localhost:${config}`,
-    )
+    const url = ctx.store.get('server.proxy.url')
+    url.port = `${config}`
+    ctx.store.set('server.proxy.url', url)
     return ctx
   }
 
   if (typeof config === 'string') {
-    ctx.store.set('server.proxy.url', config)
+    ctx.store.set('server.proxy.url', new URL(config))
+    return ctx
+  }
+
+  if (config instanceof URL) {
+    ctx.store.set('server.dev.url', config)
     return ctx
   }
 

--- a/packages/@roots/bud-api/src/api/methods/serve/index.ts
+++ b/packages/@roots/bud-api/src/api/methods/serve/index.ts
@@ -1,26 +1,44 @@
 import type {Framework, Server} from '@roots/bud-framework'
+import {URL} from 'url'
 
 export interface serve {
   (port: number): Framework
 }
 
 export interface serve {
-  (url: Server.Configuration['dev']['url']): Framework
+  (url: URL): Framework
+}
+
+export interface serve {
+  (url: string): Framework
 }
 
 export interface serve {
   (config: Partial<Server.Configuration['dev']>): Framework
 }
 
-export const serve: serve = function (config) {
+export const serve: serve = function (
+  config:
+    | URL
+    | string
+    | number
+    | Partial<Server.Configuration['dev']>,
+): Framework {
   const ctx = this as Framework
 
   if (typeof config === 'number') {
-    ctx.store.set('server.dev.url', `http://localhost:${config}`)
+    const url = ctx.store.get('server.dev.url')
+    url.port = `${config}`
+    ctx.store.set('server.dev.url', url)
     return ctx
   }
 
   if (typeof config === 'string') {
+    ctx.store.set('server.dev.url', new URL(config))
+    return ctx
+  }
+
+  if (config instanceof URL) {
     ctx.store.set('server.dev.url', config)
     return ctx
   }

--- a/packages/@roots/bud-dashboard/src/components/dashboard.component.tsx
+++ b/packages/@roots/bud-dashboard/src/components/dashboard.component.tsx
@@ -126,6 +126,7 @@ export const Dashboard = ({
         stats?.errors?.length <= 0 && (
           <Serve
             theme={theme}
+            features={instance.current.store.get('features')}
             server={instance.current.store.get('server')}
           />
         )}

--- a/packages/@roots/bud-dashboard/src/components/serve/serve.component.tsx
+++ b/packages/@roots/bud-dashboard/src/components/serve/serve.component.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import {Url} from './url.component'
 
-export const Serve = ({theme, server}) => {
+export const Serve = ({features, theme, server}) => {
   return (
     <Text>
       <Text color={theme?.colors.text}>
@@ -12,7 +12,7 @@ export const Serve = ({theme, server}) => {
       </Text>
       <Newline />
 
-      {server.middleware.proxy && (
+      {features.proxy && server.proxy.url && (
         <Text color={theme?.colors.text}>
           <Url label="proxy" value={server.proxy.url} />
         </Text>

--- a/packages/@roots/bud-framework/src/Hooks.ts
+++ b/packages/@roots/bud-framework/src/Hooks.ts
@@ -240,6 +240,11 @@ export namespace Hooks {
     ) => Promise<Buffer | string>
     [`proxy.replace`]: Array<[string | RegExp, string]>
     [`proxy.options`]?: ProxyOptions
+    [`server.inject`]?: Array<(app: Framework) => string>
+    [`server.middleware`]?: Record<
+      string,
+      (app: Framework) => Express.Response
+    >
 
     // this is wack
     [key: `extension.${string}`]: any

--- a/packages/@roots/bud-framework/src/Server/Config.ts
+++ b/packages/@roots/bud-framework/src/Server/Config.ts
@@ -1,3 +1,5 @@
+import {URL} from 'url'
+
 /**
  * Server configuration
  *
@@ -10,28 +12,20 @@ export interface Configuration {
    * @public
    */
   middleware: Record<string, boolean>
-  /**
-   * Development server URL
-   *
-   * @public
-   */
-  dev: {
-    url: string
-  }
 
   /**
    * Development server URL
    *
    * @public
    */
-  proxy: {
-    url: string
-    replace: {
-      href: true
-      window: true
-      publicPath: true
-    }
-  }
+  dev: {url: URL}
+
+  /**
+   * Development server URL
+   *
+   * @public
+   */
+  proxy: {url: URL}
 
   /**
    * Files which should reload the browser when changed.

--- a/packages/@roots/bud-framework/src/Server/Interface.ts
+++ b/packages/@roots/bud-framework/src/Server/Interface.ts
@@ -40,22 +40,19 @@ export default interface Interface extends Service {
   middleware: Middleware
 
   /**
+   * Server port
+   */
+  port: string
+
+  /**
    * Watcher instance
    *
    * @public
    */
   watcher: {
-    [key: string]: any
-    close: CallableFunction
-    on: CallableFunction
+    getWatchedFiles(): Promise<Array<string>>
+    watch(): Promise<void>
   }
-
-  /**
-   * Retrieve an array of watched files.
-   *
-   * @public
-   */
-  getWatchedFiles(): Promise<Array<string>>
 
   /**
    * Run the server instance

--- a/packages/@roots/bud-framework/src/Store.ts
+++ b/packages/@roots/bud-framework/src/Store.ts
@@ -202,6 +202,11 @@ export namespace Store {
       manifest?: boolean
 
       /**
+       * Enable or disable proxy
+       */
+      proxy?: boolean
+
+      /**
        * Enable or disable runtime chunk
        *
        * @public

--- a/packages/@roots/bud-framework/src/Store.ts
+++ b/packages/@roots/bud-framework/src/Store.ts
@@ -578,8 +578,5 @@ export namespace Store {
     ['server.browser.log']: Repository['server']['browser']['log']
     ['server.dev.url']: Repository['server']['dev']['url']
     ['server.proxy.url']: Repository['server']['proxy']['url']
-    ['server.proxy.replace.href']: Repository['server']['proxy']['replace']['href']
-    ['server.proxy.replace.window']: Repository['server']['proxy']['replace']['window']
-    ['server.proxy.replace.publicPath']: Repository['server']['proxy']['replace']['publicPath']
   }
 }

--- a/packages/@roots/bud-server/package.json
+++ b/packages/@roots/bud-server/package.json
@@ -77,7 +77,7 @@
     "express": "^4.17.1",
     "http-proxy-middleware": "2.0.1",
     "tslib": "^2.3.1",
-    "webpack-dev-middleware": "5.2.2",
+    "webpack-dev-middleware": "5.3.0",
     "webpack-hot-middleware": "^2.25.1"
   }
 }

--- a/packages/@roots/bud-server/src/client/proxy-click-interceptor.js
+++ b/packages/@roots/bud-server/src/client/proxy-click-interceptor.js
@@ -1,5 +1,6 @@
 /* global __resourceQuery */
 /* eslint-disable no-console, no-extra-semi */
+// @ts-check
 
 ;(async () => {
   const main = async () => {
@@ -21,10 +22,18 @@
       'background: transparent;',
     )
 
-    document.addEventListener('click', e => {
-      const target = e.target.closest('a')
-      if (!target || target.href.includes(origin.dev)) return
-      target.href = target.href.replace(origin.proxy, origin.dev)
+    document.addEventListener('click', event => {
+      event.preventDefault()
+
+      if (!(event.target instanceof HTMLAnchorElement)) return
+
+      const el = event.target.closest('a')
+      const href = el?.getAttribute('href')
+      if (!href || href.includes(origin.dev)) return
+
+      Object.assign(el, {
+        href: href.replace(origin.proxy, origin.dev),
+      })
     })
   }
 

--- a/packages/@roots/bud-server/src/client/proxy-click-interceptor.js
+++ b/packages/@roots/bud-server/src/client/proxy-click-interceptor.js
@@ -5,8 +5,7 @@
 ;(async () => {
   const main = async () => {
     const {headers} = await fetch(window.location.origin, {
-      method: 'HEAD',
-      mode: 'cors',
+      method: 'GET',
     })
 
     const origin = {
@@ -16,15 +15,13 @@
 
     if (!origin.proxy || !origin.dev) return
 
-    console.log(
-      `%c[bud]%c intercepting anchor links`,
+    console.info(
+      `%c bud %c intercepting anchor links`,
       'background: #525ddc; color: #ffffff;',
       'background: transparent;',
     )
 
     document.addEventListener('click', event => {
-      event.preventDefault()
-
       if (!(event.target instanceof HTMLAnchorElement)) return
 
       const el = event.target.closest('a')

--- a/packages/@roots/bud-server/src/middleware/dev/index.ts
+++ b/packages/@roots/bud-server/src/middleware/dev/index.ts
@@ -1,3 +1,8 @@
+import {
+  IncomingMessage,
+  ServerResponse,
+} from 'webpack-dev-middleware'
+
 import {WebpackDevMiddleware} from './dev.dependencies'
 import type {Framework} from './dev.interface'
 
@@ -21,7 +26,10 @@ export default function dev(app: Framework) {
  */
 const makeOptions = (
   app: Framework,
-): WebpackDevMiddleware.Options => ({
+): WebpackDevMiddleware.Options<
+  IncomingMessage,
+  ServerResponse
+> => ({
   writeToDisk: true,
   publicPath: app.hooks.filter('build.output.publicPath'),
   stats: false,

--- a/packages/@roots/bud-server/src/middleware/proxy/proxy.middleware.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/proxy.middleware.ts
@@ -12,6 +12,8 @@ import {URL} from './url'
  * @public
  */
 export const middleware = (app: Framework) => {
+  if (app.store.is('features.proxy', false)) return
+
   const url = new URL(() => app)
   const interceptor = new ResponseInterceptorFactory(
     () => app,

--- a/packages/@roots/bud-server/src/middleware/proxy/proxy.middleware.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/proxy.middleware.ts
@@ -15,6 +15,7 @@ export const middleware = (app: Framework) => {
   if (app.store.is('features.proxy', false)) return
 
   const url = new URL(() => app)
+
   const interceptor = new ResponseInterceptorFactory(
     () => app,
     url,

--- a/packages/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -68,18 +68,14 @@ export class ResponseInterceptorFactory {
       if (!body) return buffer
 
       /**
-       * Process replacements
+       * Process replacements and return body
        */
-      body = this.replacements?.reduce(
-        (html: string, [from, to]) => html.replaceAll(from, to),
-        body,
-      )
-
-      /**
-       * Send string body back to http-proxy-middleware
-       * it will be converted to Buffer on our behalf
-       */
-      return body
+      return this.app.hooks
+        .filter('proxy.replace', () => [this.replaceAssetPath()])
+        ?.reduce(
+          (html, [from, to]) => html.replaceAll(from, to),
+          body,
+        )
     } catch (err) {
       this.app.error(err)
       return buffer
@@ -100,17 +96,6 @@ export class ResponseInterceptorFactory {
         () => this._interceptor,
       ),
     )
-  }
-
-  /**
-   * Replacements to make on the response body
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  public get replacements() {
-    const replacements = [this.replaceAssetPath()]
-    return this.app.hooks.filter('proxy.replace', replacements)
   }
 
   /**

--- a/packages/@roots/bud-server/src/middleware/proxy/url.ts
+++ b/packages/@roots/bud-server/src/middleware/proxy/url.ts
@@ -31,7 +31,7 @@ export class URL {
    * @public
    */
   public get dev(): nodeUrl {
-    return new nodeUrl(this.config.dev.url)
+    return this.config.dev.url
   }
 
   /**
@@ -40,7 +40,7 @@ export class URL {
    * @public
    */
   public get proxy(): nodeUrl {
-    return new nodeUrl(this.config.proxy.url)
+    return this.config.proxy.url
   }
 
   /**
@@ -59,6 +59,7 @@ export class URL {
     const publicPath = this.app.hooks.filter(
       'build.output.publicPath',
     )
+
     return publicPath !== 'auto' ? publicPath : '/'
   }
 

--- a/packages/@roots/bud-server/src/server/index.ts
+++ b/packages/@roots/bud-server/src/server/index.ts
@@ -1,12 +1,11 @@
 import * as Framework from '@roots/bud-framework'
 import Express from 'express'
-import {URL} from 'url'
 
 import * as middleware from '../middleware'
 import __BudRouter from '../router/__bud'
 import {inject} from '../util/inject'
-import {bind, chokidar, globby} from './server.dependencies'
-import type {Watcher} from './server.interface'
+import {bind} from './server.dependencies'
+import {Watcher} from './server.watcher'
 
 /**
  * Server service class
@@ -45,7 +44,7 @@ export class Server
    *
    * @public
    */
-  public middleware: Framework.Server.Middleware = {}
+  public middleware: Framework.Server.Middleware
 
   /**
    * Watcher instance
@@ -55,63 +54,39 @@ export class Server
   public watcher: Watcher
 
   /**
-   * Service register callback
+   * Port
    *
-   * @internal
+   * @public
    */
-  public async bootstrap(): Promise<void> {
+  public get port(): string {
+    const url = this.app.store.get('server.dev.url')
+    if (!url.port || url.port == '') {
+      return url.protocol == 'https' ? '443' : '80'
+    }
+
+    return url.port
+  }
+
+  /**
+   * Service boot callback
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public async boot(): Promise<void> {
     this.application = Express()
-  }
 
-  /**
-   * {@inheritDoc @roots/bud-framework#Server.Interface.getWatchedFilesArray}
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  @bind
-  public async getWatchedFiles(): Promise<Array<string>> {
-    const [files, options] =
-      this.app.store.getValues('server.watch')
+    this.app.hooks.on('server.inject', () => [
+      instance =>
+        `@roots/bud-server/client/index.js?name=${instance.name}&path=/__bud/hmr`,
+      () =>
+        `@roots/bud-server/client/proxy-click-interceptor.js`,
+    ])
 
-    if (!files?.length) return []
-
-    const globResults = await globby(
-      files.map((file: string) =>
-        this.app.path('project', file),
-      ),
-      options,
-    )
-
-    return globResults as unknown as Array<string>
-  }
-
-  /**
-   * Process middlewares
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  @bind
-  public processMiddlewares() {
-    this.middleware = Object.entries(middleware)
-      .filter(([k, v]) => {
-        if (this.app.store.is(`server.middleware.${k}`, true)) {
-          this.log('log', `middleware ${k} is enabled.`)
-          return true
-        }
-
-        return false
-      })
-      .reduce((acc, [key, generate]) => {
-        const middleware = generate(this.app)
-
-        this.log(`info`, `configured middleware: ${key}`)
-
-        this.application.use(middleware)
-
-        return {...acc, [key]: middleware}
-      }, {})
+    this.app.hooks.on('server.middleware', () => {
+      return middleware
+    })
   }
 
   /**
@@ -122,18 +97,87 @@ export class Server
    */
   @bind
   public async run(): Promise<this> {
+    /**
+     * Instantiate watcher
+     */
+    this.watcher = new Watcher(this.app)
+
+    /**
+     * Filter server before
+     */
     await this.app.hooks.filterAsync<'event.server.before'>(
       'event.server.before',
       this.app,
     )
 
+    /**
+     * Prep and run compilation
+     */
+    await this.compile()
+
+    /**
+     * Apply middleware
+     */
+    Object.entries(
+      this.app.hooks.filter('server.middleware'),
+    ).map(([key, factory]) => {
+      this.log(`info`, `using middleware: ${key}`)
+      this.application.use(factory(this.app))
+    })
+
+    /**
+     * 404 middleware
+     */
+    this.application.use(
+      (
+        _req: Express.Request,
+        res: Express.Response,
+        _next: Express.NextFunction,
+      ) => {
+        res.status(404).send("Sorry can't find that!")
+      },
+    )
+
+    /**
+     * Listen
+     */
+    this.instance = this.application.listen(
+      this.port,
+      async (error: string) => {
+        this.log('info', `started server on %s`, this.port)
+        if (error) this.log('error', error)
+
+        this.app.hooks.filter('event.server.listen')
+      },
+    )
+
+    /**
+     * If watching and a file it is watching
+     * is touched, reload the window.
+     */
+    this.instance.on('change', path => {
+      this.middleware?.hot?.publish({
+        action: 'reload',
+        message: `Detected file change: ${path}. Reloading window.`,
+      })
+    })
+
+    await this.app.hooks.filterAsync<'event.server.after'>(
+      'event.server.after',
+      this.app,
+    )
+
+    return this
+  }
+
+  @bind
+  public async compile() {
     await Promise.all(
       [this.app, ...this.app.children.getValues()].map(
         async (instance: Framework.Framework) => {
           await inject(
             instance,
-            (instance: Framework.Framework) =>
-              `@roots/bud-server/client/index.js?name=${instance.name}&path=/__bud/hmr`,
+            this.app.hooks.filter('server.inject'),
           )
         },
       ),
@@ -147,67 +191,10 @@ export class Server
     })
 
     await this.app.compiler.compile()
-    this.processMiddlewares()
-
-    this.application.use((req, res, next) => {
-      res.status(404).send("Sorry can't find that!")
-    })
-
-    /**
-     * Listen
-     */
-    const url = new URL(this.app.store.get('server.dev.url'))
-    this.log('info', `starting server on %s`, url.port)
-
-    this.instance = this.application.listen(
-      url.port,
-      async (error: string) => {
-        if (error) this.log('error', error)
-
-        this.app.hooks.filter('event.server.listen')
-
-        this.log(
-          'success',
-          'listening on %s',
-          JSON.stringify(this.instance.address()),
-        )
-      },
-    )
-
-    /**
-     * Initialize Watcher
-     */
-    const watchFiles = await this.getWatchedFiles()
-
-    if (watchFiles.length) {
-      watchFiles.forEach(file => {
-        this.log('log', `watching`, file, `for changes`)
-      })
-      this.watcher = chokidar.watch(watchFiles)
-    }
-
-    /**
-     * If watching and a file it is watching
-     * is touched, reload the window.
-     */
-    this.watcher?.on &&
-      this.watcher.on('change', path => {
-        this.middleware?.hot?.publish({
-          action: 'reload',
-          message: `Detected file change: ${path}. Reloading window.`,
-        })
-      })
-
-    await this.app.hooks.filterAsync<'event.server.after'>(
-      'event.server.after',
-      this.app,
-    )
-
-    return this
   }
 
   /**
-   * {@inheritDoc @roots/bud-framework#Server.Interface.inject}
+   * App close handler
    *
    * @public
    * @decorator `@bind`

--- a/packages/@roots/bud-server/src/server/index.ts
+++ b/packages/@roots/bud-server/src/server/index.ts
@@ -155,7 +155,7 @@ export class Server
      * If watching and a file it is watching
      * is touched, reload the window.
      */
-    this.instance.on('change', path => {
+    this.watcher.instance.on('change', path => {
       this.middleware?.hot?.publish({
         action: 'reload',
         message: `Detected file change: ${path}. Reloading window.`,

--- a/packages/@roots/bud-server/src/server/server.watcher.ts
+++ b/packages/@roots/bud-server/src/server/server.watcher.ts
@@ -1,0 +1,65 @@
+import {Framework} from '@roots/bud-framework'
+import chokidar, {FSWatcher} from 'chokidar'
+import globby from 'globby'
+import {bind} from 'helpful-decorators'
+
+export class Watcher {
+  /**
+   * Watcher instance
+   *
+   * @public
+   */
+  public instance: FSWatcher
+
+  /**
+   * Get watched files
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public async getWatchedFiles(): Promise<Array<string>> {
+    const [files, options] =
+      this.app.store.getValues('server.watch')
+
+    if (!files?.length) return []
+
+    const globResults = await globby(
+      files.map((file: string) =>
+        this.app.path('project', file),
+      ),
+      options,
+    )
+
+    return globResults.map(entry =>
+      typeof entry === 'object' ? entry.path : entry,
+    )
+  }
+
+  /**
+   * Class constructor
+   *
+   * @param app - Application instance
+   */
+  public constructor(public app: Framework) {}
+
+  /**
+   * Initialize watch files
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public async watch() {
+    const watchFiles = await this.getWatchedFiles()
+
+    if (watchFiles.length) {
+      this.instance = chokidar.watch(
+        watchFiles.map(entry => {
+          this.app.log('log', `watching`, entry, `for changes`)
+          return entry
+        }),
+      )
+    }
+  }
+}

--- a/packages/@roots/bud-server/src/util/inject.ts
+++ b/packages/@roots/bud-server/src/util/inject.ts
@@ -3,7 +3,7 @@ import {Framework} from '@roots/bud-framework'
 export interface inject {
   (
     app: Framework,
-    injection: (app: Framework) => string,
+    injection: Array<(app: Framework) => string>,
   ): Promise<void>
 }
 
@@ -23,7 +23,7 @@ export const inject: inject = async (
       (entrypoints, [name, entry]) => {
         entry.import = [
           ...new Set([
-            injection(instance),
+            ...injection.map(inject => inject(instance)),
             ...(entry.import ?? []),
           ]),
         ]

--- a/packages/@roots/bud/src/seed.ts
+++ b/packages/@roots/bud/src/seed.ts
@@ -1,5 +1,6 @@
 import type {Store} from '@roots/bud-framework'
 import {cpus} from 'os'
+import {URL} from 'url'
 
 /**
  * Bud configuration defaults
@@ -295,16 +296,11 @@ export const seed: Partial<Store.Repository> = {
     },
 
     dev: {
-      url: 'http://localhost:3000',
+      url: new URL('http://localhost:3000'),
     },
 
     proxy: {
-      url: 'http://localhost',
-      replace: {
-        href: true,
-        window: true,
-        publicPath: true,
-      },
+      url: new URL('http://localhost'),
     },
   },
 

--- a/packages/@roots/bud/src/seed.ts
+++ b/packages/@roots/bud/src/seed.ts
@@ -99,6 +99,13 @@ export const seed: Partial<Store.Repository> = {
     manifest: true,
 
     /**
+     * Proxy enabled
+     *
+     * @public
+     */
+    proxy: false,
+
+    /**
      * @public
      */
     runtimeChunk: false,

--- a/tests/unit/bud-api/repository/server.test.ts
+++ b/tests/unit/bud-api/repository/server.test.ts
@@ -23,7 +23,7 @@ describe('bud.serve', function () {
     await bud.api.processQueue()
 
     expect(bud.store.get('server.dev.url')).toEqual(
-      'http://example.com',
+      new URL('http://example.com'),
     )
   })
 })

--- a/tests/unit/bud-server/__snapshots__/service.test.ts.snap
+++ b/tests/unit/bud-server/__snapshots__/service.test.ts.snap
@@ -8,7 +8,25 @@ Object {
     "overlay": true,
   },
   "dev": Object {
-    "url": "http://localhost:3000",
+    "url": Object {
+      Symbol(context): URLContext {
+        "flags": 400,
+        "fragment": null,
+        "host": "localhost",
+        "password": "",
+        "path": Array [
+          "",
+        ],
+        "port": 3000,
+        "query": null,
+        "scheme": "http:",
+        "username": "",
+      },
+      Symbol(query): URLSearchParams {
+        Symbol(query): Array [],
+        Symbol(context): "http://localhost:3000/",
+      },
+    },
   },
   "middleware": Object {
     "dev": true,
@@ -16,12 +34,25 @@ Object {
     "proxy": false,
   },
   "proxy": Object {
-    "replace": Object {
-      "href": true,
-      "publicPath": true,
-      "window": true,
+    "url": Object {
+      Symbol(context): URLContext {
+        "flags": 400,
+        "fragment": null,
+        "host": "localhost",
+        "password": "",
+        "path": Array [
+          "",
+        ],
+        "port": null,
+        "query": null,
+        "scheme": "http:",
+        "username": "",
+      },
+      Symbol(query): URLSearchParams {
+        Symbol(query): Array [],
+        Symbol(context): "http://localhost/",
+      },
     },
-    "url": "http://localhost",
   },
   "watch": Object {
     "files": Array [],

--- a/tests/unit/bud-server/service.test.ts
+++ b/tests/unit/bud-server/service.test.ts
@@ -29,15 +29,10 @@ describe('@roots/bud-server', function () {
       },
 
       dev: {
-        url: 'http://localhost:3000',
+        url: new URL('http://localhost:3000/'),
       },
       proxy: {
-        url: 'http://localhost',
-        replace: {
-          href: true,
-          window: true,
-          publicPath: true,
-        },
+        url: new URL('http://localhost/'),
       },
 
       watch: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3741,7 +3741,7 @@ __metadata:
     http-proxy-middleware: 2.0.1
     tslib: ^2.3.1
     webpack: 5.65.0
-    webpack-dev-middleware: 5.2.2
+    webpack-dev-middleware: 5.3.0
     webpack-hot-middleware: ^2.25.1
   languageName: unknown
   linkType: soft
@@ -24329,9 +24329,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-middleware@npm:5.2.2, webpack-dev-middleware@npm:^5.2.1":
-  version: 5.2.2
-  resolution: "webpack-dev-middleware@npm:5.2.2"
+"webpack-dev-middleware@npm:5.3.0, webpack-dev-middleware@npm:^5.2.1":
+  version: 5.3.0
+  resolution: "webpack-dev-middleware@npm:5.3.0"
   dependencies:
     colorette: ^2.0.10
     memfs: ^3.2.2
@@ -24340,7 +24340,7 @@ __metadata:
     schema-utils: ^4.0.0
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
-  checksum: 8dfcb1244ba564e525f9d6644174a558cebd4857317bbdbcd394848641f7f0c0aeb0e7b2803dd56286b4820a7f66d27b8e58e8f1dec5515417ffa40da1f6197d
+  checksum: 01f9e11583bb682cd5ab5a1b9d6dc99545f777513c4c15aa67d10f5d057fc3d0c6f9365e02c07792d3c9b17bd47a16c8185e66eb66e9de74d8ccf561e75085e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Type of change

- MINOR: feature

## Dependencies added

- none

## Details

- safer client anchor link interceptor
- safer watch files glob
- dev client scripts (`hmr` and `proxy-click-interceptor`) are filterable with `server.inject` hook
- `proxy-click-interceptor.js` added to `dev` by default but filterable as mentioned above
- dev middleware (`hot`, `proxy` and `dev`) are filterable with `server.middleware` hook
- watch files concerns broken into separate class
- `dev` and `proxy` urls are always treated as node URLs
- `bud.serve` accepts a `string`, `URL` or `number` and always sets a `URL`
- `bud.proxy` accepts a `string`, `URL` or `number` and always sets a `URL`
- fixes dev middleware typings; bumps `webpack-dev-middleware`. see #851

## Notes

Add a middleware with a factory which receives `Bud` and returns an `Express.Response`:

```ts
bud.hooks.on('server.middleware', middleware => ({
  ...middleware,
  'my-middleware': (bud) => (req, res, next) => {},
})
```

Add a client script:

```ts
bud.hooks.on('server.inject', injections => [
   ...injections,
   require.resolve('scripts/my-dev-only-client-script.js'),
])
```

Set a `dev` url with a port:

```ts
bud.serve(3000)
```

Set a `dev` url with a string:

```ts
bud.serve('dev.example.com')
```

Set a `dev` url with a URL:

```ts
bud.serve(new URL('http://dev.example.com:3000'))
```

Same goes for `bud.proxy`