### PR TITLE
docs(config) add /dev and workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Deploy docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Cache
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - name: Restore
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install tsdoc
+        run: npm install tsdoc --global
+
+      - name: Install repo
+        run: yarn
+
+      - name: Build docs
+        run: yarn @bud docs --api --site
+
+      - name: Deploy to netlify
+        uses: netlify/actions/cli@master
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.DEV_NETLIFY_SITE_ID }}
+        with:
+          args: deploy --dir=sources/@repo/docs/build --prod

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ storage
 # Examples
 /examples/*/dist
 /examples/*/.budfiles
+
+# Local Netlify folder
+**/.netlify

--- a/sources/@repo/docs/config/docusaurus.theme.ts
+++ b/sources/@repo/docs/config/docusaurus.theme.ts
@@ -93,6 +93,13 @@ export const navbar = {
     },
     {to: '/blog', label: 'Blog', position: 'left'},
     {
+      href: '/dev',
+      label: 'Development',
+      position: 'right',
+      className: 'header-github-link',
+      'aria-label': 'Release notes',
+    },
+    {
       href: '/releases',
       label: 'Releases',
       position: 'right',

--- a/sources/@repo/docs/config/index.ts
+++ b/sources/@repo/docs/config/index.ts
@@ -64,7 +64,7 @@ const docusaurusConfig: Config = {
       {
         id: 'dev',
         path: docsPath('content/dev'),
-        routeBasePath: docsPath('content/dev'),
+        routeBasePath: 'dev',
         sidebarPath,
         include: ['**/*.md', '**/*.mdx'],
       },

--- a/sources/@repo/docs/content/dev/index.mdx
+++ b/sources/@repo/docs/content/dev/index.mdx
@@ -2,12 +2,12 @@
 title: Developer contribution guide
 description: Be a pal. Contribute to bud.
 sidebar_label: Introduction
-slug: /dev/
+slug: /
 ---
 
 This is a work-in-progress.
 
-You can [reference API documentation here](/dev/api).
+You can [reference API documentation here](https://budjs.netlify.app/dev/api/).
 
 ## Requirements
 

--- a/sources/@repo/docs/netlify.toml
+++ b/sources/@repo/docs/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base = "./"
-  publish = "build/"
+  publish = "sources/@repo/docs/build/"
   command = "yarn docusaurus build"


### PR DESCRIPTION
## Overview

This is already deployed to the docs site as-is. 

dev guide: [/dev](https://budjs.netlify.app/dev) 
api docs: [/dev/api/](https://budjs.netlify.app/dev/api/).

Adds a workflow for publishing on 'v*' branch push. This is all I really need feedback on.

- I don't think those branches are protected?
- I don't want to install typedoc in the repo. I think it causes gcc issues.
- Any other feedback or suggestions 👍🏽 

## Type of change

- docs

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none
