### PR TITLE
fix: add `@repo` to docs edit url

### DIFF
--- a/sources/@repo/docs/config/index.ts
+++ b/sources/@repo/docs/config/index.ts
@@ -34,7 +34,7 @@ const docusaurusConfig: Config = {
         docs: {
           path: docsPath('content/docs'),
           sidebarPath,
-          editUrl: join(config.url.web, `edit/main/sources/docs/`),
+          editUrl: join(config.url.web, `edit/main/sources/@repo/docs/`),
           remarkPlugins: [
             [require('@docusaurus/remark-plugin-npm2yarn'), {sync: true}],
           ],


### PR DESCRIPTION
## Overview

Adds the `@repo` folder to the docusaurus "Edit this page" link.

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
