### PR TITLE
fix(workflow-test): add fake `NPM_AUTH_TOKEN`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
           docker compose run bud yarn @bud lint --skypack --eslint
 
       - name: Publish
+        env:
+          NPM_AUTH_TOKEN: "kjo"
         run: |
           docker compose run bud yarn @bud release --tag latest
 


### PR DESCRIPTION
## Overview

Currently all builds are failing because `NPM_AUTH_TOKEN` is missing.

This PR sets a fake one in the workflow.

refers: none
closes: none

## Type of change

- NONE: does not change the API

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Proposed changes

- fix(workflow-test): add fake `NPM_AUTH_TOKEN`

### Alternative solution

This is not included here but could be an alternative approach.

- fix(docker-compose): add default fake `NPM_AUTH_TOKEN`

## Dependency changes

- none