### PR TITLE
Disable selector-id-pattern in Sage config

### DIFF
--- a/sources/@roots/sage/stylelint-config/index.js
+++ b/sources/@roots/sage/stylelint-config/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'no-descending-specificity': null,
     'no-empty-source': null,
     'selector-class-pattern': null,
+    'selector-id-pattern': null,
     'string-quotes': null,
     'value-list-comma-newline-after': null,
   },


### PR DESCRIPTION
## Overview

Like `selector-class-pattern`, disabling the `selector-id-pattern` rule allows you to style certain WordPress core IDs (e.g., `#login_error`).

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- MINOR: feature

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
