### PR TITLE
fix: tailwindcss shouldn't throw when there is no config

### DIFF
--- a/sources/@roots/bud-tailwindcss/src/tailwind.extension.ts
+++ b/sources/@roots/bud-tailwindcss/src/tailwind.extension.ts
@@ -31,7 +31,7 @@ const getVerifiedUserConfigPath = async function (
 
     return configPath
   } catch (e) {
-    this.error({
+    this.warn({
       message: '@roots/bud-tailwindcss failed to load user config',
     })
     return null
@@ -102,7 +102,7 @@ export const BudTailwindCssExtension: BudTailwindCssExtension = {
 
       log.success('postcss has been configured for tailwindcss')
     } catch (e) {
-      log.error({message: e})
+      log.warn({message: e})
     }
   },
 }


### PR DESCRIPTION
## Overview

I was playing around with esm and noticed that tailwind config was causing a build failure without the `.cjs` extension. But, that doesn't make sense because tailwind doesn't even require a config file.

This downgrades the error logging on tailwind to a warning if the config file is not found.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible buf fix

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependency changes

- none

<!--
- [@roots/bud] adds [package]@[version]
- [@roots/sage] removes [package]@[version]
- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
-->