### PR TITLE
fix/cannot-resolve-eslit-config

### DIFF
--- a/sources/@roots/bud-react/eslint-config/index.js
+++ b/sources/@roots/bud-react/eslint-config/index.js
@@ -5,7 +5,7 @@
  */
 module.exports = {
   plugins: ['react', 'react-hooks', 'jsx-a11y'],
-  extends: ['@roots/bud-babel', 'plugin:react/recommended'],
+  extends: [require.resolve('@roots/bud-babel/eslint-config'), 'plugin:react/recommended'],
   plugins: ['react-hooks', 'jsx-a11y'],
   settings: {
     react: {


### PR DESCRIPTION
Cannot resolve esling-config

## Overview

When loading eslint configs with latest version getting error, that eslint cannot resolve extend of `@roots/bud-babel`

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

@roots/bud

### Adds

- `require.resolve('@roots/bud-babel/eslint-config')`

### Removes

- `'@roots/bud-babel'`
