### PR TITLE
config: add sources/deprecated to renovate ignore

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,19 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:daily",
-    ":dependencyDashboard"
-  ],
+  "baseBranches": ["main"],
   "commitMessageAction": "Bump",
   "commitMessageTopic": "{{depName}}",
-  "postUpdateOptions": ["yarnDedupeHighest"],
-  "timezone": "America/Los_Angeles",
-  "baseBranches": ["main"],
+  "extends": ["config:base", "schedule:daily", ":dependencyDashboard"],
+  "ignorePaths": ["sources/deprecated/**"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     },
     {
-      "matchPackagePrefixes": ["@yarnpkg/"],
-      "groupName": "yarnpkg monorepo"
+      "groupName": "yarnpkg monorepo",
+      "matchPackagePrefixes": ["@yarnpkg/"]
     }
-  ]
+  ],
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "timezone": "America/Los_Angeles"
 }


### PR DESCRIPTION
## Overview

We don't need to update these deps

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none
