### PR TITLE
feature: rule.includes as an array

### DIFF
--- a/sources/@roots/bud-api/src/api/methods/persist/index.ts
+++ b/sources/@roots/bud-api/src/api/methods/persist/index.ts
@@ -11,9 +11,8 @@ export const persist: persist = function (
   const ctx = this as Framework
 
   if (cacheStrategy === false) {
-    ctx.api.log('success', {
-      message: 'cache disabled',
-    })
+    ctx.api.log('success', {message: 'cache disabled'})
+
     ctx.hooks.on('build.cache', () => false)
     return ctx
   }
@@ -46,7 +45,7 @@ export const persist: persist = function (
       ctx.path('storage', 'cache', 'webpack'),
     )
     .hooks.on('build.cache.buildDependencies', () => ({
-      bud: ctx.project.get('dependencies'),
+      bud: Array.from(new Set<string>(ctx.project.get('dependencies'))),
     }))
     .hooks.on('build.cache.managedPaths', () => [ctx.path('modules')])
 

--- a/sources/@roots/bud-build/src/Build/rules.ts
+++ b/sources/@roots/bud-build/src/Build/rules.ts
@@ -16,7 +16,7 @@ export const js = (app: Framework) =>
   app.build
     .makeRule()
     .setTest(({store}) => store.get('patterns.js'))
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setUse([])
 
 /**
@@ -28,7 +28,7 @@ export const css = (app: Framework) =>
   app.build
     .makeRule()
     .setTest(({store}) => store.get('patterns.css'))
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setUse(({isProduction, build}) => [
       isProduction ? build.items.minicss : build.items.style,
       build.items.css,
@@ -43,7 +43,7 @@ export const cssModule = (app: Framework) =>
   app.build
     .makeRule()
     .setTest(({store}) => store.get('patterns.cssModule'))
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setUse(({isProduction, build}) => [
       isProduction ? build.items.minicss : build.items.style,
       build.items.cssModule,
@@ -58,7 +58,7 @@ export const image = (app: Framework): Rule =>
   app.build
     .makeRule()
     .setTest(({store}) => store.get('patterns.image'))
-    .setExclude(({store}) => store.get('patterns.modules'))
+    .setInclude(({path}) => [path('src')])
     .setType('asset/resource')
     .setGenerator(app => ({
       filename: app.store.is('features.hash', true)
@@ -78,7 +78,7 @@ export const webp = (app: Framework) =>
   app.build
     .makeRule()
     .setTest(({store}) => store.get('patterns.webp'))
-    .setExclude(({store}) => store.get('patterns.modules'))
+    .setInclude(({path}) => [path('src')])
     .setType('asset/resource')
     .setGenerator(app => ({
       filename: app.store.is('features.hash', true)
@@ -96,7 +96,7 @@ export const svg = (app: Framework) =>
   app.build
     .makeRule()
     .setTest(({store}) => store.get('patterns.svg'))
-    .setExclude(({store}) => store.get('patterns.modules'))
+    .setInclude(({path}) => [path('src')])
     .setType('asset/resource')
     .setGenerator(app => ({
       filename: app.store.is('features.hash', true)
@@ -114,8 +114,7 @@ export const font = (app: Framework) =>
     .makeRule()
     .setType('asset')
     .setTest(({store}) => store.get('patterns.font'))
-    .setExclude(({store}) => store.get('patterns.modules'))
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setGenerator(app => ({
       filename: app.store.is('features.hash', true)
         ? 'fonts/'.concat(app.store.get('hashFormat')).concat('[ext]')
@@ -131,7 +130,7 @@ export const json = (app: Framework) =>
   app.build
     .makeRule()
     .setType('json')
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setTest(({store}) => store.get('patterns.json'))
     .setParser({parse: json5Parser.parse})
 
@@ -144,7 +143,7 @@ export const yml = (app: Framework) =>
   app.build
     .makeRule()
     .setType('json')
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setTest(({store}) => store.get('patterns.yml'))
     .setParser({parse: yamlParser.parse})
 
@@ -156,7 +155,7 @@ export const yml = (app: Framework) =>
 export const html = (app: Framework) =>
   app.build
     .makeRule()
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setTest(({store}) => store.get('patterns.html'))
     .setUse(({build}) => [build.items.html])
 
@@ -168,7 +167,7 @@ export const html = (app: Framework) =>
 export const csv = (app: Framework) =>
   app.build
     .makeRule()
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setTest(({store}) => store.get('patterns.csv'))
     .setUse(({build}) => [build.items.csv])
 
@@ -180,7 +179,7 @@ export const csv = (app: Framework) =>
 export const xml = (app: Framework) =>
   app.build
     .makeRule()
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setTest(({store}) => store.get('patterns.xml'))
     .setUse(({build}) => [build.items.xml])
 
@@ -193,6 +192,6 @@ export const toml = (app: Framework) =>
   app.build
     .makeRule()
     .setType('json')
-    .setInclude(({path}) => path('src'))
+    .setInclude(({path}) => [path('src')])
     .setTest(({store}) => store.get('patterns.html'))
     .setParser({parse: tomlParser.parse})

--- a/sources/@roots/bud-build/src/Rule/index.ts
+++ b/sources/@roots/bud-build/src/Rule/index.ts
@@ -31,14 +31,14 @@ export class Rule extends Base implements FrameworkRule.Interface {
   /**
    * Include paths
    */
-  public include?: (app: Framework) => string
+  public include?: (app: Framework) => Array<string | RegExp>
 
   /**
    * {@inheritDoc @roots/bud-framework#Rule.Abstract.exclude}
    *
    * @public
    */
-  public exclude?: (app: Framework) => RegExp
+  public exclude?: (app: Framework) => Array<string | RegExp>
 
   /**
    * {@inheritDoc @roots/bud-framework#Rule.Abstract."type"}
@@ -162,7 +162,7 @@ export class Rule extends Base implements FrameworkRule.Interface {
    * @decorator `@bind`
    */
   @bind
-  public getInclude(): string {
+  public getInclude(): Array<string | RegExp> {
     return this.include ? this.include(this.app) : null
   }
 
@@ -173,7 +173,9 @@ export class Rule extends Base implements FrameworkRule.Interface {
    * @decorator `@bind`
    */
   @bind
-  public setInclude(include: Maybe<[Framework], string>): Rule {
+  public setInclude(
+    include: Maybe<[Framework], Array<string | RegExp>>,
+  ): Rule {
     this.include = this.normalizeInput(include)
     return this
   }
@@ -185,7 +187,7 @@ export class Rule extends Base implements FrameworkRule.Interface {
    * @decorator `@bind`
    */
   @bind
-  public getExclude(): RegExp {
+  public getExclude(): Array<string | RegExp> {
     return this.exclude ? this.exclude(this.app) : null
   }
 
@@ -196,7 +198,9 @@ export class Rule extends Base implements FrameworkRule.Interface {
    * @decorator `@bind`
    */
   @bind
-  public setExclude(exclude: Maybe<[Framework], RegExp>): Rule {
+  public setExclude(
+    exclude: Maybe<[Framework], Array<string | RegExp>>,
+  ): Rule {
     this.exclude = this.normalizeInput(exclude)
     return this
   }

--- a/sources/@roots/bud-framework/src/Build/Rule/index.ts
+++ b/sources/@roots/bud-framework/src/Build/Rule/index.ts
@@ -18,8 +18,8 @@ export interface Parser extends Record<string, any> {}
 export type Options = Partial<{
   test: Maybe<Array<Framework>, RegExp>
   use: Maybe<Array<Framework>, Array<Item.Interface>>
-  include: Maybe<Array<Framework>, string>
-  exclude: Maybe<Array<Framework>, RegExp>
+  include: Maybe<Array<Framework>, Array<string | RegExp>>
+  exclude: Maybe<Array<Framework>, Array<string | RegExp>>
   type: Maybe<Array<Framework>, string>
   parser: Maybe<Array<Framework>, Parser>
   generator: Maybe<Array<Framework>, any>
@@ -100,42 +100,46 @@ export interface Interface {
    *
    * @public
    */
-  exclude?: (app: Framework) => RegExp
+  exclude?: (app: Framework) => Array<string | RegExp>
 
   /**
    * Get the value of `exclude`
    *
    * @public
    */
-  getExclude(): RegExp
+  getExclude(): Array<string | RegExp>
 
   /**
    * Set the value of `exclude`
    *
    * @public
    */
-  setExclude(exclude: Maybe<[Framework], RegExp>): Rule.Interface
+  setExclude(
+    exclude: Maybe<[Framework], Array<string | RegExp>>,
+  ): Rule.Interface
 
   /**
    * Include paths
    *
    * @public
    */
-  include?: (app: Framework) => string
+  include?: (app: Framework) => Array<string | RegExp>
 
   /**
    * Get the value of `include`
    *
    * @public
    */
-  getInclude(): string
+  getInclude(): Array<string | RegExp>
 
   /**
    * Set the value of `include`
    *
    * @public
    */
-  setInclude(include: Maybe<[Framework], string>): Rule.Interface
+  setInclude(
+    include: Maybe<[Framework], Array<string | RegExp>>,
+  ): Rule.Interface
 
   /**
    * Type

--- a/tests/unit/bud-build/__snapshots__/config.test.ts.snap
+++ b/tests/unit/bud-build/__snapshots__/config.test.ts.snap
@@ -1,20 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`bud.build.config has expected cache default 1`] = `
-Object {
-  "buildDependencies": Object {
-    "bud": Any<Array>,
-  },
-  "cacheDirectory": StringContaining ".budfiles",
-  "managedPaths": Any<Array>,
-  "type": "filesystem",
-  "version": Any<String>,
-}
-`;
-
 exports[`bud.build.config has expected default css rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": Object {},
   "use": Array [
     Object {
@@ -40,7 +30,9 @@ Object {
 
 exports[`bud.build.config has expected default cssModule rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": Object {},
   "use": Array [
     Object {
@@ -61,7 +53,9 @@ Object {
 
 exports[`bud.build.config has expected default csv rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": Object {},
   "use": Array [
     Object {
@@ -73,11 +67,12 @@ Object {
 
 exports[`bud.build.config has expected default font rule 1`] = `
 Object {
-  "exclude": /\\(node_modules\\|bower_components\\)/,
   "generator": Object {
     "filename": "fonts/[name][ext]",
   },
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": /\\\\\\.\\(ttf\\|otf\\|eot\\|woff2\\?\\|ico\\)\\$/,
   "type": "asset",
 }
@@ -85,7 +80,9 @@ Object {
 
 exports[`bud.build.config has expected default html rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": Object {},
   "use": Array [
     Object {
@@ -97,10 +94,12 @@ Object {
 
 exports[`bud.build.config has expected default image rule 1`] = `
 Object {
-  "exclude": Object {},
   "generator": Object {
     "filename": "images/[name][ext]",
   },
+  "include": Array [
+    "/srv/bud/tests/util/project/src",
+  ],
   "test": Object {},
   "type": "asset/resource",
 }
@@ -108,7 +107,9 @@ Object {
 
 exports[`bud.build.config has expected default js rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": Object {},
   "use": Array [
     Object {
@@ -121,7 +122,9 @@ Object {
 
 exports[`bud.build.config has expected default json rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "parser": Object {
     "parse": [Function],
   },
@@ -141,10 +144,12 @@ Object {
 
 exports[`bud.build.config has expected default svg rule 1`] = `
 Object {
-  "exclude": /\\(node_modules\\|bower_components\\)/,
   "generator": Object {
     "filename": "svg/[name][ext]",
   },
+  "include": Array [
+    "/srv/bud/tests/util/project/src",
+  ],
   "test": Object {},
   "type": "asset/resource",
 }
@@ -152,7 +157,9 @@ Object {
 
 exports[`bud.build.config has expected default toml rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "parser": Object {
     "parse": [Function],
   },
@@ -163,10 +170,12 @@ Object {
 
 exports[`bud.build.config has expected default webp rule 1`] = `
 Object {
-  "exclude": /\\(node_modules\\|bower_components\\)/,
   "generator": Object {
     "filename": "images/[name][ext]",
   },
+  "include": Array [
+    "/srv/bud/tests/util/project/src",
+  ],
   "test": Object {},
   "type": "asset/resource",
 }
@@ -174,7 +183,9 @@ Object {
 
 exports[`bud.build.config has expected default xml rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "test": Object {},
   "use": Array [
     Object {
@@ -186,7 +197,9 @@ Object {
 
 exports[`bud.build.config has expected default yaml rule 1`] = `
 Object {
-  "include": StringContaining "src",
+  "include": Array [
+    StringContaining "src",
+  ],
   "parser": Object {
     "parse": [Function],
   },

--- a/tests/unit/bud-build/config.test.ts
+++ b/tests/unit/bud-build/config.test.ts
@@ -22,15 +22,24 @@ describe('bud.build.config', function () {
   })
 
   it('has expected cache default', () => {
-    expect(bud.build.config.cache).toMatchSnapshot({
-      type: 'filesystem',
-      buildDependencies: {
-        bud: expect.any(Array),
-      },
-      cacheDirectory: expect.stringContaining('.budfiles'),
-      managedPaths: expect.any(Array),
-      version: expect.any(String),
-    })
+    const cache = bud.build.config.cache as any
+
+    expect(cache.type).toStrictEqual('filesystem')
+
+    expect(cache.buildDependencies.bud).toStrictEqual([
+      expect.stringContaining('package.json'),
+      expect.stringContaining('bud.config.js'),
+    ])
+
+    expect(cache.cacheDirectory).toStrictEqual(
+      expect.stringContaining('.budfiles/cache/webpack'),
+    )
+
+    expect(cache.managedPaths).toStrictEqual([
+      expect.stringContaining('node_modules'),
+    ])
+
+    expect(cache.version).toStrictEqual(expect.any(String))
   })
 
   it('has expected context default', () => {
@@ -137,7 +146,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[0],
     ).toMatchSnapshot({
       test: /\.(js|jsx)/,
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       use: [
         {
           loader: expect.any(String),
@@ -152,7 +161,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[1],
     ).toMatchSnapshot({
       test: /\.css$/,
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       use: [
         {
           loader: expect.stringContaining(
@@ -181,7 +190,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[2],
     ).toMatchSnapshot({
       test: /\.module.css$/,
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       use: [
         {
           loader: expect.stringContaining(
@@ -204,7 +213,6 @@ describe('bud.build.config', function () {
     expect(
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[3],
     ).toMatchSnapshot({
-      exclude: /(node_modules|bower_components)/,
       generator: {
         filename: 'images/[name][ext]',
       },
@@ -242,7 +250,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[6],
     ).toMatchSnapshot({
       type: 'asset',
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       generator: {filename: 'fonts/[name][ext]'},
     })
   })
@@ -251,7 +259,7 @@ describe('bud.build.config', function () {
     expect(
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[7],
     ).toMatchSnapshot({
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       parser: {parse: json5.parse},
       test: /\.json$/,
       type: 'json',
@@ -262,7 +270,7 @@ describe('bud.build.config', function () {
     expect(
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[8],
     ).toMatchSnapshot({
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       parser: {parse: yaml.parse},
       test: /\.ya?ml$/,
       type: 'json',
@@ -274,7 +282,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[9],
     ).toMatchSnapshot({
       test: /\.(html?)$/,
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       use: [
         {
           loader: expect.stringContaining('html-loader/dist/cjs.js'),
@@ -288,7 +296,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[10],
     ).toMatchSnapshot({
       test: /\.(csv|tsv)$/,
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       use: [
         {
           loader: expect.stringContaining('csv-loader/index.js'),
@@ -302,7 +310,7 @@ describe('bud.build.config', function () {
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[11],
     ).toMatchSnapshot({
       test: /\.xml$/,
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       use: [
         {
           loader: expect.stringContaining('/xml-loader/index.js'),
@@ -315,7 +323,7 @@ describe('bud.build.config', function () {
     expect(
       (bud.build.config.module.rules[1] as RuleSetRule).oneOf[12],
     ).toMatchSnapshot({
-      include: expect.stringContaining('src'),
+      include: [expect.stringContaining('src')],
       parser: {
         parse: toml.parse,
       },

--- a/tests/unit/bud-build/rule.test.ts
+++ b/tests/unit/bud-build/rule.test.ts
@@ -53,7 +53,7 @@ describe('Build Rule', function () {
   it('getExclude', () => {
     const definition = {
       test: /.foo$/,
-      exclude: /.bar$/,
+      exclude: [/.bar$/],
     }
 
     const rule = new Rule(bud, definition)
@@ -64,7 +64,7 @@ describe('Build Rule', function () {
   it('setExclude from fn', () => {
     const rule = new Rule(bud, {test: /.foo$/})
 
-    const mutationFn = () => /.js$/
+    const mutationFn = () => [/.js$/]
     rule.setExclude(mutationFn)
 
     expect(rule.exclude).toEqual(mutationFn)
@@ -73,11 +73,9 @@ describe('Build Rule', function () {
   it('setExclude from obj', () => {
     const rule = new Rule(bud, {test: /.foo$/})
 
-    const mutation = /.js$/
+    const mutation = [/.js$/]
     rule.setExclude(mutation)
 
-    expect<RegExp>(rule.exclude(bud)).toStrictEqual<RegExp>(
-      mutation,
-    )
+    expect(rule.exclude(bud)).toStrictEqual(mutation)
   })
 })

--- a/tests/unit/bud/services/project/project.test.ts
+++ b/tests/unit/bud/services/project/project.test.ts
@@ -1,6 +1,6 @@
-import {fs} from '@roots/bud-support'
+import {beforeAll, describe, expect, it} from '@jest/globals'
 import {Bud, factory} from '@repo/test-kit/bud'
-import {expect, describe, beforeAll, it} from '@jest/globals'
+import {fs} from '@roots/bud-support'
 
 const PROJECT_MANIFEST_PATH = `${process.cwd()}/tests/util/project/package.json`
 const PROJECT_BUD_PROFILE_PATH = `${process.cwd()}/tests/util/project/.budfiles/bud/profile.json`
@@ -39,9 +39,7 @@ describe('bud.project', function () {
   })
 
   it('has evn records matching profile.json artifact', async () => {
-    expect(bud.project.get('env.all')).toMatchSnapshot(
-      profile.env.all,
-    )
+    expect(bud.project.get('env.all')).toMatchSnapshot(profile.env.all)
     expect(bud.project.get('env.public')).toMatchSnapshot(
       profile.env.public,
     )
@@ -62,9 +60,7 @@ describe('bud.project', function () {
   })
 
   it('references @roots/bud-babel', async () => {
-    expect(
-      bud.project.get('modules.@roots/bud-babel'),
-    ).toMatchSnapshot({
+    expect(bud.project.get('modules.@roots/bud-babel')).toMatchSnapshot({
       bud: {type: 'extension'},
       name: '@roots/bud-babel',
       peerDependencies: {},
@@ -90,9 +86,7 @@ describe('bud.project', function () {
   })
 
   it('references @roots/bud-eslint', async () => {
-    expect(
-      bud.project.get('modules.@roots/bud-eslint'),
-    ).toMatchSnapshot({
+    expect(bud.project.get('modules.@roots/bud-eslint')).toMatchSnapshot({
       bud: {
         type: 'extension',
       },
@@ -107,9 +101,7 @@ describe('bud.project', function () {
   })
 
   it('references @roots/bud-postcss', async () => {
-    expect(
-      bud.project.get('modules.@roots/bud-postcss'),
-    ).toMatchSnapshot({
+    expect(bud.project.get('modules.@roots/bud-postcss')).toMatchSnapshot({
       bud: {
         type: 'extension',
       },


### PR DESCRIPTION
## Overview

In regards to `config.module.rules` (`RuleSetItem`). 

- removes all use of `excludes`, opting instead for `includes` only
- `includes` now specified as an `Array` of `String` or `RegExp` values

This sets us up nicely to provide a facade developers can use to specify directories to resolve source modules from (by default it is restricted to the bud `src` path).

The API already supports this with either a callback (preferred so you can use `bud.path` and other dynamic utils rather than just plunking in strings):

```ts
bud.build.rules.js.setIncludes((bud) => [/* ...paths */])
```

or an array of values: (no problem for an end user to directly set paths like this):

```ts
bud.build.rules.js.setIncludes([/* ...paths */])
```

But eventually we want some sort of function to wrap that API, since it's a little "in the weeds". Maybe something like:

```ts
bud.resolveFrom([/* ...paths */])
bud.resolveFrom(() => [/* ...paths */])
bud.resolveFrom([/* ...paths */], [/* optional -- specify rules to apply to */])
```


refers: none
closes: none

## Type of change

- MINOR: feature

This PR includes breaking changes to the following core packages:

- Technically, this breaks the typings if a user is specifying includes as a string.
- But, it will still technically work as an array or a string.
- Webpack accepts either a string or an array. Going forward, Bud always assuming it is supplied as an array.

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
