### PR TITLE
fix: babel root

### DIFF
--- a/sources/@roots/bud-babel/package.json
+++ b/sources/@roots/bud-babel/package.json
@@ -65,7 +65,6 @@
     "@babel/plugin-transform-runtime": "^7.16.4",
     "@babel/preset-env": "^7.16.4",
     "babel-loader": "^8.2.3",
-    "babel-plugin-add-module-exports": "^1.0.4",
     "tslib": "^2.3.1"
   },
   "peerDependencies": {

--- a/sources/@roots/bud-babel/src/babel.extension.ts
+++ b/sources/@roots/bud-babel/src/babel.extension.ts
@@ -28,7 +28,7 @@ export const options: Extension.Module['options'] = async (
       compact: false,
     },
   },
-  root: app.path('@src'),
+  root: app.path(),
 })
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,7 +3135,6 @@ __metadata:
     "@types/lodash": 4.14.180
     "@types/node": 16.11.26
     babel-loader: ^8.2.3
-    babel-plugin-add-module-exports: ^1.0.4
     tslib: ^2.3.1
     webpack: 5.70.0
   peerDependencies:
@@ -6954,13 +6953,6 @@ __metadata:
     "@babel/core": ^7.0.0
     webpack: ">=2"
   checksum: 78e1e1a91954d644b6ce66366834d4d245febbc0fde33e4e2831725e83d6e760d12b3a78e9534ce92af69067bef1d9d9674df36d8c1f20ee127bc2354b2203ba
-  languageName: node
-  linkType: hard
-
-"babel-plugin-add-module-exports@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "babel-plugin-add-module-exports@npm:1.0.4"
-  checksum: def017e6f34c956302b2fb2ce594d253b83229c3491444f89c2ee4a66e0882025a814676e27173687ca6d1fd4fbff860ce2f35ca4d66d1b333f6c78c8765e981
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview

- Set babel `root` to `projectDir` so babel-loader can find `babel.config.js` files.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
