### PR TITLE
fix(server): type error: watcher undefined

### DIFF
--- a/sources/@roots/bud-server/src/server/index.ts
+++ b/sources/@roots/bud-server/src/server/index.ts
@@ -179,7 +179,7 @@ export class Server
      * event subscribers.
      */
     await this.watcher.watch()
-    this.watcher.instance.on('change', path => {
+    this.watcher.instance?.on('change', path => {
       this.middleware?.hot?.publish({
         action: 'reload',
         message: `Detected file change: ${path}. Reloading window.`,


### PR DESCRIPTION
## Overview

Fixes a fatal error when a user does not call `bud.watch` or otherwise has no watched files.

closes: [1082](https://github.com/roots/bud/issues/1082)

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependency changes

- none

<!--
- [@roots/bud] adds [package]@[version]
- [@roots/sage] removes [package]@[version]
- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
-->