### PR TITLE
docs: new serve() https syntax

### DIFF
--- a/sources/@repo/docs/content/docs/05-bud.serve.mdx
+++ b/sources/@repo/docs/content/docs/05-bud.serve.mdx
@@ -55,8 +55,7 @@ bud.serve(new URL('http://example.test:3000'))
 Serve over `https`:
 
 ```ts title='bud.config.js'
-bud.serve({
-  url: 'https://example.test:3000',
+bud.serve('https://example.test', {
   cert: '/path/to/example.test.crt',
   key: '/path/to/example.test.key',
 })


### PR DESCRIPTION
## Overview

Update new `serve()` https syntax as described in https://bud.js.org/blog/5.7.0#upgrade-guide.

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
