### PR TITLE
fix: devtool facade typings

### DIFF
--- a/sources/@roots/bud-api/src/api/facade/facade.interface.ts
+++ b/sources/@roots/bud-api/src/api/facade/facade.interface.ts
@@ -2,7 +2,7 @@ import type * as alias from '../methods/alias'
 import type * as assets from '../methods/assets'
 import type {config} from '../methods/config'
 import type {define} from '../methods/define'
-import type {devtool} from '../methods/devtool'
+import type * as devtool from '../methods/devtool'
 import type {facade as entryFacade} from '../methods/entry'
 import type {experiments} from '../methods/experiments'
 import type {externals} from '../methods/externals'
@@ -210,7 +210,7 @@ export class Facade {
    *
    * @public
    */
-  public devtool: devtool
+  public devtool: devtool.facade
 
   /**
    * Bundle vendor modules separately from application code.

--- a/sources/@roots/bud-api/src/api/methods/devtool/index.ts
+++ b/sources/@roots/bud-api/src/api/methods/devtool/index.ts
@@ -5,6 +5,10 @@ export interface devtool {
   (devtool?: Configuration['devtool']): Promise<Framework>
 }
 
+export interface facade {
+  (devtool?: Configuration['devtool']): Framework
+}
+
 export const devtool: devtool = async function (devtool = false) {
   this as Framework
 


### PR DESCRIPTION
## Overview

`bud.devtool` lacks facade typings. This change adds this typing.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
