### PR TITLE
🛠️ : dev(none): fix invalid emoji name

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -19,7 +19,7 @@ module.exports = {
       name: '🔨 dev\tadd or update config files or dev scripts',
     },
     {value: ':rewind: revert', name: '⏪️ revert\trevert commit'},
-    {value: ':merge: merge', name: '🔀 merge\tmerge branch'},
+    {value: ':fast_forward: merge', name: '⏩ merge\tmerge branch'},
     {value: ':construction: wip', name: '🚧 wip\twork in progress'},
   ],
 


### PR DESCRIPTION
## Overview

`:merge:` isn't a thing. `:twisted_rightward_arrows:` isn't a thing i'm going to type. 

behold: `:merge:` becomes `:fast_forward:`

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
