### PR TITLE
dev(none): fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,13 +13,13 @@ closes: none
 
 ## Type of change
 
-- NONE: does not change the API
+- PATCH: Backwards compatible bug fix
 
 <!--
-- MAJOR: Potentially breaking change to the API
-- MINOR: Backwards compatible feature
-- PATCH: Backwards compatible buf fix
-- NONE: does not change the API
+- MAJOR: breaking change
+- MINOR: feature
+- PATCH: bug fix
+- NONE: internal change
 -->
 
 This PR includes breaking changes to the following core packages:
@@ -30,39 +30,16 @@ This PR includes breaking changes to the follow extensions:
 
 - none
 
-## Proposed changes
+## Dependencies
 
 <!--
-- fix(package): description of the fix
-- feat(package): description of the feature
-- docs(package): description of the documentation change
-- style(package): description of the style change
-- refactor(package): description of the refactoring
-- test(package): description of the test change
-- chore(package): description of the chore change
+- [@roots/bud]: [package]@[version]
 -->
 
-- forthcoming
-
-## Dependency changes
+### Adds
 
 - none
 
-<!--
-- [@roots/bud] adds [package]@[version]
-- [@roots/sage] removes [package]@[version]
-- [@roots/bud-babel] updates [package]@[version] to [package]@[version]
--->
+### Removes
 
-## Todo
-
-<!--
-These items are not required to submit the PR.
-
-Please don't go out of your way to meet these criteria
-if you have not spoken to maintainers about your PR.
--->
-
-- [ ] covered by unit and/or integration tests
-- [ ] include documentation updates
-- [ ] featured in the changelog
+- none


### PR DESCRIPTION
## Overview

It has been annoying. Also, there was a typo

refers: none
closes: none

## Type of change

- NONE: does not change the API

<!--
- MAJOR: Potentially breaking change to the API
- MINOR: Backwards compatible feature
- PATCH: Backwards compatible buf fix
- NONE: does not change the API
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none