### PR TITLE
fix: late extensions are assumed to be modules

### DIFF
--- a/sources/@roots/bud-extensions/src/Controller/controller.service.ts
+++ b/sources/@roots/bud-extensions/src/Controller/controller.service.ts
@@ -361,15 +361,16 @@ export class Controller {
     if (this.meta.registered) return this
     this.meta.registered = true
 
-    await Promise.all(
-      this.app.project.peers.modules[this.name].requires.map(
-        async ([name]) => {
-          if (!this.app.extensions.get(name).meta.registered) {
-            await this.app.extensions.get(name).register()
-          }
-        },
-      ),
-    )
+    this.app.project.has(`project.peers.${this.name}.requires`) &&
+      (await Promise.all(
+        this.app.project
+          .get(`project.peers.${this.name}.requires`)
+          .map(async ([name]) => {
+            if (!this.app.extensions.get(name).meta.registered) {
+              await this.app.extensions.get(name).register()
+            }
+          }),
+      ))
 
     await this.mixin()
     await this.api()
@@ -396,15 +397,16 @@ export class Controller {
     }
     if (this.meta.bound) return this
     this.meta.bound = true
-    await Promise.all(
-      this.app.project.peers.modules[this.name].requires.map(
-        async ([name]) => {
-          if (!this.app.extensions.get(name).meta.bound) {
-            await this.app.extensions.get(name).api()
-          }
-        },
-      ),
-    )
+    this.app.project.has(`project.peers.${this.name}.requires`) &&
+      (await Promise.all(
+        this.app.project
+          .get(`project.peers.${this.name}.requires`)
+          .map(async ([name]) => {
+            if (!this.app.extensions.get(name).meta.bound) {
+              await this.app.extensions.get(name).api()
+            }
+          }),
+      ))
 
     const methodMap: Record<string, CallableFunction> = isFunction(
       this._module.api,
@@ -445,15 +447,16 @@ export class Controller {
     }
     if (this.meta.mixed) return this
     this.meta.mixed = true
-    await Promise.all(
-      this.app.project.peers.modules[this.name].requires.map(
-        async ([name]) => {
-          if (!this.app.extensions.get(name).meta.mixed) {
-            await this.app.extensions.get(name).mixin()
-          }
-        },
-      ),
-    )
+    this.app.project.has(`project.peers.${this.name}.requires`) &&
+      (await Promise.all(
+        this.app.project
+          .get(`project.peers.${this.name}.requires`)
+          .map(async ([name]) => {
+            if (!this.app.extensions.get(name).meta.mixed) {
+              await this.app.extensions.get(name).mixin()
+            }
+          }),
+      ))
 
     let classMap: Record<string, any>
 
@@ -492,15 +495,16 @@ export class Controller {
     }
     if (this.meta.booted) return this
     this.meta.booted = true
-    await Promise.all(
-      this.app.project.peers.modules[this.name].requires.map(
-        async ([name]) => {
-          if (!this.app.extensions.get(name).meta.boot) {
-            await this.app.extensions.get(name).boot()
-          }
-        },
-      ),
-    )
+    this.app.project.has(`project.peers.${this.name}.requires`) &&
+      (await Promise.all(
+        this.app.project
+          .get(`project.peers.${this.name}.requires`)
+          .map(async ([name]) => {
+            if (!this.app.extensions.get(name).meta.boot) {
+              await this.app.extensions.get(name).boot()
+            }
+          }),
+      ))
 
     if (isFunction(this._module.boot)) {
       await this._module.boot(this.app, this.moduleLogger)


### PR DESCRIPTION
## Overview

Fixes a problem where extensions with a `register` or `boot` method that are added late (in the config file) were assumed to be imported extensions. This is also in #1108 but that's a larger change and I'm trying to be careful not to introduce regressions with it. This one part of it is good to go, though.

This issue doesn't effect people who are doing stuff like:

```ts
app.use(
  new BrowserSync()
)
```

You have to be defining `register` or `boot`, which is a little strange to do if you aren't writing a module. 
So, it's not a super urgent fix.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependency changes

- none

<!--
- [@roots/bud] adds [package]@[version]
- [@roots/sage] removes [package]@[version]
- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
-->