### PR TITLE
improve: bud.assets

### DIFF
--- a/sources/@roots/bud-api/src/api/facade/facade.interface.ts
+++ b/sources/@roots/bud-api/src/api/facade/facade.interface.ts
@@ -50,13 +50,37 @@ export class Facade {
    * Copy static assets during compilation.
    *
    * @remarks
-   * You may specify paths with a string literal or glob pattern.
+   * You may specify paths with a string literal, glob pattern, options object,
+   * or an array of any of these.
    *
    * @example
-   * Copy **src/images** to **dist/images**
-   *
    * ```js
-   * app.assets(['src/images'])
+   * app.assets('images')
+   * ```
+   *
+   * @example
+   * ```js
+   * app.assets(['images', 'fonts'])
+   * ```
+   *
+   * @example
+   * ```js
+   * app.assets({
+   *  from: app.path('src', 'images'),
+   *  errorOnUnmatchedPattern: true,
+   * })
+   * ```
+   *
+   * @example
+   * ```js
+   * app.assets([
+   *   {
+   *    from: app.path('src', 'images'),
+   *    errorOnUnmatchedPattern: true,
+   *   },
+   *   'fonts',
+   *   '** /*.txt'
+   * ])
    * ```
    *
    * @public
@@ -67,13 +91,37 @@ export class Facade {
    * Copy static assets during compilation.
    *
    * @remarks
-   * You may specify paths with a string literal or glob pattern.
+   * You may specify paths with a string literal, glob pattern, options object,
+   * or an array of any of these.
    *
    * @example
-   * Copy **src/images** to **dist/images**
-   *
    * ```js
-   * app.assets(['src/images'])
+   * app.assets('images')
+   * ```
+   *
+   * @example
+   * ```js
+   * app.assets(['images', 'fonts'])
+   * ```
+   *
+   * @example
+   * ```js
+   * app.assets({
+   *  from: app.path('src', 'images'),
+   *  errorOnUnmatchedPattern: true,
+   * })
+   * ```
+   *
+   * @example
+   * ```js
+   * app.assets([
+   *   {
+   *    from: app.path('src', 'images'),
+   *    errorOnUnmatchedPattern: true,
+   *   },
+   *   'fonts',
+   *   '** /*.txt'
+   * ])
    * ```
    *
    * @public

--- a/sources/@roots/bud-api/src/api/methods/assets/assets.interface.ts
+++ b/sources/@roots/bud-api/src/api/methods/assets/assets.interface.ts
@@ -1,9 +1,20 @@
 import type {Framework} from '@roots/bud-framework'
-
-export interface method {
-  (from: string[]): Promise<Framework>
-}
+import CopyPlugin from 'copy-webpack-plugin'
 
 export interface facade {
-  (from: string[]): Framework
+  (
+    paths:
+      | string
+      | CopyPlugin.ObjectPattern
+      | Array<string | CopyPlugin.ObjectPattern>,
+  ): Framework
+}
+
+export interface method {
+  (
+    paths:
+      | string
+      | CopyPlugin.ObjectPattern
+      | Array<string | CopyPlugin.ObjectPattern>,
+  ): Promise<Framework>
 }

--- a/sources/@roots/bud-api/src/api/methods/assets/assets.method.ts
+++ b/sources/@roots/bud-api/src/api/methods/assets/assets.method.ts
@@ -1,34 +1,114 @@
 import type {Framework} from '@roots/bud-framework'
-import {globby} from '@roots/bud-support'
-import {dirname} from 'path'
+import CopyPlugin from 'copy-webpack-plugin'
+import {isArray, isString} from 'lodash'
+import {normalize} from 'path'
 
 import type {method} from './assets.interface'
 
 export const assets: method = async function assets(
-  paths: string[],
+  ...request: Array<
+    | string
+    | CopyPlugin.ObjectPattern
+    | Array<string | CopyPlugin.ObjectPattern>
+  >
 ): Promise<Framework> {
-  this as Framework
-  paths = await globby(paths)
+  /**
+   * tsc will complain about `this` context being lost
+   * when destructuring bud even though the context of
+   * this function will be bound.
+   */
+  const ctx = this as Framework
 
-  paths.map((src: string) => {
-    const dirName = dirname(src).replace(
-      this.path('src'),
-      this.path('dist'),
-    )
+  /**
+   * Flatten request
+   */
+  request = request.flat()
 
-    const fileName =
-      this.store.is('features.hash', true) && this.isProduction
-        ? `${dirName}/${this.store.get('hashFormat')}[ext]`
-        : `${dirName}/${this.store.get('fileFormat')}[ext]`
+  /**
+   * We know it's not a directory
+   * - when it ends with a globstar
+   *
+   * We'll say it's a directory when:
+   * - a pattern ends with `/`
+   * - a pattern has segments and it's last path segment does not contain a `.`
+   * - a pattern has no segments and does not contain a dot
+   */
+  const isDirectoryish = (pattern: string) => {
+    if (pattern.endsWith('*')) return false
+    if (pattern.endsWith('/')) return true
+    if (pattern.includes('/') && !pattern.split('/').pop().includes('.'))
+      return true
 
-    this.extensions.get('copy-webpack-plugin').mergeOption('patterns', [
-      {
-        from: src,
-        to: fileName,
-        noErrorOnMissing: true,
-      },
-    ])
-  })
+    return !pattern.includes('.')
+  }
+  /**
+   * Return a wildcard glob for a given path
+   */
+  const toWildcard = (pattern: string) => normalize(`${pattern}/**/*`)
+  /**
+   * Replace a leading dot with the project path
+   */
+  const fromDotRel = (pattern: string) =>
+    pattern.startsWith('./')
+      ? pattern.replace('./', `/`.concat(ctx.path('project')))
+      : pattern
 
-  return this
+  /**
+   * Take an input string and return a {@link CopyPlugin.ObjectPattern}
+   */
+  const makePatternObject = (input: string): CopyPlugin.ObjectPattern => {
+    /**
+     * Process raw user input.
+     *
+     * - Replace leading dot with project path
+     * - Append wildcard glob to directory requests
+     */
+    const from = isDirectoryish(input)
+      ? fromDotRel(toWildcard(input))
+      : fromDotRel(input)
+
+    /**
+     * Test if input starts with a given string
+     */
+    const test = (test: string) => from.startsWith(test)
+
+    /**
+     * Return path that serves as base of request
+     *
+     * @remarks
+     * In order of priority:
+     *  - project `src` path
+     *  - project path
+     *  - raw input
+     */
+    const context = () => {
+      if (test(ctx.path('src'))) return ctx.path('src')
+      if (test(ctx.path('project'))) return ctx.path('project')
+      if (!test('/')) return ctx.path('src')
+      else return
+    }
+
+    return {
+      from,
+      context: context(),
+      noErrorOnMissing: true,
+    }
+  }
+
+  /**
+   * Parse a request item
+   */
+  const parse = (request: string | CopyPlugin.ObjectPattern) => {
+    return isString(request) ? makePatternObject(request) : request
+  }
+
+  const mergePattern = isArray(request)
+    ? request.map(parse)
+    : [parse(request)]
+
+  ctx.extensions
+    .get('copy-webpack-plugin')
+    .mergeOption('patterns', mergePattern)
+
+  return ctx
 }

--- a/tests/unit/bud-api/repository/assets.test.ts
+++ b/tests/unit/bud-api/repository/assets.test.ts
@@ -18,6 +18,6 @@ describe('bud.assets', function () {
 
     const {options} = bud.extensions.get('copy-webpack-plugin')
 
-    expect(options.get('patterns')).toHaveLength(2)
+    expect(options.get('patterns')).toHaveLength(1)
   })
 })


