### PR TITLE
fix: json logging errors

### DIFF
--- a/sources/@roots/bud-api/src/api/api.service.ts
+++ b/sources/@roots/bud-api/src/api/api.service.ts
@@ -80,7 +80,8 @@ export class Api extends Framework.Service implements Framework.Api {
   public async call(name: string, ...args: any[]) {
     this.log('log', {
       message: `executing ${chalk.blue(name)}`,
-      suffix: args && !isEmpty(args) ? JSON.stringify(args) : 'none',
+      suffix:
+        args && !isEmpty(args) ? this.app.json.stringify(args) : 'none',
     })
 
     // get a reference to the callable

--- a/sources/@roots/bud-api/src/api/facade/facade.factory.ts
+++ b/sources/@roots/bud-api/src/api/facade/facade.factory.ts
@@ -22,9 +22,9 @@ export const factory: factory = (name: string): facade =>
   function facade(...args: any[]): Framework {
     this.api.queue.push([name, args])
 
-    this.api.log('log', {
+    this.log({
       message: `facade added to queue: ${chalk.cyan(name)}`,
-      suffix: JSON.stringify(args),
+      suffix: this.json.stringify(args),
     })
 
     return this

--- a/sources/@roots/bud-build/src/Build/index.ts
+++ b/sources/@roots/bud-build/src/Build/index.ts
@@ -3,9 +3,9 @@ import {
   Items,
   Loaders,
   Rules,
+  Service,
 } from '@roots/bud-framework'
-import {Service} from '@roots/bud-framework'
-import {bind, chalk, fs, lodash, prettyFormat} from '@roots/bud-support'
+import {bind, chalk, fs, lodash} from '@roots/bud-support'
 import type * as Webpack from 'webpack'
 import {Configuration} from 'webpack'
 
@@ -194,7 +194,11 @@ export class Build extends Service implements Contract.Interface {
 
       await writeFile(
         filePath,
-        `module.exports = (${prettyFormat(this.config)})`,
+        `module.exports = ${this.app.json.stringify(
+          this.config,
+          null,
+          2,
+        )}`,
       )
     } catch (error) {
       this.log('error', `failed to write webpack.config.json`)

--- a/sources/@roots/bud-framework/src/Framework/parser/json.ts
+++ b/sources/@roots/bud-framework/src/Framework/parser/json.ts
@@ -1,3 +1,4 @@
+import {jsonStringify} from '@roots/bud-support'
 import {readFile, writeFile} from 'fs-extra'
 import json5 from 'json5'
 
@@ -10,3 +11,5 @@ export const write = async (file: string, data: any): Promise<void> => {
   const source = json5.stringify(data)
   await writeFile(file, source)
 }
+
+export const stringify = jsonStringify


### PR DESCRIPTION
## Overview

Saw this on discourse: https://discourse.roots.io/t/access-site-from-local-network-with-bud/22131/6

This isn't right. It should be OK to use a webpack plugin directly with `app.use`. The logic with extensions is fine. The problem is the logging of the plugin object -- the webpack plugin from the post has a circular reference.

This fix:

- makes a safe json stringifier available from `bud.json.stringify`
- sanitizes potentially dangerous values in `bud.use` with `bud.json.stringify`
- sanitizes `.budfiles/bud/webpack.config.js` with the same fn call (for the same reason)

refers: 
- #973 

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
