### PR TITLE
Add release GH workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,15 @@
-name: Release next version
+name: Release latest version
 
 on:
-  push:
-    branches:
-      - next
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version number (x.y.z format)
+        required: true
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-        node:
-          - 16.x
-
-    name: test node@${{matrix.node}}/${{matrix.platform}}
-    runs-on: ${{matrix.platform}}
+  release:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,7 +19,7 @@ jobs:
       - name: Setup
         uses: actions/setup-node@v2
         with:
-          node-version: ${{matrix.node}}
+          node-version: 16.x
 
       - name: Cache
         id: yarn-cache-dir-path
@@ -45,5 +38,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Release
-        run: >
-          yarn @bud release --tag next
+        env:
+          NPM_AUTH_TOKEN: {{ secrets.NODE_AUTH_TOKEN }}
+          YARN_RC_FILENAME: ".yarnrc.yml"
+        run: yarn @bud release --tag latest --version {{ inputs.version }}


### PR DESCRIPTION
Adds a new workflow for release a latest version.

For now it's set to be manually run via a `workflow_dispatch` with a version input. We'll figure out how to automate this based on a `release-x.y.z` branch name after.