### PR TITLE
do not inject proxy client fix into non-proxy app

### DIFF
--- a/sources/@roots/bud-server/src/server/index.ts
+++ b/sources/@roots/bud-server/src/server/index.ts
@@ -107,7 +107,8 @@ export class Server
   public applyMiddlewares() {
     Object.entries(this.app.hooks.filter('server.middleware')).map(
       ([key, factory]) => {
-        this.log(`info`, `using middleware: ${key}`)
+        if (this.app.store.isFalse(`server.middleware.${key}` as any))
+          return this.log(`info`, `not using middleware: ${key}`)
 
         const middleware = factory(this.app)
 
@@ -116,6 +117,8 @@ export class Server
         })
 
         this.application.use(this.middleware[key])
+
+        this.log(`info`, `using middleware: ${key}`)
       },
     )
   }

--- a/sources/@roots/bud-server/src/server/index.ts
+++ b/sources/@roots/bud-server/src/server/index.ts
@@ -87,7 +87,7 @@ export class Server
 
       .hooks.async('event.server.before', async app => {
         app.when(
-          ({store}) => store.is('features.proxy', true),
+          ({store}) => store.is('server.middleware.proxy', true),
           ({hooks}) =>
             hooks.on('server.inject', inject => [
               ...inject,


### PR DESCRIPTION
## Overview

Fixes an issue where the client-side script that intercepts anchor clicks and redirects to proxy is included in dev bundles that don't utilize a proxy.

refers: none
closes: [1082](https://github.com/roots/bud/issues/1082)

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none