### PR TITLE
fix: proxy media

### DIFF
--- a/sources/@roots/bud-api/src/api/methods/serve/index.ts
+++ b/sources/@roots/bud-api/src/api/methods/serve/index.ts
@@ -4,22 +4,67 @@ import {lodash} from '@roots/bud-support'
 
 const {isFunction} = lodash
 
+interface Specification {
+  /**
+   * A preferred port or an iterable of preferred ports to use.
+   */
+  port: number | Iterable<number>
+
+  /**
+   * Use ssl connection
+   */
+  ssl?: boolean
+
+  /**
+   * Ports that should not be returned.
+   */
+  exclude?: Iterable<number>
+
+  /**
+   * The host on which port resolution should be performed. Can be either an IPv4 or IPv6 address.
+   * By default, it checks availability on all local addresses defined in [OS network interfaces](https://nodejs.org/api/os.html#os_os_networkinterfaces). If this option is set, it will only check the given host.
+   */
+  host?: string
+
+  /**
+   * SSL certificate (path)
+   */
+  cert?: string
+
+  /**
+   * SSL key (path)
+   */
+  key?: string
+
+  /**
+   * Connection options or a callback handling the merging options onto
+   * ones which have already been set
+   */
+  options?:
+    | Connection.Options
+    | ((options: Connection.Options) => Connection.Options)
+}
+
 export interface method {
   (
-    url: URL | string,
+    url?: URL | string,
     options?:
       | Connection.Options
       | ((options: Connection.Options) => Connection.Options),
   ): Framework
+  (specification: Specification): Framework
+  (port: number): Framework
+  (url: string | URL): Framework
 }
 
 export type facade = method
 
