### PR TITLE
wip: improve alias support

### DIFF
--- a/sources/@roots/bud-server/src/server/server.watcher.ts
+++ b/sources/@roots/bud-server/src/server/server.watcher.ts
@@ -11,6 +11,13 @@ export class Watcher {
   public instance: FSWatcher
 
   /**
+   * Class constructor
+   *
+   * @param app - Application instance
+   */
+  public constructor(public app: Framework) {}
+
+  /**
    * Get watched files
    *
    * @public
@@ -22,22 +29,21 @@ export class Watcher {
 
     if (!files?.length) return []
 
-    const globResults = await globby.globby(
-      files.map((file: string) => this.app.path('project', file)),
-      options,
-    )
+    return await globby.globby(
+      files.map((file: string) => {
+        this.app.build.config.resolve.alias &&
+          Object.entries(this.app.build.config.resolve.alias).map(
+            ([key, value]) => {
+              file = file.replace(key, value)
+            },
+          )
 
-    return globResults.map(entry =>
-      typeof entry === 'object' ? entry.path : entry,
+        if (!file.startsWith('/')) file = this.app.path('project', file)
+
+        return file
+      }, options),
     )
   }
-
-  /**
-   * Class constructor
-   *
-   * @param app - Application instance
-   */
-  public constructor(public app: Framework) {}
 
   /**
    * Initialize watch files


### PR DESCRIPTION
## Overview

`bud.watch` and `bud.assets` should support aliases set up in `bud.alias`.

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- MINOR: feature

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
