### PR TITLE
fix(api) bud.assets: do not emit to assets dir

### DIFF
--- a/packages/@roots/bud-api/src/api/methods/assets/assets.method.ts
+++ b/packages/@roots/bud-api/src/api/methods/assets/assets.method.ts
@@ -14,8 +14,8 @@ export const assets: method = async function assets(
 
     const fileName =
       this.store.is('features.hash', true) && this.isProduction
-        ? `assets/${dirName}/${this.store.get('hashFormat')}`
-        : `assets/${dirName}/${this.store.get('fileFormat')}`
+        ? `${dirName}/${this.store.get('hashFormat')}`
+        : `${dirName}/${this.store.get('fileFormat')}`
 
     this.extensions
       .get('copy-webpack-plugin')


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

- bud.assets would emit to `[dist]/assets/[path]`. now it emits to `[dist]/[path]`. 
- this prevents duplicated items when copying files that are also used in compilation
