### PR TITLE
fix: react-refresh / babel integration

### DIFF
--- a/sources/@roots/bud-babel/src/babel.config.ts
+++ b/sources/@roots/bud-babel/src/babel.config.ts
@@ -90,7 +90,7 @@ export class Config {
     ...args: [string] | [string, string] | [string, [string, string]]
   ): this {
     if (args.length == 1) {
-      this.plugins[args[0]] = [args[0]]
+      this.plugins[args[0]] = [require.resolve(args[0])]
       return this
     }
 

--- a/sources/@roots/bud-babel/src/babel.config.ts
+++ b/sources/@roots/bud-babel/src/babel.config.ts
@@ -86,13 +86,16 @@ export class Config {
   }
 
   @bind
-  public setPlugin(name: string, plugin: [any, any] | string): this {
-    if (Array.isArray(plugin)) {
-      this.plugins[name] = plugin
+  public setPlugin(
+    ...args: [string] | [string, string] | [string, [string, string]]
+  ): this {
+    if (args.length == 1) {
+      this.plugins[args[0]] = [args[0]]
       return this
     }
 
-    this.plugins[name] = [plugin]
+    this.plugins[args[0]] = Array.isArray(args[1]) ? args[1] : [args[1]]
+
     return this
   }
 

--- a/sources/@roots/bud-babel/src/babel.extension.ts
+++ b/sources/@roots/bud-babel/src/babel.extension.ts
@@ -1,67 +1,100 @@
 import {Item, Loader} from '@roots/bud-build'
-import {Framework} from '@roots/bud-framework'
+import {Extension, Framework} from '@roots/bud-framework'
 
 import {Config} from './babel.config'
 import {DEFAULT_PLUGINS, DEFAULT_PRESETS} from './babel.constants'
 
 /**
- * Adds Babel transpiler support to Framework projects
+ * Babel options
  *
  * @public
  */
-export const name = '@roots/bud-babel'
+export interface Options {
+  cacheDirectory: string
+  env: any
+  root: string
+  presets?: any
+  plugins?: any
+}
 
 /**
- * Exposes app.babel configuration utility
+ * Adds Babel transpiler support
  *
  * @public
  */
-export const mixin = async app => ({
+export interface BabelExtension extends Extension.Module<Options> {
+  name: '@roots/bud-babel'
+  mixin: (app: Framework) => Promise<{babel: [typeof Config, Framework]}>
+  options: (app: Framework) => Options
+  register: (app: Framework) => Promise<void>
+}
+
+/**
+ * Extension name
+ *
+ * @public
+ */
+export const name: BabelExtension['name'] = '@roots/bud-babel'
+
+/**
+ * Bud mixins
+ *
+ * @remarks
+ * Registers `bud.babel` configuration class
+ *
+ * @public
+ */
+export const mixin: BabelExtension['mixin'] = async app => ({
   babel: [Config, app],
 })
 
 /**
- * Extension register event
+ * Extension options
  *
  * @public
  */
-export const register = async (app: Framework) => {
-  app.build.loaders.babel = new Loader(() =>
-    require.resolve('babel-loader'),
-  )
-
-  app.build.items.babel = new Item({
-    loader: ({build}) => build.loaders.babel,
-    options: app => {
-      const options: {
-        cacheDirectory: string
-        env: any
-        root: string
-        presets?: any
-        plugins?: any
-      } = {
-        cacheDirectory: app.path('storage', 'cache', 'babel'),
-        env: {
-          development: {
-            compact: false,
-          },
-        },
-        root: app.path('src'),
-      }
-
-      if (app.babel?.presets) {
-        options.presets = Object.values(app.babel.presets)
-      }
-
-      if (app.babel?.plugins) {
-        options.plugins = Object.values(app.babel.plugins)
-      }
-
-      return options
+export const options: BabelExtension['options'] = app => ({
+  cacheDirectory: app.path('storage', 'cache', 'babel'),
+  env: {
+    development: {
+      compact: false,
     },
+  },
+  root: app.path('src'),
+  ...(app.babel.presets
+    ? {presets: Object.values(app.babel.presets)}
+    : {}),
+  ...(app.babel.plugins
+    ? {plugins: Object.values(app.babel.plugins)}
+    : {}),
+})
+
+/**
+ * Extension registration
+ *
+ * @public
+ */
+export const register: BabelExtension['register'] = async app => {
+  /**
+   * Babel loader
+   */
+  app.build.loaders.babel = new Loader(require.resolve('babel-loader'))
+
+  /**
+   * Babel ruleset item
+   */
+  app.build.items.babel = new Item({
+    loader: app => app.build.loaders.babel,
+    options: app => app.extensions.get('@roots/bud-babel').options.all(),
   })
 
-  app.build.rules.js.setUse([app.build.items.babel])
+  /**
+   * Babel ruleset rule
+   */
+  app.build.rules.js.setUse(app => [app.build.items.babel])
 
+  /**
+   * Default babel presets and plugins
+   */
   app.babel.setPresets(DEFAULT_PRESETS).setPlugins(DEFAULT_PLUGINS)
 }

--- a/sources/@roots/bud-babel/src/index.ts
+++ b/sources/@roots/bud-babel/src/index.ts
@@ -3,7 +3,7 @@
 
 /**
  * The {@link @roots/bud-babel# | @roots/bud-babel extension} adds Babel
- * transpilation to {@link @roots/bud-framework# | @roots/bud-framework}.
+ * support to {@link @roots/bud-framework# | @roots/bud-framework}.
 
  * @see https://roots.io/bud
  * @see https://github.com/roots/bud
@@ -11,54 +11,6 @@
  * @packageDocumentation
  */
 
-import '@roots/bud'
-import '@roots/bud-framework'
+import './typings'
 
-import {Item, Loader} from '@roots/bud-build'
-
-import {Config} from './babel.config'
-import {mixin, name, register} from './babel.extension'
-
-interface BabelExtension {
-  name: typeof name
-  mixin: typeof mixin
-  register: typeof register
-}
-
-declare module '@roots/bud-framework' {
-  interface Framework {
-    babel: Config
-  }
-
-  interface Modules {
-    '@roots/bud-babel': BabelExtension
-  }
-
-  interface Loaders {
-    babel: Loader
-  }
-
-  interface Items {
-    babel: Item
-  }
-}
-
-declare module '@roots/bud' {
-  interface Bud {
-    babel: Config
-  }
-
-  interface Modules {
-    '@roots/bud-babel': BabelExtension
-  }
-
-  interface Loaders {
-    babel: Loader
-  }
-
-  interface Items {
-    babel: Item
-  }
-}
-
-export {name, mixin, register}
+export {mixin, name, options, register} from './babel.extension'

--- a/sources/@roots/bud-babel/src/typings.ts
+++ b/sources/@roots/bud-babel/src/typings.ts
@@ -1,0 +1,25 @@
+import '@roots/bud'
+import '@roots/bud-framework'
+
+import {Item, Loader} from '@roots/bud-build'
+
+import {Config} from './babel.config'
+import {BabelExtension} from './babel.extension'
+
+declare module '@roots/bud-framework' {
+  interface Framework {
+    babel: Config
+  }
+
+  interface Modules {
+    '@roots/bud-babel': BabelExtension
+  }
+
+  interface Loaders {
+    babel: Loader
+  }
+
+  interface Items {
+    babel: Item
+  }
+}

--- a/sources/@roots/bud-react/package.json
+++ b/sources/@roots/bud-react/package.json
@@ -109,14 +109,18 @@
     "tslib": "2.3.1"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-refresh": "0.11.0"
   },
   "peerDependenciesMeta": {
     "react": {
       "optional": true
     },
     "react-dom": {
+      "optional": true
+    },
+    "react-refresh": {
       "optional": true
     }
   }

--- a/sources/@roots/bud-react/src/react-refresh/extension.ts
+++ b/sources/@roots/bud-react/src/react-refresh/extension.ts
@@ -21,10 +21,7 @@ export interface ReactRefreshExtension
 
 export const ReactRefreshExtension: ReactRefreshExtension = {
   name: '@pmmmwh/react-refresh-webpack-plugin',
-
   options: {overlay: false},
-
-  make: opt => new RefreshPlugin(opt.all()),
-
-  when: ({isDevelopment}) => isDevelopment,
+  make: options => new RefreshPlugin(options.all()),
+  when: app => app.isDevelopment,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3667,12 +3667,15 @@ __metadata:
     type-fest: 2.11.2
     webpack: 5.68.0
   peerDependencies:
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-refresh: 0.11.0
   peerDependenciesMeta:
     react:
       optional: true
     react-dom:
+      optional: true
+    react-refresh:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Overview

- Fixes react-refresh / babel integration
- Specifies `react-refresh` as an optional npm peer module.
- Improves `babel.setPlugin` method: a plugin can now be set from a string: `babel.setPlugin('babel-plugin-name')`. Assuming there are no associated options (which is the case for `react-refresh/babel`.
- Surfaces babel loader options as extension options: `bud.extensions.get('@roots/bud-babel').options.set('option', value)` works like you (might) expect.
- Cleans up extension entrypoint

`reactRefresh` is still off by default. It can be enabled with `.reactRefresh()`. I've had luck using it with Sage.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
