### PR TITLE
fix(server) https protocol check always returns false

### DIFF
--- a/packages/@roots/bud-server/src/server/index.ts
+++ b/packages/@roots/bud-server/src/server/index.ts
@@ -61,7 +61,7 @@ export class Server
   public get port(): string {
     const url = this.app.store.get('server.dev.url')
     if (!url.port || url.port == '') {
-      return url.protocol == 'https' ? '443' : '80'
+      return url.protocol == 'https:' ? '443' : '80'
     }
 
     return url.port


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

The way it was the protocol check would always returns `false`. Node URL's protocol includes the trailing `:`, but this check was against `https` (without the `:`).
