### PR TITLE
improve: `bud build` command

### DIFF
--- a/sources/@roots/bud/src/cli/Runner/index.ts
+++ b/sources/@roots/bud/src/cli/Runner/index.ts
@@ -107,7 +107,7 @@ export class Runner {
       await manifest.configs(this.app, this.logger)
       this.logger.timeEnd('process user configs')
     } catch (error) {
-      this.logger.error(error)
+      throw new Error(error)
     }
 
     await flags.config(this.app, this.cli.flags)

--- a/sources/@roots/bud/src/cli/commands/build.ts
+++ b/sources/@roots/bud/src/cli/commands/build.ts
@@ -114,7 +114,7 @@ export default class Build extends Command {
 
   public async run() {
     await this.prime(Build)
-    await this.build()
+    await this.runner.make()
 
     this.app.hooks.on('event.compiler.done', stats => {
       this.notifier.notify(this.app, stats)


### PR DESCRIPTION
## Overview

Improves `bud build` cli command.

Better guarding against processes hanging in CI. 

Second, if a user is using multiple configs (example: `bud.config.ts` and `bud.config.production.ts`) they can rely on the `bud` object having been mutated before the next config is called.

This allows for the base config to `bud.use` an extension which adds a function to bud that they call in production. Previously, this function wouldn't have been available for use in the production config.

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Proposed changes

- better assurance of non zero exit code when something goes bad
-  the api and extension queues are processed directly after each config is called

## Dependency changes

- none
