### PR TITLE
improve(repo): set pkg version 0.0.0

### DIFF
--- a/sources/@roots/bud-api/package.json
+++ b/sources/@roots/bud-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-api",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Bud configuration API",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-babel/package.json
+++ b/sources/@roots/bud-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-babel",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds babel support to @roots/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-build/package.json
+++ b/sources/@roots/bud-build/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-build",
   "description": "Bud webpack config build controller",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-cache/package.json
+++ b/sources/@roots/bud-cache/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-cache",
   "description": "Config caching",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-compiler/package.json
+++ b/sources/@roots/bud-compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-compiler",
   "description": "Compilation handler",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-compress/package.json
+++ b/sources/@roots/bud-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-compress",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds gzip and brotli compression to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-criticalcss/package.json
+++ b/sources/@roots/bud-criticalcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-criticalcss",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds critical.css support to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-dashboard/package.json
+++ b/sources/@roots/bud-dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-dashboard",
   "description": "Bud CLI dashboard",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-emotion/package.json
+++ b/sources/@roots/bud-emotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-emotion",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "CSS-in-JS support for the @roots/bud framework",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-entrypoints/package.json
+++ b/sources/@roots/bud-entrypoints/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-entrypoints",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Webpack tools",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-esbuild/package.json
+++ b/sources/@roots/bud-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-esbuild",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "ESBuild transpilation extension for Bud projects",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-eslint/package.json
+++ b/sources/@roots/bud-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-eslint",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds eslint support to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-extensions/package.json
+++ b/sources/@roots/bud-extensions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-extensions",
   "description": "Bud extensions controller",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-framework/package.json
+++ b/sources/@roots/bud-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-framework",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "A friendly build tool to help manage your project assets.",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-hooks/package.json
+++ b/sources/@roots/bud-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-hooks",
   "description": "Hooks controller for Bud",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-imagemin/package.json
+++ b/sources/@roots/bud-imagemin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-imagemin",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Image minification for `@roots/bud` projects",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-library/package.json
+++ b/sources/@roots/bud-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-library",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds dynamic link library support to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-mdx/package.json
+++ b/sources/@roots/bud-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-mdx",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "mdx extension for @roots/bud projects",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-postcss/package.json
+++ b/sources/@roots/bud-postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-postcss",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds postcss support to @roots/bud projects",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-preset-recommend/package.json
+++ b/sources/@roots/bud-preset-recommend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-preset-recommend",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Recommended preset for Bud projects",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-preset-wordpress/package.json
+++ b/sources/@roots/bud-preset-wordpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-preset-wordpress",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "WordPress-ready preset for Bud projects",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-prettier/package.json
+++ b/sources/@roots/bud-prettier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-prettier",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds prettier support to Bud",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-purgecss/package.json
+++ b/sources/@roots/bud-purgecss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-purgecss",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds purgecss support to Bud",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-react/package.json
+++ b/sources/@roots/bud-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-react",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "React support for @roots/bud projects.",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-sass/package.json
+++ b/sources/@roots/bud-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-sass",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Sass support for @roots/bud projects.",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-server/package.json
+++ b/sources/@roots/bud-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud-server",
   "description": "Development server for @roots/bud",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-solid/package.json
+++ b/sources/@roots/bud-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-solid",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "solid-js support for @roots/bud projects.",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-stylelint/package.json
+++ b/sources/@roots/bud-stylelint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-stylelint",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds stylelint support to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-support/package.json
+++ b/sources/@roots/bud-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-support",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "👨🏽‍🍳 Internal packages for @roots/bud",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/bud-tailwindcss/package.json
+++ b/sources/@roots/bud-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-tailwindcss",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds tailwindcss support to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-terser/package.json
+++ b/sources/@roots/bud-terser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-terser",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds terser support to Bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-typescript/package.json
+++ b/sources/@roots/bud-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-typescript",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds Typescript support to Bud.",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-vue/package.json
+++ b/sources/@roots/bud-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-vue",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Adds @vue/vue support to @roots/bud projects",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-wordpress-dependencies/package.json
+++ b/sources/@roots/bud-wordpress-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-wordpress-dependencies",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Webpack tools",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-wordpress-externals/package.json
+++ b/sources/@roots/bud-wordpress-externals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-wordpress-externals",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Webpack tools",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud-wordpress-manifests/package.json
+++ b/sources/@roots/bud-wordpress-manifests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud-wordpress-manifests",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Webpack tools",
   "repository": {
     "type": "git",

--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/bud",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Frontend build tools combining the best parts of Symfony Encore and Laravel Mix",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/container/package.json
+++ b/sources/@roots/container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/container",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Collections utility",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/critical-css-webpack-plugin/package.json
+++ b/sources/@roots/critical-css-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/critical-css-webpack-plugin",
   "description": "Webpack plugin for generating critical-path CSS",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/roots/bud.git",

--- a/sources/@roots/dependencies/package.json
+++ b/sources/@roots/dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/dependencies",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "Automated package installation",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/entrypoints-webpack-plugin/package.json
+++ b/sources/@roots/entrypoints-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/entrypoints-webpack-plugin",
   "description": "Manifest with assets grouped by entrypoint",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/roots/bud.git",

--- a/sources/@roots/filesystem/package.json
+++ b/sources/@roots/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/filesystem",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "A simple, high-level virtual filesystem",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/@roots/ink-prettier/package.json
+++ b/sources/@roots/ink-prettier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/ink-prettier",
   "description": "Prettier component for React Ink",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/ink-use-style/package.json
+++ b/sources/@roots/ink-use-style/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/ink-use-style",
   "description": "Themes and styles for React Ink",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/merged-manifest-webpack-plugin/package.json
+++ b/sources/@roots/merged-manifest-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/merged-manifest-webpack-plugin",
   "description": "Webpack plugin to merge roots manifests.",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/roots/bud.git",

--- a/sources/@roots/sage/package.json
+++ b/sources/@roots/sage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roots/sage",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "description": "@roots/sage preset for @roots/bud",
   "repository": {
     "type": "git",

--- a/sources/@roots/wordpress-dependencies-webpack-plugin/package.json
+++ b/sources/@roots/wordpress-dependencies-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/wordpress-dependencies-webpack-plugin",
   "description": "Webpack plugin to help with wp_enqueue_script",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/roots/bud.git",

--- a/sources/@roots/wordpress-externals-webpack-plugin/package.json
+++ b/sources/@roots/wordpress-externals-webpack-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/wordpress-externals-webpack-plugin",
   "description": "Webpack plugin to register WordPress dependencies as externals",
-  "version": "5.1.0",
+  "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/roots/bud.git",


### PR DESCRIPTION
## Overview

I propose just keeping the version of packages at 0.0.0 on main. right now the version is just sitting at 5.1.0, forgotten. I like this because it won't cause any chaos if someone who can publish to `@roots` accidentally runs a release locally.

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none