### PR TITLE
fix: failing ci builds

### DIFF
--- a/.docker/bud.dockerfile
+++ b/.docker/bud.dockerfile
@@ -1,11 +1,7 @@
-FROM node:16
+FROM node:lts
 
 LABEL name 'bud'
 LABEL version 1
 
-RUN npm install netlify-cli npm-cli-login typedoc --global
-
 COPY ./.docker/bud/motd /etc/motd
 COPY ./.docker/bud/bash.bashrc /etc/bash.bashrc
-
-COPY ./ /srv/bud

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,20 +45,20 @@ jobs:
 
       - name: Setup
         run: |
-          docker compose run bud yarn install --immutable
+          docker-compose run --rm bud yarn install --immutable
 
       - name: Lint
         run: |
-          docker compose run bud yarn @bud lint --skypack --eslint
+          docker-compose run --rm bud yarn @bud lint --skypack --eslint
 
       - name: Publish
         run: |
-          docker compose run bud yarn @bud release --tag latest
+          docker-compose run --rm bud yarn @bud release --tag latest
 
       - name: Unit
         run: |
-          docker compose run bud yarn @bud test unit --coverage --maxWorkers 50%
+          docker-compose run --rm bud yarn @bud test unit --coverage --maxWorkers 50%
 
       - name: Integration
         run: |
-          docker compose run bud yarn @bud test integration --coverage --maxWorkers 50%
+          docker-compose run --rm bud yarn @bud test integration --coverage --maxWorkers 50%

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       - YARN_RC_FILENAME=${YARN_RC_FILENAME:-config/yarnrc.dev.yml}
     volumes:
       - ./:/srv/bud
-      - modules:/srv/bud/node_modules
       - mocks:/srv/mocks
+      - modules:/srv/bud/node_modules
       - support-libs:/srv/bud/sources/@roots/bud-support/lib
 
 networks:

--- a/sources/@repo/docs/content/dev/ci.mdx
+++ b/sources/@repo/docs/content/dev/ci.mdx
@@ -1,0 +1,49 @@
+---
+title: CI
+description: Developer notes on CI processes
+sidebar_label: CI
+---
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+## Test
+
+This is the CI workflow when a pull request is made to the `main` branch.
+
+:::danger Protip
+
+If you are logged into npm with publish permimssions for the `@roots` organization,
+running this script outside of the container _will publish the package_.
+
+:::
+
+<Tabs
+  defaultValue="docker"
+  values={[
+    {label: 'docker', value: 'docker'},
+    {label: 'native', value: 'native'},
+  ]}>
+  <TabItem value="docker">
+
+```sh
+docker-compose run --rm bud yarn install --immutable \
+  && docker-compose run --rm bud yarn @bud lint --skypack --eslint \
+  && docker-compose run --rm bud yarn @bud release --tag latest \
+  && docker-compose run --rm bud yarn @bud test unit --coverage --maxWorkers 50% \
+  && docker-compose run --rm bud yarn @bud test integration --maxWorkers 50%
+```
+
+  </TabItem>
+  <TabItem value="native">
+
+```sh
+yarn install --immutable \
+  && yarn @bud lint --skypack --eslint \
+  && yarn @bud release --tag latest \
+  && yarn @bud test unit --coverage --maxWorkers 50% \
+  && yarn @bud test integration --maxWorkers 50%
+```
+
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
## Overview

- no logging in ci? i found an upstream mention of this being a common issue starting around when our issue started
- builds failing stochastically. seem like they fail mostly around the `Publish` step.

refers: #1052 
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Proposed changes

- use `docker-compose` over `docker compose`
- use `--rm` flag on `run`
- remove nice-to-haves from the dockerfile
- use `node:lts` for base image
- document with some copy-paste friendly scripts in docs site (`/dev/ci`)

## Dependency changes

- removed global packages:
  - typedoc
  - npm-login-command
  - netlify-cli