### PR TITLE
:package: move html-webpack-plugin to dependencies

### DIFF
--- a/sources/@roots/bud-api/package.json
+++ b/sources/@roots/bud-api/package.json
@@ -76,21 +76,15 @@
   "devDependencies": {
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework",
     "@skypack/package-check": "0.2.2",
-    "@types/fs-extra": "9.0.13",
-    "@types/jest": "27.4.1",
-    "@types/lodash": "4.14.180",
     "@types/node": "16.11.26",
-    "fs-extra": "10.0.1",
-    "html-webpack-plugin": "5.5.0",
-    "lodash": "4.17.21",
     "nanoid": "3.3.1",
-    "npm-run-path": "5.1.0",
     "webpack": "5.70.0"
   },
   "dependencies": {
     "@roots/bud-support": "workspace:sources/@roots/bud-support",
     "copy-webpack-plugin": "10.2.4",
     "css-minimizer-webpack-plugin": "3.4.1",
+    "html-webpack-plugin": "5.5.0",
     "tslib": "^2.3.1"
   }
 }

--- a/sources/@roots/bud-preset-wordpress/src/bud.env.ts
+++ b/sources/@roots/bud-preset-wordpress/src/bud.env.ts
@@ -1,0 +1,14 @@
+import '@roots/bud-babel'
+import '@roots/bud-postcss'
+import '@roots/bud-react'
+import '@roots/bud-wordpress-dependencies'
+import '@roots/bud-wordpress-externals'
+import '@roots/bud-wordpress-manifests'
+
+import {BudWordPressPreset} from './'
+
+declare module '@roots/bud-framework' {
+  interface Modules {
+    '@roots/bud-preset-wordpress': BudWordPressPreset
+  }
+}

--- a/sources/@roots/bud-preset-wordpress/src/index.ts
+++ b/sources/@roots/bud-preset-wordpress/src/index.ts
@@ -10,19 +10,15 @@
  * @packageDocumentation
  */
 
-import type {Bud, Extension} from '@roots/bud-framework'
+import './bud.env'
 
-declare module '@roots/bud-framework' {
-  interface Modules {
-    '@roots/bud-preset-wordpress': BudWordPressPreset
-  }
-}
+import type {Bud, Extension} from '@roots/bud-framework'
 
 /**
  * Preset config for WordPress plugins & themes
  * @public
  */
-type BudWordPressPreset = Extension.Module
+export type BudWordPressPreset = Extension.Module
 
 /**
  * Find/replace {@link URL.href} with {@link URL.pathname}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,17 +3295,11 @@ __metadata:
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework"
     "@roots/bud-support": "workspace:sources/@roots/bud-support"
     "@skypack/package-check": 0.2.2
-    "@types/fs-extra": 9.0.13
-    "@types/jest": 27.4.1
-    "@types/lodash": 4.14.180
     "@types/node": 16.11.26
     copy-webpack-plugin: 10.2.4
     css-minimizer-webpack-plugin: 3.4.1
-    fs-extra: 10.0.1
     html-webpack-plugin: 5.5.0
-    lodash: 4.17.21
     nanoid: 3.3.1
-    npm-run-path: 5.1.0
     tslib: ^2.3.1
     webpack: 5.70.0
   languageName: unknown
@@ -16412,21 +16406,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:5.1.0, npm-run-path@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "npm-run-path@npm:5.1.0"
-  dependencies:
-    path-key: ^4.0.0
-  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
-  languageName: node
-  linkType: hard
-
 "npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
   dependencies:
     path-key: ^3.0.0
   checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
+  languageName: node
+  linkType: hard
+
+"npm-run-path@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "npm-run-path@npm:5.1.0"
+  dependencies:
+    path-key: ^4.0.0
+  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- :package: deps(none): html-webpack-plugin should be a dependency
- :label: types(none): fix @roots/bud-preset-wordpress typings
- :package: deps(none): yarn.lock

## Overview

This is a stub PR for a proposed change. Details forthcoming.

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
