### PR TITLE
test: add `bud.devtool` spec

### DIFF
--- a/tests/unit/bud-api/repository/devtool.test.ts
+++ b/tests/unit/bud-api/repository/devtool.test.ts
@@ -1,5 +1,4 @@
-import {Bud, factory, mockProject} from '@repo/test-kit/bud'
-import {execa} from '@roots/bud-support'
+import {Bud, factory} from '@repo/test-kit/bud'
 
 describe('bud.devtool', function () {
   let bud: Bud

--- a/tests/unit/bud-api/repository/devtool.test.ts
+++ b/tests/unit/bud-api/repository/devtool.test.ts
@@ -1,0 +1,43 @@
+import {Bud, factory, mockProject} from '@repo/test-kit/bud'
+import {execa} from '@roots/bud-support'
+
+describe('bud.devtool', function () {
+  let bud: Bud
+
+  beforeAll(async () => (bud = await factory()))
+
+  it('is a function', () => {
+    expect(bud.devtool).toBeInstanceOf(Function)
+  })
+
+  it('is not defined by default', async () => {
+    expect(bud.hooks.filter('build.devtool')).toBeUndefined()
+  })
+
+  it('enables default when called', async () => {
+    await bud.api.call('devtool')
+    expect(bud.hooks.filter('build.devtool')).toBe(
+      'cheap-module-source-map',
+    )
+  })
+
+  it('disables devtool when called with `false`', async () => {
+    await bud.api.call('devtool', false)
+    expect(bud.hooks.filter('build.devtool')).toBe(false)
+  })
+
+  it('enables specified devtool when called with a string', async () => {
+    await bud.api.call('devtool', 'source-map')
+    expect(bud.hooks.filter('build.devtool')).toBe('source-map')
+  })
+
+  it('sets source-map option for css loaders to `true` when enabled', async () => {
+    await bud.api.call('devtool', 'source-map')
+    expect(bud.build.items.css.getOptions()['sourceMap']).toBe(true)
+  })
+
+  it('sets source-map option for css loaders to `false` when disabled', async () => {
+    await bud.api.call('devtool', false)
+    expect(bud.build.items.css.getOptions()['sourceMap']).toBe(false)
+  })
+})


### PR DESCRIPTION
## Overview

- Simple test spec for `bud.devtool`.

refers: none
closes: none

## Type of change

- NONE: internal change

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
