### PR TITLE
fix(sage) various fixes

### DIFF
--- a/sources/@roots/bud-build/src/Build/rules.ts
+++ b/sources/@roots/bud-build/src/Build/rules.ts
@@ -123,7 +123,6 @@ export const font = (app: Framework) =>
           ? `fonts/${app.store.get('hashFormat')}[ext]`
           : `fonts/${app.store.get('fileFormat')}[ext]`,
     }))
-    .setParser({dataUrlCondition: {maxSize: 50000}})
 
 /**
  * Returns {@link Rule} for `.jsonc` handling

--- a/sources/@roots/bud-postcss/src/postcss.extension.ts
+++ b/sources/@roots/bud-postcss/src/postcss.extension.ts
@@ -36,10 +36,10 @@ export const BudPostCssExtension: Extension.Module = {
       options: ({postcss}) => {
         return {
           postcssOptions: {
-            ...(app.hooks.filter(
+            ...app.hooks.filter(
               'extension.@roots/bud-postcss.options',
-              {},
-            ) ?? {}),
+              () => ({}),
+            ),
             plugins: [...(postcss.getValues() ?? [])],
           },
           sourceMap: true,

--- a/sources/@roots/bud-sass/src/sass.postcss.ts
+++ b/sources/@roots/bud-sass/src/sass.postcss.ts
@@ -7,9 +7,9 @@ import type {Signale} from '@roots/bud-support'
  * @internal
  */
 export function configure(app: Framework): void {
-  app.extensions
-    .get('@roots/bud-postcss')
-    .setOption('syntax', 'postcss-scss')
+  app.hooks.on('extension.@roots/bud-postcss.options', options => ({
+    syntax: 'postcss-scss',
+  }))
 }
 
 /**

--- a/sources/@roots/sage/src/hooks/event.app.close.ts
+++ b/sources/@roots/sage/src/hooks/event.app.close.ts
@@ -1,7 +1,7 @@
+import {Bud} from '@roots/bud'
 import {pathExistsSync, removeSync} from 'fs-extra'
 
-export default app => () => {
-  const path = app.path('dist', 'hmr.json')
-
+export default function (this: Bud) {
+  const path = this.path('dist', 'hmr.json')
   pathExistsSync(path) && removeSync(path)
 }

--- a/sources/@roots/sage/src/hooks/event.build.make.before.dev.ts
+++ b/sources/@roots/sage/src/hooks/event.build.make.before.dev.ts
@@ -8,15 +8,14 @@ import {Bud} from '@roots/bud'
  *
  * @public
  */
