### PR TITLE
fix: move bud webpack cache into subdir

### DIFF
--- a/sources/@roots/bud-api/src/api/methods/persist/index.ts
+++ b/sources/@roots/bud-api/src/api/methods/persist/index.ts
@@ -42,7 +42,9 @@ export const persist: persist = function (
 
     .hooks.on('build.cache.version', () => ctx.cache.version)
     .hooks.on('build.cache.type', (): 'filesystem' => 'filesystem')
-    .hooks.on('build.cache.cacheDirectory', () => ctx.path('storage'))
+    .hooks.on('build.cache.cacheDirectory', () =>
+      ctx.path('storage', 'cache', 'webpack'),
+    )
     .hooks.on('build.cache.buildDependencies', () => ({
       bud: ctx.project.get('dependencies'),
     }))

--- a/tests/unit/bud-api/repository/persist.test.ts
+++ b/tests/unit/bud-api/repository/persist.test.ts
@@ -15,17 +15,13 @@ describe('bud.persist', function () {
     bud.persist()
     await bud.api.processQueue()
 
-    expect(bud.hooks.filter('build.cache.version')).toBe(
-      bud.cache.version,
-    )
+    expect(bud.hooks.filter('build.cache.version')).toBe(bud.cache.version)
 
-    expect(bud.hooks.filter('build.cache.type')).toBe(
-      'filesystem',
-    )
+    expect(bud.hooks.filter('build.cache.type')).toBe('filesystem')
 
-    expect(
-      bud.hooks.filter('build.cache.cacheDirectory'),
-    ).toEqual(bud.path('storage'))
+    expect(bud.hooks.filter('build.cache.cacheDirectory')).toEqual(
+      bud.path('storage', 'cache', 'webpack'),
+    )
 
     expect(
       bud.hooks.filter('build.cache.buildDependencies'),
@@ -36,9 +32,9 @@ describe('bud.persist', function () {
       ],
     })
 
-    expect(bud.hooks.filter('build.cache.managedPaths')).toEqual(
-      [bud.path('modules')],
-    )
+    expect(bud.hooks.filter('build.cache.managedPaths')).toEqual([
+      bud.path('modules'),
+    ])
   })
 
   it('disables caching', async () => {


### PR DESCRIPTION
## Overview

This is a stub PR for a proposed change. Details forthcoming.

- bud's webpack cache should be in a subdirectory to avoid conflict with bud caches.

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none