### PR TITLE
fix(server) fix sourcemap warning

### DIFF
--- a/packages/@roots/bud-server/tsconfig.json
+++ b/packages/@roots/bud-server/tsconfig.json
@@ -5,7 +5,8 @@
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib/cjs",
-    "declarationDir": "./types"
+    "declarationDir": "./types",
+    "sourceMap": false
   },
   "include": ["src"],
   "references": [


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

- bud client scripts no longer accompanied by sourcemap
- we're not using webpack to generate the sourcemap (they come from tsc)
- fixes the warning emitted by chrome devtools
