### PR TITLE
fix: tailwind scss stylelint config

### DIFF
--- a/sources/@roots/bud-tailwindcss/package.json
+++ b/sources/@roots/bud-tailwindcss/package.json
@@ -43,7 +43,7 @@
   "exports": {
     ".": "./lib/cjs/index.js",
     "./stylelint-config": "./stylelint-config/default.js",
-    "./stylelint-config/scss": "./stylelint-config/scss/scss.js"
+    "./stylelint-config/scss": "./stylelint-config/scss.js"
   },
   "bud": {
     "type": "extension",

--- a/sources/@roots/bud-tailwindcss/stylelint-config/scss.js
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/scss.js
@@ -1,6 +1,8 @@
 module.exports = {
   rules: {
     ...require('./common'),
+    'no-invalid-position-at-import-rule': null,
+    'at-rule-no-unknown': require('./rules/at-rule-no-unknown'),
     'scss/at-rule-no-unknown': require('./rules/at-rule-no-unknown'),
   },
 }


### PR DESCRIPTION
## Overview

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->
Looks like a couple changes to the tailwind scss config got lost in the shuffle. This fixes:

- The file path to `scss.js` in `package.json`
- Disable `no-invalid-position-at-import-rule` -- For using `@import` anywhere in `scss` files.
- Includes both `at-rule-no-unknown` and `scss/at-rule-no-unknown` -- For some reason, it only works with both rulesets included.

refers: #1226
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
