### PR TITLE
🚑 fix(patch): allow extensions import failure

### DIFF
--- a/sources/@roots/bud-extensions/src/Extensions/extensions.service.ts
+++ b/sources/@roots/bud-extensions/src/Extensions/extensions.service.ts
@@ -77,17 +77,19 @@ export class Extensions extends Service implements Contract.Service {
       Object.keys({
         ...(this.app.context.manifest?.devDependencies ?? {}),
         ...(this.app.context.manifest?.dependencies ?? {}),
-      }).map(async pkg => {
-        try {
-          const manifest = await this.app.module
-            .manifestPath(pkg)
-            .then(this.app.module.readManifest)
+      })
+        .filter(name => !name.startsWith('@types'))
+        .map(async pkg => {
+          try {
+            const manifest = await this.app.module
+              .manifestPath(pkg)
+              .then(this.app.module.readManifest)
 
-          return manifest.bud ? await this.import(pkg) : noop
-        } catch (error) {
-          this.app.error(`Error importing`, pkg, `\n`, error)
-        }
-      }),
+            return manifest.bud ? await this.import(pkg) : noop
+          } catch (error) {
+            this.app.warn(`Error importing`, pkg, `\n`, error)
+          }
+        }),
     )
   }
 


### PR DESCRIPTION
## Overview

Not all packages are guaranteed to resolve to a module. Allow import attempts to silently fail.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
