### PR TITLE
🩹 ensure parallism is at least 1cpu by default

### DIFF
--- a/sources/@roots/bud/src/seed.ts
+++ b/sources/@roots/bud/src/seed.ts
@@ -240,7 +240,7 @@ export const seed: Partial<Store.Repository> = {
       removeEmptyChunks: true,
       splitChunks: {},
     },
-    parallelism: cpus().length - 1,
+    parallelism: Math.max(cpus().length - 1, 1),
     performance: {
       hints: false,
     },


### PR DESCRIPTION
## Overview

Currently if `cpus().length - 1` will evaluate to `0` if there is only 1 CPU.

refers: none
closes: #1117

## Type of change

- PATCH: Backwards compatible bug fix


This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Proposed changes

- fix(bud): 🩹 ensure parallism is at least 1cpu by default

## Dependency changes

- none