-export const method: method = function (input, options?) {
-  const app = this as Framework
-
-  if (!app.isDevelopment) return app
-
+const processOptions = (
+  app: Framework,
+  options:
+    | Connection.Options
+    | ((options: Connection.Options) => Connection.Options),
+) => {
   if (options) {
     const unwrapped = isFunction(options)
       ? options(app.hooks.filter('dev.options') ?? {})
@@ -28,15 +73,83 @@ export const method: method = function (input, options?) {
     app.hooks.on('dev.options', value =>
       value ? {...value, ...unwrapped} : unwrapped,
     )
+
+    unwrapped.cert && app.hooks.on('dev.cert', unwrapped.cert as string)
+    unwrapped.key && app.hooks.on('dev.key', unwrapped.key as string)
+  }
+}
+
+const processURL = (app: Framework, url: URL) => {
+  app.hooks.on('dev.host', url.hostname)
+  url.port && app.hooks.on('dev.port', [Number(url.port)])
+  app.hooks.on('dev.ssl', url.protocol === 'https:')
+}
+
+export const method: method = function (...input) {
+  const app = this as Framework
+  if (!app.isDevelopment) return app
+
+  if (input.length > 1) {
+    const [url, options] = input
+
+    if (url instanceof URL) {
+      processURL(app, url)
+    }
+
+    if (typeof url === 'string') {
+      processURL(app, new URL(url))
+    }
+
+    if (typeof url === 'number') {
+      app.hooks.on('dev.port', [url])
+    }
+
+    if (Array.isArray(url)) {
+      app.hooks.on('dev.port', url)
+      return app
+    }
+
+    processOptions(app, options)
+
+    return app
   }
 
-  if (typeof input === 'string') {
-    return app.hooks.on('dev.url', new URL(input))
+  const specification: Specification = input.pop()
+
+  if (Array.isArray(specification)) {
+    app.hooks.on('dev.port', specification)
+    return app
   }
 
-  if (input instanceof URL) {
-    return app.hooks.on('dev.url', input)
+  if (typeof specification === 'string') {
+    processURL(app, new URL(specification))
+    return app
   }
+
+  if (typeof specification === 'number') {
+    app.hooks.on('dev.port', [specification])
+    return app
+  }
+
+  specification.host && app.hooks.on('dev.host', specification.host)
+  specification.ssl && app.hooks.on('dev.ssl', specification.ssl)
+  specification.cert && app.hooks.on('dev.cert', specification.cert)
+  specification.key && app.hooks.on('dev.key', specification.key)
+  specification.port &&
+    app.hooks.on(
+      'dev.port',
+      Array.isArray(specification.port)
+        ? specification.port
+        : [specification.port],
+    )
+  specification.exclude &&
+    app.hooks.on(
+      'dev.exclude',
+      Array.isArray(specification.exclude)
+        ? specification.exclude
+        : [specification.exclude],
+    )
+  specification.options && processOptions(app, specification.options)
 
   return app
 }

--- a/sources/@roots/bud-framework/src/Hooks.ts
+++ b/sources/@roots/bud-framework/src/Hooks.ts
@@ -207,10 +207,47 @@ export namespace Hooks {
       LocationKeyMap,
       ConfigMap {
     [`extension`]: ValueOf<Plugins> | ValueOf<Modules>
+    /**
+     * Dev server connection options
+     */
     [`dev.options`]: Server.Connection.Options
-    [`dev.url`]: URL
+
+    /**
+     * IPV4 or IPV6 binding
+     */
+    [`dev.host`]: string
+    /**
+     * Ports to exclude from selection
+     */
+    [`dev.exclude`]: Array<number>
+    /**
+     * Ports to prefer
+     */
+    [`dev.port`]: Array<number>
+    /**
+     * Should use SSL server
+     */
+    [`dev.ssl`]: boolean
+    /**
+     * SSL certificate (path)
+     */
+    [`dev.cert`]: string
+    /**
+     * SSL key (path)
+     */
+    [`dev.key`]: string
+
+    /**
+     * Files which trigger a full browser reload
+     */
     [`dev.watch.files`]: Set<string>
+    /**
+     * FS.Watcher options
+     */
     [`dev.watch.options`]: WatchOptions
+    /**
+     * Scripts included in dev builds
+     */
     [`dev.client.scripts`]: Set<(app: Framework) => string>
     [`middleware.enabled`]: Array<keyof Server.Middleware.Available>
     [`middleware.proxy.target`]: URL

--- a/sources/@roots/bud-framework/src/Server/Connection.ts
+++ b/sources/@roots/bud-framework/src/Server/Connection.ts
@@ -27,15 +27,29 @@ export interface Connection {
   instance: HttpServer | HttpsServer
 
   /**
-   * Server URL
+   * Resolved port
+   * @public
+   */
+  port: number
+
+  /**
+   * Resolved URL
    * @public
    */
   url: URL
 
   /**
+   * User specifications
+   * @public
+   */
+  specification: {
+    port: Array<number>
+    exclude: Array<number>
+    host: string
+  }
+
+  /**
    * Create server
-   * @remarks
-   * Returns Node server
    * @public
    */
   createServer(app: any): Promise<Connection['instance']>

--- a/sources/@roots/bud-server/src/middleware/proxy/index.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/index.ts
@@ -104,7 +104,7 @@ export const proxy = (app: Framework) => {
      */
     protocolRewrite: app.hooks.filter(
       `middleware.proxy.options.protocolRewrite`,
-      url.dev.protocol?.startsWith('https') ? 'https' : undefined,
+      app.hooks.filter('dev.ssl') ? 'https' : undefined,
     ),
 
     /**

--- a/sources/@roots/bud-server/src/seed.ts
+++ b/sources/@roots/bud-server/src/seed.ts
@@ -59,7 +59,19 @@ export const seed = (app: Framework) => {
         () => src(`proxy-click-interceptor.js`),
       ]),
     )
-    .hooks.on(`dev.url`, new URL(`http://localhost`))
     .hooks.on(`dev.watch.files`, new Set([]))
     .hooks.on(`dev.watch.options`, {})
+
+    /**
+     * Proxy interception
+     */
+    .hooks.action(`event.proxy.interceptor`, async app =>
+      app.hooks.on(
+        `middleware.proxy.replacements`,
+        (replacements): Array<[string | RegExp, string]> => [
+          ...(replacements ?? []),
+          [app.hooks.filter('middleware.proxy.target').href, '/'],
+        ],
+      ),
+    )
 }

--- a/sources/@roots/bud-server/src/server/index.ts
+++ b/sources/@roots/bud-server/src/server/index.ts
@@ -13,7 +13,6 @@ import {Watcher} from './server.watcher'
 
 /**
  * Server service class
- *
  * @public
  */
 export class Server
@@ -22,35 +21,36 @@ export class Server
 {
   /**
    * Express instance
-   *
    * @public
    */
   public application: Express.Application
 
   /**
+   * Express instance
+   * @public
+   */
+  public express = Express
+
+  /**
    * Watcher instance
-   *
    * @public
    */
   public watcher: Watcher
 
   /**
    * Server connections
-   *
    * @public
    */
   public connection: Connection
 
   /**
    * Available middleware
-   *
    * @public
    */
   public availableMiddleware = middlewareMap
 
   /**
    * Utilized middleware
-   *
    * @public
    */
   public get enabledMiddleware(): BudServer.Service['enabledMiddleware'] {
@@ -65,7 +65,6 @@ export class Server
 
   /**
    * Applied middleware
-   *
    * @public
    */
   public appliedMiddleware: Partial<
@@ -74,7 +73,6 @@ export class Server
 
   /**
    * Register service
-   *
    * @public
    * @decorator `@bind`
    * @decorator `@once`
@@ -84,14 +82,14 @@ export class Server
   public async register(): Promise<void> {
     seed(this.app)
 
-    this.application = Express()
+    this.application = this.express()
     this.application.set('x-powered-by', false)
+
     this.watcher = new Watcher(this.app)
   }
 
   /**
    * Boot service
-   *
    * @public
    * @decorator `@bind`
    * @decorator `@once`
@@ -106,14 +104,12 @@ export class Server
       this.app.compiler.compile,
       this.applyMiddleware,
     )
-    this.app.hooks.action('event.server.after', async () =>
-      this.watcher.watch(),
-    )
+
+    this.app.hooks.action('event.server.after', this.watcher.watch)
   }
 
   /**
    * Set connection
-   *
    * @public
    * @decorator `@bind`
    * @decorator `@once`
@@ -122,18 +118,17 @@ export class Server
   @once
   public async setConnection() {
     this.connection =
-      this.app.hooks.filter('dev.options') &&
-      this.app.hooks.filter('dev.options').cert &&
-      this.app.hooks.filter('dev.options').key
-        ? new Https(this.app, this.app.hooks.filter('dev.url'))
-        : new Http(this.app, this.app.hooks.filter('dev.url'))
+      (this.app.hooks.filter('dev.cert') &&
+        this.app.hooks.filter('dev.key')) ||
+      this.app.hooks.filter('dev.ssl')
+        ? new Https(this.app)
+        : new Http(this.app)
 
     await this.connection.setup()
   }
 
   /**
    * Inject scripts
-   *
    * @public
    * @decorator `@bind`
    * @decorator `@once`
@@ -155,7 +150,6 @@ export class Server
 
   /**
    * Apply middleware
-   *
    * @public
    * @decorator `@bind`
    * @decorator `@once`
@@ -171,7 +165,6 @@ export class Server
 
   /**
    * Run development server
-   *
    * @public
    * @decorator `@bind`
    */

--- a/sources/@roots/bud/bin/bud.js
+++ b/sources/@roots/bud/bin/bud.js
@@ -13,20 +13,17 @@ const { makeContext } = require('../lib/cjs/context/index.js')
 
 /**
  * Run Bud CLI
- *
  * @public
  */
 const bud = async () => {
   /**
    * Arguments
-   *
    * @public
    */
   const argv = process.argv.splice(2)
 
   /**
    * Execution context
-   *
    * @see {@link https://mael.dev/clipanion/docs/contexts}
    */
   const context = await makeContext()
@@ -70,13 +67,11 @@ const bud = async () => {
 
   /**
    * CLI instantiation
-   *
    * @see {@link https://mael.dev/clipanion/docs/api/cli}
-   *
    * @public
    */
   const application = new Cli({
-    binaryLabel: context.application.name,
+    binaryLabel: context.application.label,
     binaryName: context.application.name,
     binaryVersion: context.application.version,
     enableColors: true,

--- a/sources/@roots/bud/src/cli/commands/build.ts
+++ b/sources/@roots/bud/src/cli/commands/build.ts
@@ -53,6 +53,7 @@ export class BuildCommand extends BaseCommand {
       t.isLiteral('production'),
       t.isLiteral('development'),
     ]),
+    env: 'BUILD_MODE',
   })
 
   /**
@@ -67,6 +68,7 @@ export class BuildCommand extends BaseCommand {
       t.isLiteral(true),
       t.isLiteral(false),
     ]),
+    env: 'BUILD_CACHE',
   })
 
   /**
@@ -150,6 +152,7 @@ export class BuildCommand extends BaseCommand {
    */
   public storage = Option.String(`--storage`, undefined, {
     description: 'Storage directory (relative to project)',
+    env: 'BUILD_PATH_STORAGE',
   })
 
   /**
@@ -185,6 +188,7 @@ export class BuildCommand extends BaseCommand {
    */
   public modules = Option.String(`--modules`, undefined, {
     description: 'Module resolution path',
+    env: 'BUILD_PATH_MODULES',
   })
 
   /**
@@ -206,6 +210,7 @@ export class BuildCommand extends BaseCommand {
    */
   public publicPath = Option.String(`--publicPath`, undefined, {
     description: 'public path of emitted assets',
+    env: 'APP_PUBLIC_PATH',
   })
 
   /**

--- a/sources/@roots/bud/src/cli/commands/install.ts
+++ b/sources/@roots/bud/src/cli/commands/install.ts
@@ -15,7 +15,5 @@ export class InstallCommand extends BaseCommand {
     this.context.stdout.write(
       `This command was deprecated in 5.3.0. In the future this command will throw an error.\n`,
     )
-
-    this.app.close()
   }
 }

--- a/sources/@roots/bud/src/context/env.ts
+++ b/sources/@roots/bud/src/context/env.ts
@@ -1,32 +1,49 @@
 import {dotenv, dotenvExpand} from '@roots/bud-support'
 import {join} from 'node:path'
 
+/**
+ * Env context
+ * @public
+ */
 export class Env {
+  /**
+   * Index
+   * @public
+   */
   [key: string]: string | undefined
 
   /**
    * Constructor
-   *
    * @param baseDirectory -- nearest directory containing package.json from root
-   * @returns
+   * @public
    */
   public constructor(baseDirectory: string) {
-    const paths = baseDirectory.split('/')
+    let values = {}
 
-    Object.entries(process.env).map(([k, v]) => (this[k] = v))
+    Object.entries(process.env).map(([k, v]) => {
+      values[k] = v
+    })
 
     const get = (path: string) => {
       const {parsed, error} = dotenv.config({path})
       if (error || !parsed) return
+
       const expanded = dotenvExpand(parsed)
       if (!expanded) return
-      Object.entries(expanded).map(([k, v]) => (this[k] = v))
+
+      Object.entries(expanded).map(([k, v]) => {
+        values[k] = v
+      })
     }
 
-    paths.reduce((a, c) => {
+    baseDirectory.split('/').reduce((a, c) => {
       const next = join(a, c)
       get(join(next, '.env'))
       return next
     }, `/`)
+
+    Object.entries(values).map(([k, v]: [string, string]) => {
+      this[k] = v
+    })
   }
 }

--- a/sources/@roots/sage/src/hooks/event.compiler.done.ts
+++ b/sources/@roots/sage/src/hooks/event.compiler.done.ts
@@ -19,7 +19,7 @@ export default async function (app: Framework) {
     await ensureDir(app.path('@dist'))
 
     await writeJson(app.path('@dist', 'hmr.json'), {
-      dev: urlToHttpOptions(app.hooks.filter('dev.url')) ?? null,
+      dev: urlToHttpOptions(app.server.connection.url) ?? null,
       proxy:
         urlToHttpOptions(app.hooks.filter('middleware.proxy.target')) ??
         null,

--- a/tests/unit/bud-api/repository/server.test.ts
+++ b/tests/unit/bud-api/repository/server.test.ts
@@ -1,5 +1,4 @@
 import {Bud, factory} from '@repo/test-kit/bud'
-import {URL} from 'url'
 
 describe('bud.serve', function () {
   let bud: Bud
@@ -17,26 +16,15 @@ describe('bud.serve', function () {
 
     await bud.api.processQueue()
 
-    expect(bud.hooks.filter('dev.url')).toStrictEqual(
-      new URL('http://example.com'),
-    )
-  })
-
-  it('sets URL from URL', async () => {
-    const testUrl = new URL('http://test-url.com')
-
-    bud.serve(testUrl)
-
-    await bud.api.processQueue()
-
-    expect(bud.hooks.filter('dev.url')).toStrictEqual(testUrl)
+    expect(bud.hooks.filter('dev.ssl')).toBe(false)
+    expect(bud.hooks.filter('dev.host')).toStrictEqual('example.com')
+    expect(bud.hooks.filter('dev.port')).toStrictEqual([3000])
   })
 
   it('sets options', async () => {
-    const url = new URL('http://test-url.com')
-
     const options = {cert: 'foo', key: 'bar'}
-    await bud.api.call('serve', url, options)
+
+    await bud.api.call('serve', {options})
 
     expect(bud.hooks.filter('dev.options')).toStrictEqual(options)
   })

--- a/tests/unit/bud-server/__snapshots__/service.test.ts.snap
+++ b/tests/unit/bud-server/__snapshots__/service.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`@roots/bud-server has expected defaults 1`] = `"http://localhost/"`;
+exports[`@roots/bud-server has expected defaults 1`] = `undefined`;
 
 exports[`@roots/bud-server has expected defaults 2`] = `Set {}`;
 

--- a/tests/unit/bud-server/service.test.ts
+++ b/tests/unit/bud-server/service.test.ts
@@ -11,7 +11,7 @@ describe('@roots/bud-server', function () {
   })
 
   it('has expected defaults', () => {
-    expect(bud.hooks.filter('dev.url')).toMatchSnapshot()
+    expect(bud.hooks.filter('dev.host')).toMatchSnapshot()
     expect(bud.hooks.filter('dev.watch.files')).toMatchSnapshot()
     expect(bud.hooks.filter('dev.watch.options')).toMatchSnapshot()
     expect(bud.hooks.filter('dev.client.scripts')).toMatchSnapshot()


### PR DESCRIPTION
## Overview

- fix: media proxy
- feat: zero config

most wp proxy people can remove all calls to `bud.serve` and `bud.proxy`, provided:
- They have a `WP_HOME` set in `process.env` or in an `.env` accessible somewhere in the path

For those that do need it:

## Specify a port #

```ts
bud.serve(3000)
// => http://0.0.0.0:3000
```

## Specify port #s

Will be tried in order.

```ts
bud.serve([3000,3001,3002])
// => http://0.0.0.0:300(0|1|2)
```

## Specify an origin string

```ts
bud.serve('http://example.test')
// => http://example.test:3000
```

Specify either of the above

## Specify as an object

```ts
bud.serve({
  host: 'http://localhost',
  port: 3000,
})
// => http://example.test:3000
```

## Specify an array of ports

```ts
bud.serve({
  host: 'http://localhost',
  port: [3000, 3001, 3002, 3003],
})
// => http://localhost:300x
```

## Specify port exclusions

```ts
bud.serve({
  exclude: [3000]
})
// => http://0.0.0.0 on any port other than 3000
```

## Specify ssl, certs, keys

```ts
bud.serve({
  ssl: true,
  cert: '/path/to/cert',
  key: '/path/to/key',
})
// => https://0.0.0.0:3000
```

Specify with HTTP(S) connection options

```ts
bud.serve({
  options: {maxHeaderSize?: number | undefined, ..etc}
})
```

These are all optional and can be combined freely.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
