### PR TITLE
fix: remove rules section from bud-tailwindcss base stylelint config

### DIFF
--- a/sources/@roots/bud-tailwindcss/stylelint-config/base.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/base.js
@@ -1,10 +1,8 @@
 module.exports = {
-  rules: {
-    'function-no-unknown': [
-      true,
-      {
-        ignoreFunctions: ['theme'],
-      },
-    ],
-  },
+  'function-no-unknown': [
+    true,
+    {
+      ignoreFunctions: ['theme'],
+    },
+  ],
 }


### PR DESCRIPTION
## Overview

Removes the nested `rules` from the base stylelint config.

closes: #1238 

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
