### PR TITLE
fix: ci logging

### DIFF
--- a/sources/@roots/bud-framework/src/Hooks.ts
+++ b/sources/@roots/bud-framework/src/Hooks.ts
@@ -193,12 +193,12 @@ export namespace Hooks {
     [`location.project`]: string
     [`location.modules`]: string
     [`location.storage`]: string
-    [`config.override`]: Configuration[]
+    [`config.override`]: Array<Configuration>
     [`event.app.close`]: unknown
     [`event.build.make.before`]: unknown
     [`event.build.make.after`]: unknown
     [`event.build.override`]: Configuration
-    [`event.compiler.before`]: Array<Framework>
+    [`event.compiler.before`]: Array<Configuration>
     [`event.compiler.after`]: Framework
     [`event.compiler.stats`]: Promise<StatsCompilation>
     [`event.compiler.error`]: Error


### PR DESCRIPTION
## Overview

Fixes issues with ci logging stemming from deprecation of `--no-dashboard` flag.

also adds error handling cos process will hang in the `ProgressPlugin` callback if something is funky.

from the build & test action run:

```
[9%] [setup] › ProgressPlugin compilation
[9%] [setup] › ESLintWebpackPlugin_1 compilation
[24%] [building] › 1/4 entries 5/5 dependencies 1/4 modules
[38%] [building] › 2/4 entries 5/5 dependencies 2/4 modules
[38%] [building] › import loader ./node_modules/mini-css-extract-plugin/dist/loader.js
[38%] [building] › import loader ./node_modules/css-loader/dist/cjs.js
[38%] [building] › 2/4 entries 5/5 dependencies 2/4 modules
[52%] [building] › 3/4 entries 15/15 dependencies 8/10 modules
[65%] [building] › 4/4 entries 15/15 dependencies 10/10 modules
[65%] [building] › 
[69%] [building] › finish
[70%] [sealing] › finish module graph
[70%] [sealing] › ResolverCachePlugin finish module graph
[70%] [sealing] › InferAsyncModulesPlugin finish module graph
[70%] [sealing] › FlagDependencyExportsPlugin finish module graph
[70%] [sealing] › InnerGraphPlugin finish module graph
[70%] [sealing] › WasmFinalizeExportsPlugin finish module graph
[70%] [sealing] › finish module graph
[71%] [sealing] › plugins
```

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

