### PR TITLE
fix: @roots/bud-entrypoints option export

### DIFF
--- a/sources/@roots/bud-entrypoints/src/index.ts
+++ b/sources/@roots/bud-entrypoints/src/index.ts
@@ -19,4 +19,4 @@ declare module '@roots/bud-framework' {
   }
 }
 
-export const {name, make} = BudEntrypointsExtension
+export const {name, options, make} = BudEntrypointsExtension


### PR DESCRIPTION
## Overview

Fixes issue resulting from `options` not being exported from `@roots/bud-entrypoints`

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
