### PR TITLE
fix: add scss stylelint rules for tailwind

### DIFF
--- a/sources/@roots/bud-tailwindcss/package.json
+++ b/sources/@roots/bud-tailwindcss/package.json
@@ -42,7 +42,8 @@
   "types": "./types/index.d.ts",
   "exports": {
     ".": "./lib/cjs/index.js",
-    "./stylelint-config": "./stylelint-config/index.js"
+    "./stylelint-config": "./stylelint-config/index.js",
+    "./stylelint-config/scss": "./stylelint-config/scss/index.js"
   },
   "bud": {
     "type": "extension",

--- a/sources/@roots/bud-tailwindcss/stylelint-config/base.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/base.js
@@ -1,0 +1,9 @@
+module.exports = {
+  'at-rule-no-unknown': require('./rules/at-rule-no-unknown'),
+  'function-no-unknown': [
+    true,
+    {
+      ignoreFunctions: ['theme'],
+    },
+  ],
+};

--- a/sources/@roots/bud-tailwindcss/stylelint-config/index.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/index.js
@@ -1,42 +1,5 @@
 module.exports = {
   rules: {
-    'at-rule-no-unknown': [
-      true,
-      {
-        ignoreAtRules: [
-          'extend',
-          'at-root',
-          'debug',
-          'warn',
-          'error',
-          'if',
-          'else',
-          'for',
-          'each',
-          'while',
-          'mixin',
-          'include',
-          'content',
-          'return',
-          'tailwind',
-          'apply',
-          'responsive',
-          'variants',
-          'screen',
-          'function',
-          'use',
-          'forward',
-          'layer',
-        ],
-      },
-    ],
-    "function-no-unknown": [
-      true,
-      {
-        "ignoreFunctions": [
-          "theme",
-        ],
-      },
-    ],
+    ...require('./base'),
   },
-}
+};

--- a/sources/@roots/bud-tailwindcss/stylelint-config/rules/at-rule-no-unknown.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/rules/at-rule-no-unknown.js
@@ -1,0 +1,35 @@
+/**
+ * at-rule-no-unknown
+ *
+ * @see {@link https://github.com/roots/bud/issues/1226}
+ */
+module.exports = [
+  true,
+  {
+    ignoreAtRules: [
+      'extend',
+      'at-root',
+      'debug',
+      'warn',
+      'error',
+      'if',
+      'else',
+      'for',
+      'each',
+      'while',
+      'mixin',
+      'include',
+      'content',
+      'return',
+      'tailwind',
+      'apply',
+      'responsive',
+      'variants',
+      'screen',
+      'function',
+      'use',
+      'forward',
+      'layer',
+    ],
+  },
+];

--- a/sources/@roots/bud-tailwindcss/stylelint-config/scss/index.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/scss/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    ...require('../base'),
+    'no-invalid-position-at-import-rule': null,
+    'scss/at-rule-no-unknown': require('../rules/at-rule-no-unknown'),
+  },
+};


### PR DESCRIPTION
## Overview

Adds stylelint support for using Tailwind in scss. Adds the following rules:

- `no-invalid-position-at-import-rule`: Disables CSS import rule in scss files
- `scss/at-rule-no-unknown`: Sets the at-rules for use with [stylelint-config-recommend-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss/blob/master/index.js)

An example `.stylelintrc` using Tailwind with scss might look like this:

```json
{
  "extends": [
    "@roots/bud-sass/stylelint-config",
    "@roots/sage/stylelint-config",
    "@roots/bud-tailwindcss/stylelint-config/scss"
  ]
}
```

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

closes: #1226 

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
