### PR TITLE
improve: process logger

### DIFF
--- a/sources/@roots/bud-framework/src/Framework/framework.process.ts
+++ b/sources/@roots/bud-framework/src/Framework/framework.process.ts
@@ -1,4 +1,10 @@
+import {Signale} from '@roots/bud-support'
+
 import {Framework} from '.'
+
+const Logger = new Signale({
+  scope: 'process',
+})
 
 /**
  * Node shutdown factory
@@ -23,17 +29,14 @@ export const makeTerminator = (
     global.process.exit()
   }
 
-  return (code: number, reason: string) => (err: Error, promise) => {
+  return (code: number, reason: string) => (err: Error) => {
     if (err && err instanceof Error) {
-      const termLog = app.logger.scoped('node', 'terminate')
-      termLog.error(err.message, err.stack)
+      Logger.error(err.message, err.stack)
     }
 
-    app.logger.scoped(app.name, 'node', 'terminate').info(reason)
+    Logger.info(reason)
 
-    app.close(exit(code))
-
-    setTimeout(exit(code), options.timeout).unref()
+    setTimeout(() => app.close(exit(code)), options.timeout).unref()
   }
 }
 

--- a/sources/@roots/bud-framework/src/Framework/index.ts
+++ b/sources/@roots/bud-framework/src/Framework/index.ts
@@ -755,8 +755,9 @@ export abstract class Framework {
    */
   @bind
   public error(...messages: any[]) {
+    this.logger.instance.enable()
     this.logger.instance.scope(...this.logger.context).error(...messages)
-    throw new Error('Error thrown. Reference message contents above.')
+    throw new Error(messages.shift())
   }
 
   @bind


### PR DESCRIPTION
## Overview

In bud 5.4.0 the logger will be disabled by default unless the `--log` flag is passed. This change ensures that even with logging disabled process and error log items are still emitted.

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none