### PR TITLE
improve(sage) push most deps onto roots/sage

### DIFF
--- a/examples/sage/package.json
+++ b/examples/sage/package.json
@@ -12,6 +12,10 @@
   },
   "devDependencies": {
     "@roots/bud": "workspace:*",
+    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint",
+    "@roots/bud-prettier": "workspace:packages/@roots/bud-prettier",
+    "@roots/bud-stylelint": "workspace:packages/@roots/bud-stylelint",
+    "@roots/bud-tailwindcss": "workspace:packages/@roots/bud-tailwindcss",
     "@roots/sage": "workspace:*",
     "@wordpress/browserslist-config": "4.1.0",
     "eslint": "8.6.0",

--- a/packages/@roots/sage/package.json
+++ b/packages/@roots/sage/package.json
@@ -65,11 +65,7 @@
   "bud": {
     "type": "extension",
     "peers": [
-      "@roots/bud-preset-wordpress",
-      "@roots/bud-eslint",
-      "@roots/bud-prettier",
-      "@roots/bud-stylelint",
-      "@roots/bud-tailwindcss"
+      "@roots/bud-preset-wordpress"
     ]
   },
   "devDependencies": {
@@ -79,12 +75,8 @@
     "webpack": "5.65.0"
   },
   "dependencies": {
-    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint",
     "@roots/bud-preset-wordpress": "workspace:packages/@roots/bud-preset-wordpress",
-    "@roots/bud-prettier": "workspace:packages/@roots/bud-prettier",
-    "@roots/bud-stylelint": "workspace:packages/@roots/bud-stylelint",
     "@roots/bud-support": "workspace:packages/@roots/bud-support",
-    "@roots/bud-tailwindcss": "workspace:packages/@roots/bud-tailwindcss",
     "helpful-decorators": "^2.1.0",
     "tslib": "^2.3.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4058,13 +4058,9 @@ __metadata:
   resolution: "@roots/sage@workspace:packages/@roots/sage"
   dependencies:
     "@roots/bud-api": "workspace:packages/@roots/bud-api"
-    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint"
     "@roots/bud-framework": "workspace:packages/@roots/bud-framework"
     "@roots/bud-preset-wordpress": "workspace:packages/@roots/bud-preset-wordpress"
-    "@roots/bud-prettier": "workspace:packages/@roots/bud-prettier"
-    "@roots/bud-stylelint": "workspace:packages/@roots/bud-stylelint"
     "@roots/bud-support": "workspace:packages/@roots/bud-support"
-    "@roots/bud-tailwindcss": "workspace:packages/@roots/bud-tailwindcss"
     "@types/node": 16.11.18
     helpful-decorators: ^2.1.0
     tslib: ^2.3.1
@@ -11429,6 +11425,10 @@ __metadata:
   resolution: "example-sage@workspace:examples/sage"
   dependencies:
     "@roots/bud": "workspace:*"
+    "@roots/bud-eslint": "workspace:packages/@roots/bud-eslint"
+    "@roots/bud-prettier": "workspace:packages/@roots/bud-prettier"
+    "@roots/bud-stylelint": "workspace:packages/@roots/bud-stylelint"
+    "@roots/bud-tailwindcss": "workspace:packages/@roots/bud-tailwindcss"
     "@roots/sage": "workspace:*"
     "@wordpress/browserslist-config": 4.1.0
     eslint: 8.6.0


### PR DESCRIPTION
## Type of change

- MINOR: feature

## Dependencies removed from @roots/sage

- @roots/bud-prettier
- @roots/bud-stylelint
- @roots/bud-eslint
- @roots/bud-tailwindcss

## Details

This gives sage users more control over the stack they want to use. 
