### PR TITLE
feat: bud.path filename handle

### DIFF
--- a/sources/@roots/bud-framework/src/Framework/methods/path.ts
+++ b/sources/@roots/bud-framework/src/Framework/methods/path.ts
@@ -51,6 +51,25 @@ export const path: path = function (base, ...segments) {
   /* Exit early with projectDir if no path was passed */
   if (!base) return app.context.projectDir
 
+  const fileHandles = (pathString: string) =>
+    pathString
+      .replace(
+        '@file',
+        app.store.is('features.hash', true)
+          ? '[path][name].[contenthash:6][ext]'
+          : '[path][name].[ext]',
+      )
+      .replace(
+        '@name',
+        app.store.is('features.hash', true)
+          ? '[name].[contenthash:6][ext]'
+          : '[name][ext]',
+      )
+
+  if (base === '@file' || base === '@name') return fileHandles(base)
+  base = fileHandles(base)
+  segments = segments.map(fileHandles)
+
   /* Parse `@` aliases. Should return an absolute path */
   if (base.startsWith(`@`)) base = parseAlias(app, base as `@${string}`)
 

--- a/sources/@roots/bud-framework/src/Framework/methods/path.ts
+++ b/sources/@roots/bud-framework/src/Framework/methods/path.ts
@@ -57,7 +57,7 @@ export const path: path = function (base, ...segments) {
         '@file',
         app.store.is('features.hash', true)
           ? '[path][name].[contenthash:6][ext]'
-          : '[path][name].[ext]',
+          : '[path][name][ext]',
       )
       .replace(
         '@name',


### PR DESCRIPTION
## Overview

- feat: add `@file` handle to `bud.path`
- feat: add `@name` handle to `bud.path`

This solves an annoyance I have with having some formulation of this snippet lying around in a dozen places:

```ts
        app.store.is('features.hash', true)
          ? '[path][name].[contenthash:6][ext]'
          : '[path][name][ext]'
```

now, you can lean on `bud.path` to handle it:
```ts
bud.path('@file')
// => [path][name].[contenthash:6][ext]
// or  [path][name][ext]
```

or, with just filename and no prepended `[path]` webpack magic string:

```ts
bud.path('@name')
```

can be used with base handles:
```ts
bud.path('@dist/@name')
```

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
