### PR TITLE
🚑 fix(patch): call user config before `bud clean`

### DIFF
--- a/sources/@repo/markdown-kit/readme/templates/extension.template.tsx
+++ b/sources/@repo/markdown-kit/readme/templates/extension.template.tsx
@@ -31,8 +31,6 @@ export const Extension = ({
 
     <code lang="shell">yarn add {name} --dev</code>
 
-    <code lang="shell">yarn bud install</code>
-
     <Docs url={projectConfig.url.docs} />
 
     <Community />

--- a/sources/@roots/bud/src/cli/commands/clean.ts
+++ b/sources/@roots/bud/src/cli/commands/clean.ts
@@ -17,6 +17,7 @@ export class CleanCommand extends BaseCommand {
 
   public async execute() {
     this.app = await factory()
+    await this.make()
     await this.cleanProjectAssets()
   }
 

--- a/tests/unit/bud-framework/framework.test.ts
+++ b/tests/unit/bud-framework/framework.test.ts
@@ -19,7 +19,6 @@ describe('bud', () => {
 
     const isDev = await factory({mode: 'development'})
     expect(isDev.isDevelopment).toEqual(true)
-    await isDev.close()
   })
 
   it('isProduction', async () => {


### PR DESCRIPTION
## Overview

Call user config before running `bud clean`

closes:  #1348

## Type of change

- PATCH: Backwards compatible bug fix

- PATCH: bug fix

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
