### PR TITLE
Ignore Tailwind theme function in Stylelint config

### DIFF
--- a/sources/@roots/bud-tailwindcss/stylelint-config/index.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/index.js
@@ -30,5 +30,13 @@ module.exports = {
         ],
       },
     ],
+    "function-no-unknown": [
+      true,
+      {
+        "ignoreFunctions": [
+          "theme",
+        ],
+      },
+    ],
   },
 }


### PR DESCRIPTION
## Overview

When using the Tailwind theme() function in CSS Stylelint throws an error. This function is in core Tailwind, so I think it would make sense to ignore it in the default config.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