### PR DESCRIPTION
## Overview

Improves `bud.assets`. No longer requires using `bud.path` helper (or absolute path, otherwise).

Supports a single pattern:

```ts
app.assets('images')
```

Supports an array of patterns:

```ts
app.assets(['images'])
```

Supports variadic patterns:

```ts
app.assets('images', 'fonts')
```

Supports wildcard globs:

```ts
app.assets('images/**/*', 'fonts/**/*')
```

Supports leading dot notation:

```ts
app.assets(['./images', './fonts'])
```

Supports absolute paths:

```ts
app.assets('/srv/www/src/images', '/srv/www/src/fonts')
```

Supports CopyPlugin options object:

```ts
app.assets({from: 'images', context: app.path('src')})
```

All of these formats yield the same result:

```ts
app.assets('images', 'fonts')
app.assets(['images', 'fonts'])
app.assets('./resources/images', './resources/fonts')
app.assets(['images/', 'fonts/'])
app.assets(
  app.path('src', 'images'), 
  app.path('src', 'fonts'),
)
app.assets(
  {from: app.path('src', 'images'), context: app.path('src')},
  {from: app.path('src', 'fonts'), context: app.path('src')},
)
app.assets([
  'images', 
  {from: app.path('src', 'fonts'), context: app.path('src')},
])
app.assets(['images/**/*', 'fonts/**/*'])
```

This is a fix for `main` as-is, and an improvement for 5.2.0.

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependency changes

- none

<!--
- [@roots/bud] adds [package]@[version]
- [@roots/sage] removes [package]@[version]
- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
-->