### PR TITLE
🧪 test(none): @roots/bud-typescript unit tests

### DIFF
--- a/sources/@roots/bud-typescript/src/bud.extension.ts
+++ b/sources/@roots/bud-typescript/src/bud.extension.ts
@@ -9,7 +9,12 @@ import {typecheck} from './bud.typecheck'
  * @public
  */
 export interface BudTypeScriptExtension
-  extends Extension.Module<Partial<Options>> {}
+  extends Extension.Module<Partial<Options>> {
+  name: '@roots/bud-typescript'
+  api: {typecheck: typecheck}
+  options: Partial<Options>
+  boot: Extension.Module['boot']
+}
 
 /**
  * @public

--- a/sources/@roots/bud-typescript/src/bud.typecheck.ts
+++ b/sources/@roots/bud-typescript/src/bud.typecheck.ts
@@ -37,8 +37,8 @@ export const typecheck: typecheck = async function (
    * if it is registered
    */
   if (options === false) {
-    this.extensions.has('fork-ts-checker-plugin') &&
-      this.extensions.remove('fork-ts-checker-plugin')
+    this.extensions.has('fork-ts-checker-webpack-plugin') &&
+      this.extensions.remove('fork-ts-checker-webpack-plugin')
 
     return this
   }
@@ -53,7 +53,7 @@ export const typecheck: typecheck = async function (
    * No options is the same as passing true.
    * It implicitly enables the plugin.
    */
-  if (!options) return this
+  if (!options || options === true) return this
 
   /**
    * If there were options passed and they are

--- a/sources/@roots/bud-typescript/src/fork-ts-checker-webpack-plugin.ts
+++ b/sources/@roots/bud-typescript/src/fork-ts-checker-webpack-plugin.ts
@@ -16,7 +16,10 @@ export type Options = Plugin['options']
  * @public
  */
 export interface BudTypeCheckPlugin
-  extends Extension.CompilerPlugin<Plugin, Options> {}
+  extends Extension.CompilerPlugin<Plugin, Options> {
+  name: 'fork-ts-checker-webpack-plugin'
+  options(app: Framework): Options
+}
 
 /**
  * extension name

--- a/sources/@roots/bud-typescript/src/index.ts
+++ b/sources/@roots/bud-typescript/src/index.ts
@@ -36,7 +36,7 @@ declare module '@roots/bud-framework' {
   }
 
   interface Modules {
-    '@roots/bud-typescript': Extension.Module
+    '@roots/bud-typescript': BudTypeScriptExtension
   }
 
   interface Plugins {

--- a/tests/unit/bud-tailwindcss/extension.test.ts
+++ b/tests/unit/bud-tailwindcss/extension.test.ts
@@ -13,15 +13,11 @@ describe('@roots/bud-tailwindcss', () => {
   })
 
   it('has name prop', () => {
-    expect(BudTailwindCssExtension.name).toBe(
-      '@roots/bud-tailwindcss',
-    )
+    expect(BudTailwindCssExtension.name).toBe('@roots/bud-tailwindcss')
   })
 
   it('has an api prop', () => {
-    expect(BudTailwindCssExtension.api.tailwind).toBeInstanceOf(
-      Function,
-    )
+    expect(BudTailwindCssExtension.api.tailwind).toBeInstanceOf(Function)
   })
 
   it('sets up postcss plugins', async () => {

--- a/tests/unit/bud-typescript/extension.test.ts
+++ b/tests/unit/bud-typescript/extension.test.ts
@@ -1,0 +1,99 @@
+import '@roots/bud-postcss'
+
+import {Bud, factory} from '@repo/test-kit/bud'
+import * as BudBabel from '@roots/bud-babel'
+import * as BudTypescript from '@roots/bud-typescript/src/index'
+
+describe('@roots/bud-typescript', () => {
+  let bud: Bud
+
+  beforeAll(async () => {
+    bud = await factory()
+  })
+
+  beforeEach(async () => {
+    bud.extensions.setStore({})
+    bud.use([BudBabel, BudTypescript])
+    await bud.api.processQueue()
+  })
+
+  it('name', () => {
+    expect(BudTypescript.name).toBe('@roots/bud-typescript')
+    expect(bud.extensions.get('@roots/bud-typescript').name).toBe(
+      '@roots/bud-typescript',
+    )
+  })
+
+  it('api', async () => {
+    expect(BudTypescript.api.typecheck).toBeInstanceOf(Function)
+    expect(
+      bud.extensions.get('@roots/bud-typescript')._module.api.typecheck,
+    ).toBeInstanceOf(Function)
+  })
+
+  it('provides callable typecheck method', async () => {
+    expect(bud.api.get('typecheck')()).toBeInstanceOf(Promise)
+    expect(bud.typecheck()).toBeInstanceOf(Bud)
+  })
+
+  it('enables typechecking when called with true', async () => {
+    await bud.api.call('typecheck', true)
+    expect(
+      bud.extensions.has('fork-ts-checker-webpack-plugin'),
+    ).toBeTruthy()
+  })
+
+  it('disables typechecking when called with false', async () => {
+    await bud.api.call('typecheck', false)
+    expect(
+      bud.extensions.has('fork-ts-checker-webpack-plugin'),
+    ).toBeFalsy()
+  })
+
+  it('enables typechecking when called with no options', async () => {
+    await bud.api.call('typecheck')
+    expect(
+      bud.extensions.has('fork-ts-checker-webpack-plugin'),
+    ).toBeTruthy()
+  })
+
+  it('has typecheck method that accepts options object', async () => {
+    const options = {
+      async: false,
+      typescript: {
+        useTypescriptIncrementalApi: true,
+        typescriptPath: require.resolve('typescript'),
+        diagnosticOptions: {
+          semantic: true,
+          syntactic: true,
+        },
+      },
+    }
+    await bud.api.call('typecheck', options)
+    expect(
+      bud.extensions.get('fork-ts-checker-webpack-plugin').options.all(),
+    ).toEqual(options)
+  })
+
+  it('has typecheck method that accepts fn callback', async () => {
+    await bud.api.call('typecheck', options => {
+      options.set('async', true)
+      return options
+    })
+
+    expect(
+      bud.extensions
+        .get('fork-ts-checker-webpack-plugin')
+        .options.get('async'),
+    ).toBe(true)
+  })
+
+  it('sets up ts module rule', async () => {
+    expect(bud.build.rules['ts']).toBeDefined()
+  })
+
+  it('adds ts and tsx extensions', async () => {
+    expect(bud.hooks.filter('build.resolve.extensions')).toContain('.ts')
+    expect(bud.hooks.filter('build.resolve.extensions')).toContain('.tsx')
+  })
+})


### PR DESCRIPTION
## Overview

- Add unit tests for `@roots/bud-typescript`
- Fixes `bud.typecheck`

refers: none
closes: none

## Type of change

- NONE: internal change
- 
<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