-export async function eventBuildMakeBeforeDevelopment(app: Bud) {
-  app.extensions
-    .get('@roots/bud-entrypoints')
-    .setOption(
-      'publicPath',
-      `${app.store.get('server.dev.url')}${app.hooks.filter(
-        'build.output.publicPath',
-      )}`,
-    )
+export async function eventBuildMakeBeforeDevelopment(this: Bud) {
+  const devUrl = `${
+    this.store.get('server.dev.url').origin
+  }${this.hooks.filter('build.output.publicPath')}`
 
-  return app
+  this.extensions
+    .get('@roots/bud-entrypoints')
+    .setOption('publicPath', devUrl)
+
+  return this
 }

--- a/sources/@roots/sage/src/hooks/event.build.make.before.production.ts
+++ b/sources/@roots/sage/src/hooks/event.build.make.before.production.ts
@@ -1,15 +1,12 @@
-import {Bud} from '@roots/bud'
-
 /**
  * event.build.make.before hook handler
  *
  * @remarks
- * ran in development mode
+ * ran in production mode
  *
  * @public
  */
-export async function eventBuildMakeBeforeProduction(app: Bud) {
-  app.extensions.get('@roots/bud-entrypoints').setOption('publicPath', '')
-
-  return app
+export async function eventBuildMakeBeforeProduction() {
+  this.hooks.on('build.output.publicPath', () => '')
+  return this
 }

--- a/sources/@roots/sage/src/sage.preset.ts
+++ b/sources/@roots/sage/src/sage.preset.ts
@@ -12,16 +12,18 @@ import eventCompilerDone from './hooks/event.compiler.done'
 const inDevelopment = (app: Framework) => {
   app.devtool()
 
-  app.hooks
-    /** Use full URL for development */
-    .async('event.build.make.before', eventBuildMakeBeforeDevelopment)
+  app.hooks /** Use full URL for development */
+    .async(
+      'event.build.make.before',
+      eventBuildMakeBeforeDevelopment.bind(app),
+    )
     /** Write hmr.json after compilation */
     .hooks.async<'event.compiler.done'>(
       'event.compiler.done',
       eventCompilerDone(app),
     )
     /** rm hmr.json when app is closed */
-    .hooks.on('event.app.close', eventAppClose(app))
+    .hooks.on('event.app.close', eventAppClose.bind(app))
 }
 
 /**
@@ -34,7 +36,7 @@ const inProduction = (app: Framework) => {
 
   app.hooks.async(
     'event.build.make.before',
-    eventBuildMakeBeforeProduction,
+    eventBuildMakeBeforeProduction.bind(app),
   )
 }
 

--- a/tests/unit/bud-build/__snapshots__/config.test.ts.snap
+++ b/tests/unit/bud-build/__snapshots__/config.test.ts.snap
@@ -77,11 +77,6 @@ Object {
     "filename": "fonts/[name][ext]",
   },
   "include": StringContaining "src",
-  "parser": Object {
-    "dataUrlCondition": Object {
-      "maxSize": 50000,
-    },
-  },
   "test": /\\\\\\.\\(ttf\\|otf\\|eot\\|woff2\\?\\|ico\\)\\$/,
   "type": "asset",
 }

--- a/tests/unit/bud-build/config.test.ts
+++ b/tests/unit/bud-build/config.test.ts
@@ -14,12 +14,8 @@ describe('bud.build.config', function () {
   })
 
   it(`doesn't include deprecated properties`, () => {
-    expect(bud.build.config.hasOwnProperty('devServer')).toBe(
-      false,
-    )
-    expect(bud.build.config.hasOwnProperty('unsafeCache')).toBe(
-      false,
-    )
+    expect(bud.build.config.hasOwnProperty('devServer')).toBe(false)
+    expect(bud.build.config.hasOwnProperty('unsafeCache')).toBe(false)
   })
 
   it('has expected bail default', () => {
@@ -73,15 +69,13 @@ describe('bud.build.config', function () {
   })
 
   it('has expected optimization.emitOnErrors default', () => {
-    expect(
-      (bud.build.config.optimization as any).emitOnErrors,
-    ).toEqual(false)
+    expect((bud.build.config.optimization as any).emitOnErrors).toEqual(
+      false,
+    )
   })
 
   it('has expected optimization.runtimeChunk default', () => {
-    expect(bud.build.config.optimization.runtimeChunk).toEqual(
-      false,
-    )
+    expect(bud.build.config.optimization.runtimeChunk).toEqual(false)
   })
 
   it('has expected profile default', () => {
@@ -167,18 +161,14 @@ describe('bud.build.config', function () {
           ),
         },
         {
-          loader: expect.stringContaining(
-            'css-loader/dist/cjs.js',
-          ),
+          loader: expect.stringContaining('css-loader/dist/cjs.js'),
           options: {
             importLoaders: 1,
             sourceMap: false,
           },
         },
         {
-          loader: expect.stringContaining(
-            'postcss-loader/dist/cjs.js',
-          ),
+          loader: expect.stringContaining('postcss-loader/dist/cjs.js'),
           options: {
             postcssOptions: expect.any(Object),
           },
@@ -200,9 +190,7 @@ describe('bud.build.config', function () {
           ),
         },
         {
-          loader: expect.stringContaining(
-            'css-loader/dist/cjs.js',
-          ),
+          loader: expect.stringContaining('css-loader/dist/cjs.js'),
           options: {
             importLoaders: 1,
             modules: true,
@@ -257,11 +245,6 @@ describe('bud.build.config', function () {
       type: 'asset',
       include: expect.stringContaining('src'),
       generator: {filename: 'fonts/[name][ext]'},
-      parser: {
-        dataUrlCondition: {
-          maxSize: 50000,
-        },
-      },
     })
   })
 
@@ -295,9 +278,7 @@ describe('bud.build.config', function () {
       include: expect.stringContaining('src'),
       use: [
         {
-          loader: expect.stringContaining(
-            'html-loader/dist/cjs.js',
-          ),
+          loader: expect.stringContaining('html-loader/dist/cjs.js'),
         },
       ],
     })
@@ -305,8 +286,7 @@ describe('bud.build.config', function () {
 
   it('has expected default csv rule', () => {
     expect(
-      (bud.build.config.module.rules[1] as RuleSetRule)
-        .oneOf[10],
+      (bud.build.config.module.rules[1] as RuleSetRule).oneOf[10],
     ).toMatchSnapshot({
       test: /\.(csv|tsv)$/,
       include: expect.stringContaining('src'),
@@ -320,16 +300,13 @@ describe('bud.build.config', function () {
 
   it('has expected default xml rule', () => {
     expect(
-      (bud.build.config.module.rules[1] as RuleSetRule)
-        .oneOf[11],
+      (bud.build.config.module.rules[1] as RuleSetRule).oneOf[11],
     ).toMatchSnapshot({
       test: /\.xml$/,
       include: expect.stringContaining('src'),
       use: [
         {
-          loader: expect.stringContaining(
-            '/xml-loader/index.js',
-          ),
+          loader: expect.stringContaining('/xml-loader/index.js'),
         },
       ],
     })
@@ -337,8 +314,7 @@ describe('bud.build.config', function () {
 
   it('has expected default toml rule', () => {
     expect(
-      (bud.build.config.module.rules[1] as RuleSetRule)
-        .oneOf[12],
+      (bud.build.config.module.rules[1] as RuleSetRule).oneOf[12],
     ).toMatchSnapshot({
       include: expect.stringContaining('src'),
       parser: {


### PR DESCRIPTION
## Overview

Please merge this before releasing anything. I'm out until tomorrow.

Having the proxy package publishing is a huge boon for me feeling confident about things working outside the repo. Thanks for everybody's patience while I pulled https://github.com/roots/bud/issues/948 together. These changes are tested in sage 10 (dev and production). 

I also tested with @roots/bud-sass added into the mix and all seems well. webpack aliases don't seem to work in sass (assets can't be referenced with `@images/[name][ext]` style syntax from a stylesheet). I don't know that this is a feature we can support. It's a resolve-url loader or postcss-scss thing, if so.

**Important**

I think the acorn side of the asset path issue fix is maybe not done yet (i'm on version v2.0.0-beta.7)? Acorn should leave asset paths alone if they are full URLs. In development, @roots/sage includes the public asset path in the `entrypoint.json` records and these URLs should not be processed. 

`entrypoints.json` in development:

```json
{
  "app": {
    "js": [
      "http://localhost:3000/app/themes/sage-10/public/app.js"
    ],
    "dependencies": []
  },
}
```

vs. production:

```
{
  "app": {
    "js": [
      "runtime.16d785.js",
      "app.c7a368.js"
    ],
    "css": [
      "app.8eced7.css"
    ],
    "dependencies": []
  },
}
```

**As is, Acorn doubles up the URL.**  So, there are errors like this:

```
http://localhost:3000/app/themes/sage-10/public/http://localhost:3000/app/themes/sage-10/public/app.js net::ERR_ABORTED 404 (Not Found)
```

This does not effect production builds. Bud is working as intended.

## Type of change

- PATCH: Backwards compatible bug fix

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Proposed changes

- fix(build): remove code to inline font assets below a certain size. it does not work consistently enough.
- fix(sass): use extension hook (instead of extension option api) to add postcss-scss to postcss configuration. i'm not sure why this extensions api call isn't working but it's just a wrapper for the hook and my fix works for now.
- improve(sage): binds context for resiliency. ensures publicPath is properly set in dev vs production.

## Dependency changes

- none

## Todo

- [x] covered by unit and/or integration tests
- [x] include documentation updates
