### PR TITLE
fix: @roots/bud-eslint loader cache

### DIFF
--- a/sources/@roots/bud-eslint/src/eslint.options.ts
+++ b/sources/@roots/bud-eslint/src/eslint.options.ts
@@ -1,15 +1,22 @@
 import type {Framework} from '@roots/bud-framework'
 import type {Options} from 'eslint-webpack-plugin'
+import {cpus} from 'os'
 
 export interface options {
   (app: Framework): Options
 }
 
-export const options: options = ({path}) => ({
+export const options: options = ({store, path}) => ({
   extensions: ['js', 'jsx', 'ts', 'tsx', 'vue'],
-  cache: true,
+  cache: store.isTrue('features.cache'),
   cacheLocation: path('storage', 'cache', 'eslint.json'),
+  cacheStrategy: 'content',
   context: path('src'),
   cwd: path('project'),
+  emitError: true,
+  emitWarning: true,
   failOnError: true,
+  eslintPath: require.resolve('eslint'),
+  resolvePluginsRelativeTo: path('project'),
+  threads: cpus.length / 2,
 })


### PR DESCRIPTION
## Overview

- eslint cache is overly aggressive
- eslint cache should be emitted to storage subdirectory
- eslint performance could probably be improved

refers: none
closes: none

## Type of change

- NONE: does not change the API

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependency changes

- none

<!--
- [@roots/bud] adds [package]@[version]
- [@roots/sage] removes [package]@[version]
- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
-->