### PR TITLE
fix: wp proxy

### DIFF
--- a/sources/@roots/bud-dashboard/src/Dashboard/stats/stats.ts
+++ b/sources/@roots/bud-dashboard/src/Dashboard/stats/stats.ts
@@ -20,7 +20,7 @@ export const write = (
       ...components.timing(app, compilation),
       ...components.summary(app, compilation),
       ...(app.store.get('features.log') ? components.framework(app) : []),
-    ].join('\n')
+    ].join('')
 
     // eslint-disable-next-line
     app.context.stdout.write(`\n${output}\n`)

--- a/sources/@roots/bud-framework/src/Dashboard.ts
+++ b/sources/@roots/bud-framework/src/Dashboard.ts
@@ -13,5 +13,5 @@ export interface Dashboard extends Service {
    *
    * @public
    */
-  stats(stats): void
+  stats(stats): Promise<void>
 }

--- a/sources/@roots/bud-framework/src/Hooks.ts
+++ b/sources/@roots/bud-framework/src/Hooks.ts
@@ -165,6 +165,7 @@ export namespace Hooks {
       `event.server.before`,
       `event.server.listen`,
       `event.server.after`,
+      `event.proxy.interceptor`,
     ]
   }
 

--- a/sources/@roots/bud-framework/src/Hooks.ts
+++ b/sources/@roots/bud-framework/src/Hooks.ts
@@ -214,7 +214,7 @@ export namespace Hooks {
     [`dev.client.scripts`]: Set<(app: Framework) => string>
     [`middleware.enabled`]: Array<keyof Server.Middleware.Available>
     [`middleware.proxy.target`]: URL
-    [`middleware.proxy.replacements`]: Array<[string, string]>
+    [`middleware.proxy.replacements`]: Array<[RegExp | string, string]>
 
     // here down is wack
     [key: Server.Middleware.OptionsKey]: any

--- a/sources/@roots/bud-preset-wordpress/src/index.ts
+++ b/sources/@roots/bud-preset-wordpress/src/index.ts
@@ -39,12 +39,12 @@ export const name: BudWordPressPreset['name'] =
 export const boot = async (app: Framework) => {
   app.when(app.env.has('WP_HOME'), () => {
     /**
-     * Set proxy if WP_HOME is available
+     * Set proxy URL
      */
     app.proxy(app.env.get('WP_HOME'))
 
     /**
-     * Intercept WP_HOME url
+     * Intercept URL
      */
     app.hooks.action('event.proxy.interceptor', async ({hooks}) =>
       hooks.on(

--- a/sources/@roots/bud-preset-wordpress/src/index.ts
+++ b/sources/@roots/bud-preset-wordpress/src/index.ts
@@ -20,57 +20,52 @@ declare module '@roots/bud-framework' {
 
 /**
  * Preset config for WordPress plugins & themes
- *
- * @remarks
- * This preset is a wrapper for the following presets:
- * - `@roots/bud-preset-recommend`
- * - `@roots/bud-react`
- * - `@roots/bud-wordpress-dependencies`
- * - `@roots/bud-wordpress-externals`
- * - `@roots/bud-wordpress-manifests`
- *
  * @public
  */
 type BudWordPressPreset = Extension.Module
 
+/**
+ * Find/replace {@link URL.href} with {@link URL.pathname}
+ *
+ * @example
+ * https://mysite.com `-->` [https://mysite.com/, /]
+ * https://mysite.com/  `-->` [https://mysite.com/, /]
+ * https://mysite.com/subsite `-->` [https://mysite.com/subsite/, /subsite/]
+ */
+const findReplace = (input: string): [string, string] => {
+  const url = new URL(input)
+  if (!url.pathname.endsWith('/')) url.pathname = `${url.pathname}/`
+  return [url.href, url.pathname]
+}
+
+/**
+ * @public
+ */
 export const name: BudWordPressPreset['name'] =
   '@roots/bud-preset-wordpress'
 
+/**
+ * @public
+ */
 export const boot = async (app: Framework) => {
-  app.when(app.env.has('WP_HOME'), () => {
-    /**
-     * Set proxy URL
-     */
-    app.proxy(app.env.get('WP_HOME'))
+  /* Exit early if env is not set */
+  if (!app.env.has('WP_SITEURL') || !app.env.has('WP_HOME')) return
 
-    /**
-     * Intercept URL
-     */
-    app.hooks.action('event.proxy.interceptor', async ({hooks}) =>
-      hooks.on(
-        'middleware.proxy.replacements',
-        (replacements): Array<[string, string]> => [
-          ...(replacements ?? []),
-          [app.env.get('WP_HOME').concat('/'), '/'],
-        ],
-      ),
-    )
-  })
+  /**
+   * Set proxy target to `WP_HOME`
+   */
+  app.proxy(new URL(app.env.get<string>('WP_HOME')).href)
 
-  app.when(app.env.has('WP_SITE_URL'), ({hooks}) => {
-    hooks.action('event.proxy.interceptor', async ({hooks}) => {
-      hooks.on(
-        'middleware.proxy.replacements',
-        (replacements): Array<[string, string]> => [
-          ...(replacements ?? []),
-          [
-            app.env.get('WP_SITEURL'),
-            app.env.get('WP_SITEURL').replace(app.env.get('WP_HOME'), ''),
-          ],
-        ],
-      )
-    })
-  })
+  /**
+   * Hook proxy server `WP_HOME` and `WP_SITEURL` replacements
+   */
+  app.hooks.action('event.proxy.interceptor', async ({hooks}) =>
+    hooks.on('middleware.proxy.replacements', replacements => [
+      ...(replacements ?? []),
+      findReplace(app.env.get<string>('WP_HOME')),
+      findReplace(app.env.get<string>('WP_SITEURL')),
+    ]),
+  )
 }
 
 export * as ThemeJSON from './theme'

--- a/sources/@roots/bud-server/src/client/bridge.ts
+++ b/sources/@roots/bud-server/src/client/bridge.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 var options = {
-  path: '/__bud/hmr',
+  path: '/__hmr',
   timeout: 20 * 1000,
   overlay: true,
   reload: false,

--- a/sources/@roots/bud-server/src/client/index.ts
+++ b/sources/@roots/bud-server/src/client/index.ts
@@ -39,7 +39,7 @@ interface Options extends BaseOptions {
     warn: false,
     name: '',
     overlayWarnings: false,
-    path: '/__bud/hmr',
+    path: '/__hmr',
   }
 
   const options: Options = Object.entries(
@@ -52,22 +52,17 @@ interface Options extends BaseOptions {
 
   hmr.setOptionsAndConnect(options)
 
-  const registerIndicator = async () => {
-    if (!options['bud.indicator']) return
+  if (options['bud.indicator']) {
     const controllerModule = await import('./indicator/index.js')
     const controller = await controllerModule.make()
     controller?.update && controllers.push(controller)
   }
 
-  const registerOverlay = async () => {
-    if (!options['bud.overlay']) return
+  if (options['bud.overlay']) {
     const controllerModule = await import('./overlay/index.js')
     const controller = await controllerModule.make()
     controller?.update && controllers.push(controller)
   }
-
-  await registerIndicator()
-  await registerOverlay()
 
   hmr.subscribeAll(payload => {
     if (!payload) return

--- a/sources/@roots/bud-server/src/client/proxy-click-interceptor.ts
+++ b/sources/@roots/bud-server/src/client/proxy-click-interceptor.ts
@@ -1,49 +1,48 @@
-/* global __resourceQuery */
-/* eslint-disable no-console, no-extra-semi */
-// @ts-check
-
 type Target = HTMLAnchorElement | HTMLLinkElement | HTMLFormElement
 type ElementTuple = [HTMLCollectionOf<Target>, any]
-type Collection = Array<ElementTuple>
-
-type Task = [Array<Target>, any]
-
-const collect = (): Collection => [
-  [document.getElementsByTagName('a'), 'href'],
-  [document.getElementsByTagName('link'), 'href'],
-  [document.getElementsByTagName('form'), 'action'],
-]
 
 const main = async () => {
-  const {headers} = await fetch(window.location.origin, {
-    method: 'GET',
-  })
+  const {headers} = await fetch(window.location.origin, {method: 'GET'})
 
-  const origin = {
-    proxy: headers.get('x-bud-proxy-origin'),
-    dev: headers.get('x-bud-dev-origin'),
+  const bud = {
+    proxy: new URL(headers.get('x-bud-proxy-origin')),
+    dev: new URL(headers.get('x-bud-dev-origin')),
   }
 
-  const normalize = ([elements, attribute]): [Array<Target>, any] => [
-    Array.from(elements),
-    attribute,
-  ]
+  setInterval(
+    () =>
+      [
+        [document.getElementsByTagName('a'), 'href'],
+        [document.getElementsByTagName('link'), 'href'],
+      ]
+        .map(
+          ([elements, attribute]: ElementTuple): [Array<Target>, any] => [
+            Array.from(elements),
+            attribute,
+          ],
+        )
+        .forEach(([elements, attribute]: [Array<Target>, any]) =>
+          elements
+            .filter(el => el.hasAttribute(attribute))
+            .filter(el => !el.hasAttribute('__bud_processed'))
+            .filter(el => {
+              const attr = el.getAttribute(attribute)
+              return (
+                attr.startsWith(bud.proxy.origin) &&
+                !attr.startsWith(bud.dev.origin)
+              )
+            })
+            .map(el => {
+              const mutated = el
+                .getAttribute(attribute)
+                .replace(bud.proxy.origin, bud.dev.origin)
 
-  const filter = ([elements, attribute]: [Array<Target>, any]) =>
-    elements.filter(el =>
-      el.getAttribute(attribute)?.includes(origin.proxy),
-    ).length
-
-  const mapElements = ([elements, attribute]: [Array<Target>, any]) => {
-    elements.map(el => {
-      const value = el.getAttribute(attribute)
-      if (!value) return
-
-      el.setAttribute(attribute, value.replace(origin.proxy, origin.dev))
-    })
-  }
-
-  collect().map(normalize).filter(filter).map(mapElements)
+              el.setAttribute(attribute, mutated)
+              el.setAttribute('__bud_processed', '')
+            }),
+        ),
+    1000,
+  )
 }
 
 ;(async () =>

--- a/sources/@roots/bud-server/src/middleware/hot/webpack-hot-middleware/middleware.js
+++ b/sources/@roots/bud-server/src/middleware/hot/webpack-hot-middleware/middleware.js
@@ -8,7 +8,7 @@ function webpackHotMiddleware(compiler, opts) {
   opts = opts || {}
   opts.log =
     typeof opts.log == 'undefined' ? console.log.bind(console) : opts.log
-  opts.path = opts.path || '/_bud/hmr'
+  opts.path = opts.path || '/__hmr'
   opts.heartbeat = opts.heartbeat || 10 * 1000
 
   var eventStream = createEventStream(opts.heartbeat)

--- a/sources/@roots/bud-server/src/middleware/proxy/index.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/index.ts
@@ -42,7 +42,7 @@ export const proxy = (app: Framework) => {
      */
     followRedirects: app.hooks.filter(
       `middleware.proxy.options.followRedirects`,
-      false,
+      true,
     ),
 
     /**

--- a/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -57,8 +57,8 @@ export class ResponseInterceptorFactory {
    *
    * @param buffer - Buffered response
    * @param proxyRes - Response from the proxy
-   * @param req - Request from the client
-   * @param res - Response from the server
+   * @param request - Request from the client
+   * @param response - Response from the server
    *
    * @public
    * @decorator `@bind`
@@ -81,14 +81,14 @@ export class ResponseInterceptorFactory {
       response.cookie(k, v, {domain: null}),
     )
 
-    return this.app.hooks
-      .filter('middleware.proxy.replacements', [
-        [this.url.proxy.href, '/'],
-      ])
-      .reduce(
-        (buffer, [find, replace]) => buffer.replaceAll(find, replace),
-        buffer.toString(),
-      )
+    return [
+      ...(this.app.hooks.filter('middleware.proxy.replacements') ?? []),
+      [this.url.proxy.href, this.url.proxy.pathname],
+    ].reduce(
+      (buffer, [find, replace]: [string | RegExp, string]) =>
+        buffer.replaceAll(find, replace),
+      buffer.toString(),
+    )
   }
 
   /**

--- a/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -70,6 +70,8 @@ export class ResponseInterceptorFactory {
     request: IncomingMessage,
     response: ServerResponse,
   ): Promise<Buffer | String> {
+    await this.app.hooks.fire('event.proxy.interceptor')
+
     response.setHeader('x-proxy-by', '@roots/bud')
     response.setHeader('x-bud-proxy-origin', this.url.proxy.origin)
     response.setHeader('x-bud-dev-origin', this.url.dev.origin)
@@ -80,7 +82,9 @@ export class ResponseInterceptorFactory {
     )
 
     return this.app.hooks
-      .filter('middleware.proxy.replacements')
+      .filter('middleware.proxy.replacements', [
+        [this.url.proxy.href, '/'],
+      ])
       .reduce(
         (buffer, [find, replace]) => buffer.replaceAll(find, replace),
         buffer.toString(),

--- a/sources/@roots/bud-server/src/middleware/proxy/url.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/url.ts
@@ -39,14 +39,4 @@ export class ApplicationURL {
    * @public
    */
   public constructor(public _app: () => Framework) {}
-
-  /**
-   * Asset public path
-   *
-   * @public
-   */
-  public get publicPath() {
-    const publicPath = this.app.hooks.filter('build.output.publicPath')
-    return publicPath !== 'auto' ? publicPath : '/'
-  }
 }

--- a/sources/@roots/bud-server/src/seed.ts
+++ b/sources/@roots/bud-server/src/seed.ts
@@ -31,18 +31,20 @@ export const seed = (app: Framework) => {
       'x-powered-by': '@roots/bud',
     })
     .hooks.on(`middleware.dev.options.publicPath`, () =>
-      app.hooks.filter(`build.output.publicPath`, `/`),
+      app.hooks.filter('build.output.publicPath'),
     )
     .hooks.on(`middleware.dev.options.stats`, false)
     .hooks.on(`middleware.dev.options.writeToDisk`, true)
 
-    .hooks.on(`middleware.hot.options.path`, `/__bud/hmr`)
+    .hooks.on(
+      `middleware.hot.options.path`,
+      () => `${app.hooks.filter('build.output.publicPath')}__hmr`,
+    )
     .hooks.on(
       `middleware.hot.options.log`,
       app.logger.instance.scope('hot').info,
     )
     .hooks.on(`middleware.hot.options.heartbeat`, 2000)
-
     .hooks.on(
       `dev.client.scripts`,
       new Set([

--- a/sources/@roots/bud/src/seed.ts
+++ b/sources/@roots/bud/src/seed.ts
@@ -204,12 +204,11 @@ export const seed: Partial<Store.Repository> = {
     ]),
   [`build.module.rules.before`]: app => [
     {
-      test: /\.[cm]?(jsx?|tsx?)$/,
-      parser: {
-        requireEnsure: false,
-      },
+      test: /\.(cjs|mjs|jsx?|tsx?)$/,
+      include: [app.path('@src')],
+      parser: {requireEnsure: false},
     },
   ],
   [`build.module.rules.after`]: app => [],
-  [`build.stats`]: app => ({preset: `normal`}),
+  [`build.stats`]: app => `normal`,
 }

--- a/sources/@roots/sage/src/acorn.ts
+++ b/sources/@roots/sage/src/acorn.ts
@@ -1,0 +1,46 @@
+import {Framework} from '@roots/bud-framework'
+
+import eventAppClose from './hooks/event.app.close'
+import eventCompilerDone from './hooks/event.compiler.done'
+
+/**
+ * Acorn compatibility layer
+ * @public
+ */
+export const makeAcornCompat = (app: Framework) => {
+  /**
+   * Override output directory for svg assets
+   * `@roots/bud-build` places them, by default, in `svg/`
+   */
+  app.build.rules.svg.setGenerator(app => ({
+    filename: app.store.is('features.hash', true)
+      ? 'images/'.concat(app.store.get('hashFormat')).concat('[ext]')
+      : 'images/'.concat(app.store.get('fileFormat')).concat('[ext]'),
+  }))
+
+  /**
+   * Tell Acorn assets have no `publicPath` even if bud is using one internally.
+   * Acorn does its own `pulicPath` processing.
+   *
+   * Not setting an empty string will likely result in duplicative path segments
+   * and unresolved assets.
+   */
+  app.extensions.get('@roots/bud-entrypoints').setOption('publicPath', '')
+
+  /**
+   * - If publicPath is `/` in production assets will not be locatable by Acorn.
+   * - If publicPath is `''` in development bud's dev server will implode.
+   * - If publicPath is the actual publicPath acorn will double up the path segments.
+   */
+  app.hooks.on('build.output.publicPath', app.isDevelopment ? `/` : ``)
+
+  /**
+   * Write hmr.json when compilation is finalized (only in development)
+   * Remove this file when process is exited.
+   */
+  app.when(app.isDevelopment, () =>
+    app.hooks
+      .action('event.compiler.done', eventCompilerDone)
+      .hooks.action('event.app.close', eventAppClose),
+  )
+}

--- a/sources/@roots/sage/src/sage.preset.ts
+++ b/sources/@roots/sage/src/sage.preset.ts
@@ -7,97 +7,111 @@ import * as ThemeJSON from './theme/extension'
 interface Sage extends Framework.Extension.Module {}
 
 /**
+ * Acorn compatibility layer
+ * @public
+ */
+const makeAcornCompat = (app: Framework.Framework) => {
+  /**
+   * Override output directory for svg assets
+   * `@roots/bud-build` places them, by default, in `svg/`
+   */
+  app.build.rules.svg.setGenerator(app => ({
+    filename: app.store.is('features.hash', true)
+      ? 'images/'.concat(app.store.get('hashFormat')).concat('[ext]')
+      : 'images/'.concat(app.store.get('fileFormat')).concat('[ext]'),
+  }))
+
+  /**
+   * Tell Acorn assets have no `publicPath` even if bud is
+   * using one internally. Acorn does its own `pulicPath` processing
+   * and not setting an empty string will likely result in duplicative
+   * path segments and unresolved assets
+   */
+  app.extensions.get('@roots/bud-entrypoints').setOption('publicPath', '')
+
+  /**
+   * - If publicPath is `/` in production assets will not be locatable by Acorn.
+   * - If publicPath is `''` in development bud's dev server will implode.
+   * - If publicPath is the actual publicPath acorn will double up the path segments.
+   */
+  app.hooks.on('build.output.publicPath', app.isDevelopment ? `/` : ``)
+
+  /**
+   * Write hmr.json when compilation is finalized (only in development)
+   * Remove this file when process is exited.
+   */
+  app.when(app.isDevelopment, () =>
+    app.hooks
+      .action('event.compiler.done', eventCompilerDone)
+      .hooks.action('event.app.close', eventAppClose),
+  )
+}
+
+/**
  * Sage preset
- *
  * @public
  */
 const Sage: Sage = {
   /**
    * Extension identifier
-   *
    * @public
    */
   name: '@roots/sage',
 
   /**
    * Extension boot
-   *
    * @public
    */
   boot: async app => {
+    /**
+     * Handle acorn compatibility concerns
+     */
+    makeAcornCompat(app)
+
     /**
      * Add theme.json generator support
      */
     await app.extensions.add(ThemeJSON)
 
-    app.extensions
-      .get('@roots/bud-entrypoints')
-      .setOption('publicPath', '')
-
     /**
-     * Override output directory for svg assets
-     * `@roots/bud-build` places them, by default, in `svg/`
+     * Set application paths
      */
-    app.build.rules.svg.setGenerator(app => ({
-      filename: app.store.is('features.hash', true)
-        ? 'images/'.concat(app.store.get('hashFormat')).concat('[ext]')
-        : 'images/'.concat(app.store.get('fileFormat')).concat('[ext]'),
-    }))
-
-    /**
-     * Application paths
-     */
-    app.setPath({
-      '@src': 'resources',
-      '@dist': 'public',
-      '@resources': '@src',
-      '@public': '@dist',
-      '@fonts': '@src/fonts',
-      '@images': '@src/images',
-      '@scripts': '@src/scripts',
-      '@styles': '@src/styles',
-      '@views': '@src/views',
-    })
-
-    /**
-     * Application aliases
-     */
-    app.alias({
-      '@fonts': app.path('@fonts'),
-      '@images': app.path('@images'),
-      '@scripts': app.path('@scripts'),
-      '@styles': app.path('@styles'),
-    })
-
-    /**
-     * Separate vendor code from application
-     */
-    app.splitChunks()
-
-    /**
-     * Production/development configuration
-     */
-    app.when(
-      /**
-       * Test for production
-       */
-      app.isProduction,
+    app
+      .setPath({
+        '@src': 'resources',
+        '@dist': 'public',
+        '@resources': '@src',
+        '@public': '@dist',
+        '@fonts': '@src/fonts',
+        '@images': '@src/images',
+        '@scripts': '@src/scripts',
+        '@styles': '@src/styles',
+        '@views': '@src/views',
+      })
 
       /**
-       * Production
+       * Set application client aliases
        */
-      () => app.minimize().hash().runtime('single'),
+      .alias({
+        '@fonts': app.path('@fonts'),
+        '@images': app.path('@images'),
+        '@scripts': app.path('@scripts'),
+        '@styles': app.path('@styles'),
+      })
 
       /**
-       * Development
+       * Create vendor chunk(s)
        */
-      () => {
-        app
-          .devtool()
-          .hooks.action('event.compiler.done', eventCompilerDone)
-          .hooks.action('event.app.close', eventAppClose)
-      },
-    )
+      .splitChunks()
+
+      /**
+       * Environment specific configuration
+       */
+      .when(
+        app.isProduction,
+        () => app.minimize().hash().runtime('single'),
+        () => app.devtool(),
+      )
   },
 }
 

--- a/sources/@roots/sage/src/sage.preset.ts
+++ b/sources/@roots/sage/src/sage.preset.ts
@@ -1,117 +1,59 @@
 import * as Framework from '@roots/bud-framework'
 
-import eventAppClose from './hooks/event.app.close'
-import eventCompilerDone from './hooks/event.compiler.done'
+import {makeAcornCompat} from './acorn'
 import * as ThemeJSON from './theme/extension'
 
 interface Sage extends Framework.Extension.Module {}
 
 /**
- * Acorn compatibility layer
- * @public
- */
-const makeAcornCompat = (app: Framework.Framework) => {
-  /**
-   * Override output directory for svg assets
-   * `@roots/bud-build` places them, by default, in `svg/`
-   */
-  app.build.rules.svg.setGenerator(app => ({
-    filename: app.store.is('features.hash', true)
-      ? 'images/'.concat(app.store.get('hashFormat')).concat('[ext]')
-      : 'images/'.concat(app.store.get('fileFormat')).concat('[ext]'),
-  }))
-
-  /**
-   * Tell Acorn assets have no `publicPath` even if bud is
-   * using one internally. Acorn does its own `pulicPath` processing
-   * and not setting an empty string will likely result in duplicative
-   * path segments and unresolved assets
-   */
-  app.extensions.get('@roots/bud-entrypoints').setOption('publicPath', '')
-
-  /**
-   * - If publicPath is `/` in production assets will not be locatable by Acorn.
-   * - If publicPath is `''` in development bud's dev server will implode.
-   * - If publicPath is the actual publicPath acorn will double up the path segments.
-   */
-  app.hooks.on('build.output.publicPath', app.isDevelopment ? `/` : ``)
-
-  /**
-   * Write hmr.json when compilation is finalized (only in development)
-   * Remove this file when process is exited.
-   */
-  app.when(app.isDevelopment, () =>
-    app.hooks
-      .action('event.compiler.done', eventCompilerDone)
-      .hooks.action('event.app.close', eventAppClose),
-  )
-}
-
-/**
- * Sage preset
  * @public
  */
 const Sage: Sage = {
   /**
-   * Extension identifier
    * @public
    */
   name: '@roots/sage',
 
   /**
-   * Extension boot
    * @public
    */
   boot: async app => {
-    /**
-     * Handle acorn compatibility concerns
-     */
+    /* Acorn concerns */
     makeAcornCompat(app)
 
-    /**
-     * Add theme.json generator support
-     */
+    /* Add theme.json extension */
     await app.extensions.add(ThemeJSON)
 
-    /**
-     * Set application paths
-     */
-    app
-      .setPath({
-        '@src': 'resources',
-        '@dist': 'public',
-        '@resources': '@src',
-        '@public': '@dist',
-        '@fonts': '@src/fonts',
-        '@images': '@src/images',
-        '@scripts': '@src/scripts',
-        '@styles': '@src/styles',
-        '@views': '@src/views',
-      })
+    /* Set application paths */
+    app.setPath({
+      '@src': 'resources',
+      '@dist': 'public',
+      '@resources': '@src',
+      '@public': '@dist',
+      '@fonts': '@src/fonts',
+      '@images': '@src/images',
+      '@scripts': '@src/scripts',
+      '@styles': '@src/styles',
+      '@views': '@src/views',
+    })
 
-      /**
-       * Set application client aliases
-       */
-      .alias({
-        '@fonts': app.path('@fonts'),
-        '@images': app.path('@images'),
-        '@scripts': app.path('@scripts'),
-        '@styles': app.path('@styles'),
-      })
+    /* Set application client aliases */
+    app.alias({
+      '@fonts': app.path('@fonts'),
+      '@images': app.path('@images'),
+      '@scripts': app.path('@scripts'),
+      '@styles': app.path('@styles'),
+    })
 
-      /**
-       * Create vendor chunk(s)
-       */
-      .splitChunks()
+    /* Create vendor chunk(s) */
+    app.splitChunks()
 
-      /**
-       * Environment specific configuration
-       */
-      .when(
-        app.isProduction,
-        () => app.minimize().hash().runtime('single'),
-        () => app.devtool(),
-      )
+    /* Environment specific configuration */
+    app.when(
+      app.isProduction,
+      () => app.minimize().hash().runtime('single'),
+      () => app.devtool(),
+    )
   },
 }
 

--- a/tests/unit/bud-build/__snapshots__/config.test.ts.snap
+++ b/tests/unit/bud-build/__snapshots__/config.test.ts.snap
@@ -135,6 +135,9 @@ Object {
 
 exports[`bud.build.config has expected default requireEnsure rule 1`] = `
 Object {
+  "include": Array [
+    "/srv/bud/tests/util/project/src",
+  ],
   "parser": Object {
     "requireEnsure": false,
   },


### PR DESCRIPTION
## Overview

- fix: regexp for js `before` rule matches .cjs, .mjs, .js, .jsx, .ts, .tsx 😳
- fix: race condition which could cause dashboard to render twice when `dashboard.run` was called after compilation.
- feat: if `WP_HOME` and `WP_SITEURL` are set in env the proxy url will be automatically set.
- fix: proxy url is replaced with`/` (rather than the dev server url). This seems to perform ideally. 
- improve: proxy-click-interceptor will only process a `link` or `anchor` element once
- improve: proxy-click-interceptor checks for inserted elements at interval.
  - wordpress inserts generated `anchor` elements and does so with the full URL as specified in `wp-config`.
- improve: @roots/sage compatibility fixes all live under one function call in `@roots/sage/src/sage-preset.ts`
- fix: redirection issues when URL is missing a trailing slash (#1210)

I believe this makes it unecessary to specify publicPath using `__webpack_public_path__` or bud's entry object:
```typescript
app.entry({
  app: {
    import: ['scripts/app.js'],
    publicPath: '/app/themes/sage/public/' // this can be removed
  },
})
```

In a bedrock env it should be fine to remove the `bud.proxy` call entirely.

refers: 
- #1210

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
