### PR TITLE
:label: types(patch): improve framework typings

### DIFF
--- a/sources/@roots/bud-api/src/api/methods/template/interpolate-html-plugin.plugin.ts
+++ b/sources/@roots/bud-api/src/api/methods/template/interpolate-html-plugin.plugin.ts
@@ -1,4 +1,4 @@
-import type {Framework, Index} from '@roots/bud-framework'
+import type {Framework} from '@roots/bud-framework'
 import {bind} from '@roots/bud-support'
 import type {Compilation, Compiler} from 'webpack'
 
@@ -17,24 +17,18 @@ export class InterpolateHtmlPlugin {
    */
   public name = 'interpolate-html-plugin'
 
-  public bud?: () => Framework
-
   /**
    * Class constructor
    *
    * @param htmlWebpackPlugin - {@link HtmlWebpackPlugin}
-   * @param replacements - {@link Index} of regular expressions
+   * @param replacements - Regular expression records
    *
    * @public
    */
   public constructor(
     public htmlWebpackPlugin: HtmlWebpackPlugin,
-    public replacements: Index<RegExp>,
-    bud?: Framework,
+    public replacements:Record<string, RegExp>,
   ) {
-    if (bud) {
-      this.bud = () => bud
-    }
   }
 
   /**
@@ -62,30 +56,13 @@ export class InterpolateHtmlPlugin {
     HtmlWebpackPlugin.getHooks(compilation).afterTemplateExecution.tap(
       'InterpolateHtmlPlugin',
       (data: any) => {
-        this.bud().dump(this.replacements, {
-          prefix: 'template replacements',
-          language: 'html',
-          callToJSON: false,
-        })
-        this.bud().dump(data.html, {
-          prefix: 'html data',
-          language: 'html',
-          callToJSON: false,
-        })
         Object.entries(this.replacements).forEach(([key, value]) => {
           data.html = data.html.replaceAll(
             new RegExp(`%${key}%`, 'g'),
             value,
           )
         })
-
-        this.bud().dump(data.html, {
-          prefix: 'html with replacements',
-          language: 'html',
-          callToJSON: false,
-          escapeString: false,
-        })
-
+        
         return data
       },
     )

--- a/sources/@roots/bud-framework/src/Extensions/Extension/compiler-plugin.interface.ts
+++ b/sources/@roots/bud-framework/src/Extensions/Extension/compiler-plugin.interface.ts
@@ -1,7 +1,7 @@
 import {Signale} from '@roots/bud-support'
 import {Container} from '@roots/container'
 
-import {Framework, Maybe} from '../..'
+import {Framework} from '../..'
 import {Module} from './module.interface'
 
 /**
@@ -25,7 +25,7 @@ export interface CompilerPlugin<
    *
    * @public
    */
-  make?: Maybe<[Container<Options>, Framework, Signale], Plugin>
+  make?: | Plugin | ((options: Container<Options>, app: Framework, logger: Signale) => Plugin)
 
   /**
    * Compiler plugin `apply` method

--- a/sources/@roots/bud-framework/src/Extensions/Extension/module.interface.ts
+++ b/sources/@roots/bud-framework/src/Extensions/Extension/module.interface.ts
@@ -1,7 +1,7 @@
 import {Signale} from '@roots/bud-support'
 import {Container} from '@roots/container'
 
-import {Factory, Framework, Loose, Maybe, Modules, Plugins} from '../..'
+import {Factory, Framework, Modules} from '../..'
 
 /**
  * Bud extension interface
@@ -10,20 +10,20 @@ import {Factory, Framework, Loose, Maybe, Modules, Plugins} from '../..'
  *
  * @public
  */
-export interface Module<Options = any> extends Loose {
+export interface Module<Options = any> extends Record<string, any> {
   /**
    * The module name
    *
    * @public
    */
-  name?: `${(keyof Modules & string) | (keyof Plugins & string)}`
+  name?: `${keyof Modules & string}`
 
   /**
    * Options registered to the extension module
    *
    * @public
    */
-  options?: Maybe<[Framework], Options>
+  options?: Options | ((app: Framework) => Options)
 
   /**
    * General purpose callback. Called first.
@@ -78,5 +78,5 @@ export interface Module<Options = any> extends Loose {
    *
    * @public
    */
-  when?: Maybe<[Framework, Container<Options>], boolean>
+  when?: boolean | ((app: Framework, options: Container<Options>) => boolean)
 }

--- a/sources/@roots/bud-framework/src/Framework/methods/path.ts
+++ b/sources/@roots/bud-framework/src/Framework/methods/path.ts
@@ -1,6 +1,6 @@
 import {resolve, sep as slash} from 'node:path'
 
-import {Framework} from '../..'
+import {Framework, Locations} from '../..'
 
 /**
  * Transform `@alias` path
@@ -12,7 +12,12 @@ import {Framework} from '../..'
  * @public
  */
 export interface parseAlias {
-  (app: Framework, base: `@${string}` & string): string
+  (
+    app: Framework,
+    base:
+      | `${keyof Locations & string}`
+      | `${keyof Locations & string}/${string}`,
+  ): string
 }
 
 export const parseAlias: parseAlias = (app, base) => {
@@ -42,7 +47,10 @@ export const parseAlias: parseAlias = (app, base) => {
  * @public
  */
 export interface path {
-  (base?: string, ...segments: Array<string>): string
+  (
+    base?: `${keyof Locations & string}` | `@file` | `@name` | `${keyof Locations & string}/${string}` | `./${string}` | `/${string}`,
+    ...segments: Array<string>
+  ): string
 }
 
 export const path: path = function (base, ...segments) {
@@ -51,7 +59,7 @@ export const path: path = function (base, ...segments) {
   /* Exit early with projectDir if no path was passed */
   if (!base) return app.context.projectDir
 
-  const fileHandles = (pathString: string) =>
+  const fileHandles = (pathString: string): string =>
     pathString
       .replace(
         '@file',

--- a/sources/@roots/bud-framework/src/Framework/methods/setPath.ts
+++ b/sources/@roots/bud-framework/src/Framework/methods/setPath.ts
@@ -15,8 +15,8 @@ const {isString} = lodash
  * @public
  */
 export interface setPath {
-  <T extends `${keyof Locations & `@${string}` & string}`>(
-    arg1: T | Record<T, string>,
+  <T extends `${keyof Locations & string}`>(
+    arg1: T | Partial<Record<T, string>>,
     arg2?: string,
   ): Framework
 }
@@ -26,7 +26,7 @@ export const setPath: setPath = function (arg1, arg2) {
 
   const input = isString(arg1) ? {[arg1]: arg2} : arg1
 
-  Object.entries(input).map(([key, value]) => {
+  Object.entries(input).map(([key, value]: [`${keyof Locations & string}`, string]) => {
     !key.startsWith(`@`) &&
       app.error(
         `bud paths are required to be prefixed with \`@\`. Please convert \`${key}\` to \`@${key}\``,

--- a/sources/@roots/bud-framework/src/Hooks.ts
+++ b/sources/@roots/bud-framework/src/Hooks.ts
@@ -1,9 +1,7 @@
-import {Container} from '@roots/container'
 import {WatchOptions} from 'chokidar'
-import {ValueOf} from 'type-fest'
 import {Configuration} from 'webpack'
 
-import {Framework, Locations, Modules, Plugins, Service} from './'
+import {Framework, Locations, Modules, Service} from './'
 import {ConfigMap} from './config.map'
 import {EntryObject} from './entry'
 import * as Server from './Server'
@@ -195,6 +193,10 @@ export namespace Hooks {
     [K in keyof Locations as `location.${K & string}`]: Locations[K]
   }
 
+  export type ModuleOptions = {
+    [K in keyof Modules as `extension.${K & string}.options`]: Modules[K]['options']
+  }
+
   /**
    * Syncronous hooks map
    *
@@ -202,11 +204,12 @@ export namespace Hooks {
    */
   export interface Map
     extends Server.Middleware.Middleware<`options`>,
-      Server.Middleware.Middleware<`factory`>,
-      Server.OptionsMap,
-      LocationKeyMap,
-      ConfigMap {
-    [`extension`]: ValueOf<Plugins> | ValueOf<Modules>
+    Server.Middleware.Middleware<`factory`>,
+    Server.OptionsMap,
+    LocationKeyMap,
+    ConfigMap,
+    ModuleOptions {
+    
     /**
      * Dev server connection options
      * @public
@@ -252,18 +255,6 @@ export namespace Hooks {
     [`middleware.enabled`]: Array<keyof Server.Middleware.Available>
     [`middleware.proxy.target`]: URL
     [`middleware.proxy.replacements`]: Array<[RegExp | string, string]>
-
-    // here down is wack
     [key: Server.Middleware.OptionsKey]: any
-    [
-      key: `extension.${
-        | (keyof Modules & string)
-        | (keyof Plugins & string)}`
-    ]: any
-    [
-      key: `extension.${
-        | (keyof Modules & string)
-        | (keyof Plugins & string)}.options`
-    ]: Container<Record<string, any>>
   }
 }

--- a/sources/@roots/bud-framework/src/index.ts
+++ b/sources/@roots/bud-framework/src/index.ts
@@ -3,30 +3,10 @@
 
 /**
  * ⚡️ Bud/Framework - Extensible build tooling for modern web development
- *
- * @remarks
- * The {@link @roots/bud-framework# | @roots/bud-framework} package defines the
- * abstract {@link Framework} class and provides interfaces for the Framework's
- * essential {@link Service} classes.
- *
- * The overarching design goal of this architecture is to make it as simple as
- * possible to swap out the underlying {@link Service} implementations without
- * having to modify the core framework code.
- *
- * To that effect, interoperability with other build tools is possible through
- * extending the {@link Framework} class and adding or modifying {@link Service}
- * classes.
- *
- * The original implementation uses Webpack as the underlying
- * build tool, but this is not a requirement for future implementations and
- * we've done our best to maintain a separation of core code from
- * the build tool we are currently leveraging.
- *
- * We sincerely hope that these efforts will help you build a better web.
- *
+ * 
  * @see https://roots.io/bud
  * @see https://github.com/roots/bud
- *
+ * 
  * @packageDocumentation
  */
 
@@ -41,17 +21,7 @@ import {Project} from './Project'
 import * as Server from './Server'
 import {Service} from './Service'
 
-/**
- * Concrete classes
- */
-//
-
 export {Store} from './Store'
-
-/**
- * Abstract classes
- */
-//
 
 export {Build}
 export {Cache}
@@ -69,11 +39,6 @@ export {Rule}
 export {Service}
 export {Server}
 
-/**
- * Types and interfaces
- */
-//
-
 export {Api} from './Api'
 export {Compiler} from './Compiler'
 export {Dashboard} from './Dashboard'
@@ -83,17 +48,7 @@ export {Hooks} from './Hooks'
 export {Logger} from './Logger'
 
 /**
- * Loosely typed interface
- *
- * @public
- */
-export interface Loose {
-  [key: string]: any
-}
-
-/**
  * Framework factory
- *
  * @public
  */
 export interface Factory<P extends any[], T> {
@@ -102,7 +57,6 @@ export interface Factory<P extends any[], T> {
 
 /**
  * Framework async factory
- *
  * @public
  */
 export interface AsyncFactory<P extends any[], T> {
@@ -110,92 +64,41 @@ export interface AsyncFactory<P extends any[], T> {
 }
 
 /**
- * Callback which accepts Framework as a parameter
- *
- * @public
- */
-export interface Tapable<P extends any[] = [Framework], T = any>
-  extends Factory<[P], T> {
-  (this: P, ...args: P): T
-}
-
-/**
- * At least one parameter is required
- *
- * @public
- */
-export type AtLeastOne<Type = unknown> = Type | Type[]
-
-/**
- * Maybe
- *
- * @remarks
- * If T is a function, and it is passed a value of type A, it returns T.
- * If it is not a function, it returns T.
- *
- * @typeParam A - Arguments to be passed when T is a function and it is invoked
- * @typeParam T - Type to be returned
- *
- * @public
- */
-export type Maybe<A extends any[], T> = T | Factory<A, T>
-
-/**
- * Hash of a given object type
- *
- * @public
- */
-export type Index<T = any> = {[key: string]: T}
-
-/**
  * Compilation mode
- *
  * @public
  */
 export type Mode = 'production' | 'development'
 
 /**
  * Registered extensions
- *
  * @virtual @public
  */
-export interface Modules extends Partial<Index<Extension.Module>> {}
-
-/**
- * Registered plugins
- *
- * @virtual @public
- */
-export interface Plugins
-  extends Partial<Index<Extension.CompilerPlugin>> {}
+export interface Plugins extends Record<string, Extension.CompilerPlugin> {}
+export interface Modules extends Plugins, Record<string, Extension.Module | Extension.CompilerPlugin> {}
 
 /**
  * Registered loaders
- *
  * @virtual @public
  */
-export interface Loaders extends Partial<Index<Loader>> {}
+export interface Loaders extends Record<string, Loader> {}
 
 /**
  * Registered items
- *
  * @virtual @public
  */
-export interface Items extends Partial<Index<Item>> {}
+export interface Items extends Record<string, Item> {}
 
 /**
  * Registered rules
- *
  * @virtual @public
  */
-export interface Rules extends Partial<Record<string, Rule>> {}
+export interface Rules extends Record<string, Rule> {}
 
 /**
  * Registered locations
- *
  * @virtual @public
  */
-export interface Locations extends Partial<Record<string, string>> {
+export interface Locations extends Record<string, string> {
   '@src': string
   '@dist': string
   '@storage': string
@@ -204,17 +107,6 @@ export interface Locations extends Partial<Record<string, string>> {
 
 /**
  * Registered services
- *
  * @virtual @public
  */
-export interface Services
-  extends Partial<Record<string, new (app: Framework) => Service>> {}
-
-/**
- * Module
- *
- * @deprecated Use {@link Extension.Module} or {@link Extension.CompilerPlugin} instead
- *
- * @public
- */
-export interface Module<P = any, O = any> extends Extension.Module<O> {}
+export interface Services {}

--- a/sources/@roots/bud-mdx/src/MdxConfig/index.ts
+++ b/sources/@roots/bud-mdx/src/MdxConfig/index.ts
@@ -1,4 +1,4 @@
-import type {Framework, Index} from '@roots/bud-framework'
+import type {Framework} from '@roots/bud-framework'
 
 interface Options {
   rehypePlugins: any[]
@@ -11,12 +11,12 @@ class MdxConfig implements MdxConfig {
   /**
    * Get registered remark plugins.
    */
-  public remarkPlugins: Index<any> = {}
+  public remarkPlugins: Record<string, any> = {}
 
   /**
    * Get registered rehype plugins.
    */
-  public rehypePlugins: Index<any> = {}
+  public rehypePlugins: Record<string, any> = {}
 
   public constructor(app: Framework) {
     this._app = () => app

--- a/sources/@roots/sage/src/bud.env.d.ts
+++ b/sources/@roots/sage/src/bud.env.d.ts
@@ -71,6 +71,18 @@ declare module '@roots/bud-framework' {
     useTailwindColors: useTailwindColors.facade
   }
 
+  interface Locations {
+    '@src': string
+    '@dist': string
+    '@resources': string
+    '@public': string
+    '@fonts': string
+    '@images': string
+    '@scripts': string
+    '@styles': string
+    '@views': string
+  }
+
   interface Modules {
     '@roots/sage': Sage
     'wp-theme-json': ThemeJSON.ThemeExtension


### PR DESCRIPTION
## Overview

Gets rid of a number of older, junky types. More strictly enforces registries for `Modules`, `Locations`, `Loaders`, `Rules`, `Items`.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
