### PR TITLE
fix: conditionally externalize wordpress dependencies

### DIFF
--- a/sources/@roots/bud-preset-wordpress/package.json
+++ b/sources/@roots/bud-preset-wordpress/package.json
@@ -49,10 +49,7 @@
       "@roots/bud-entrypoints",
       "@roots/bud-postcss",
       "@roots/bud-preset-recommend",
-      "@roots/bud-react",
-      "@roots/bud-wordpress-externals",
-      "@roots/bud-wordpress-dependencies",
-      "@roots/bud-wordpress-manifests"
+      "@roots/bud-react"
     ]
   },
   "devDependencies": {

--- a/sources/@roots/bud-preset-wordpress/src/index.ts
+++ b/sources/@roots/bud-preset-wordpress/src/index.ts
@@ -7,42 +7,6 @@
  * @see https://roots.io/bud
  * @see https://github.com/roots/bud
  *
- * @remarks
- * - 💁 Composable - Build boss web applications with a modular, configurable build system
- *
- * - 💪 Modern - Modern framework that scales from a single file to thousands of lines of code
- *
- * - 🌱 Easy - Low bundle size and fast build times
- *
- * @remarks
- * This preset is a wrapper for the following presets:
- *
- * - {@link @roots/bud-preset-recommend# | @roots/bud-preset-recommend}
- *
- * - {@link @roots/bud-react# | @roots/bud-react}
- *
- * - {@link @roots/bud-wordpress-dependencies# | @roots/bud-wordpress-dependencies}
- *
- * - {@link @roots/bud-wordpress-externals# | @roots/bud-wordpress-externals}
- *
- * - {@link @roots/bud-wordpress-manifests# | @roots/bud-wordpress-manifests}
- *
- * @example
- * ```js
- * const wp = require('@roots/bud-preset-wordpress')
- *
- * module.exports = (app: Framework) => {
- *   app.use(wp)
- * }
- * ```
- *
- * @remarks
- * - 💁 Composable - Build exceptional applications with a modular, configurable build system
- *
- * - 💪 Modern - Modern framework written in TypeScript with an expressive API
- *
- * - 🌱 Easy - Low bundle size and fast build times
- *
  * @packageDocumentation
  */
 


### PR DESCRIPTION
## Overview

There is [at least one report of incompatibility between the HMR scripts and externalized wordpress dependencies](https://github.com/roots/bud/issues/1181). I don't personally have this problem. Are there others who are having problems with hot reload of React components when using the `@roots/bud-preset-wordpress` or `@roots/sage`?

I don't know what is the correct thing to do here or how to advise users about it. Open to thoughts, suggestions, feedback. 

Perhaps it makes most sense to make this opt-in? `@roots/bud-preset-wordpress` could register a function that takes a boolean to either enable or disable the externals plugin. 

Lastly, this change would require a patch to Acorn. Acorn assumes that the manifest will contain a `dependencies` array and this change does not generate this array when compiling in development mode. 

refers: 
- https://github.com/roots/bud/issues/1181

edits:
- Removed draft user advisement as `window.wp.React` is distinct from `window.wp.element`. 

## Type of change

- MINOR: feature

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- `@roots/bud-wordpress-preset`
- `@roots/sage`

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
