### PR TITLE
fix: check for valid browserslist before defining

### DIFF
--- a/sources/@roots/bud-build/src/Build/config.ts
+++ b/sources/@roots/bud-build/src/Build/config.ts
@@ -417,7 +417,11 @@ export async function config(app: Framework): Promise<void> {
      */
     .hooks.on<'build.target'>(
       'build.target',
-      () => `browserslist:${app.path('project', 'package.json')}`,
+      () =>
+        app.project.has('manifest.browserslist') &&
+          app.project.isArray('manifest.browserslist')
+            ? `browserslist:${app.path('project', 'package.json')}`
+            : undefined,
     )
 
     /**


### PR DESCRIPTION
## Overview

Fixes a fatal error when a `browserslist` property is not set in `package.json`.

refers: none
closes: https://github.com/roots/bud/issues/1082

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependency changes

- none

<!--
- [@roots/bud] adds [package]@[version]
- [@roots/sage] removes [package]@[version]
- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
-->