### PR TITLE
fix(sage) remove unnecessary URL wrap in hmr.json

### DIFF
--- a/packages/@roots/sage/src/hooks/event.compiler.done.ts
+++ b/packages/@roots/sage/src/hooks/event.compiler.done.ts
@@ -1,21 +1,17 @@
 import {Framework} from '@roots/bud-framework'
 import {fs} from '@roots/bud-support'
 import {ensureDir} from 'fs-extra'
-import {URL, urlToHttpOptions} from 'url'
+import {urlToHttpOptions} from 'url'
 import {Stats} from 'webpack'
 
 const {writeJson} = fs
 
 export default (app: Framework) => async (stats: Stats) => {
   const contents = {
-    dev: urlToHttpOptions(
-      new URL(app.store.get('server.dev.url')),
-    ),
-    proxy: app.store.is('server.middleware.proxy', true)
-      ? urlToHttpOptions(
-          new URL(app.store.get('server.proxy.url')),
-        )
-      : false,
+    dev: urlToHttpOptions(app.store.get('server.dev.url')),
+    proxy:
+      urlToHttpOptions(app.store.get('server.proxy.url')) ??
+      false,
     publicPath: app.hooks.filter('build.output.publicPath'),
   }
 


### PR DESCRIPTION
## Type of change

- PATCH: bugfix

## Dependencies added

- none

## Details

Now that the `Store.Repository['server']['dev']['url']` and `Store.Repository['server']['proxy']['url']` are stored as a URL object we don't need to instantiate them as a `URL` when generating `hmr.json`. 
