### PR TITLE
🐛 fix(patch): do not emit empty js assets

### DIFF
--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -118,6 +118,7 @@
     "type-fest": "^2.5.4",
     "webpack": "5.72.1",
     "webpack-cli": "^4.9.1",
-    "webpack-manifest-plugin": "^5.0.0"
+    "webpack-manifest-plugin": "^5.0.0",
+    "webpack-remove-empty-scripts": "0.8.0"
   }
 }

--- a/sources/@roots/bud/src/extensions/index.ts
+++ b/sources/@roots/bud/src/extensions/index.ts
@@ -6,7 +6,8 @@ import MiniCssExtractPlugin from './mini-css-extract-plugin'
 import DefineWebpackPlugin from './webpack-define-plugin'
 import HotModuleReplacementPlugin from './webpack-hot-module-replacement-plugin'
 import WebpackManifestPlugin from './webpack-manifest-plugin'
-import BudProvide from './webpack-provide-plugin'
+import ProvidePlugin from './webpack-provide-plugin'
+import RemoveEmptyScriptsPlugin from './webpack-remove-empty-scripts'
 
 /**
  * Built-in extensions factory
@@ -16,11 +17,12 @@ import BudProvide from './webpack-provide-plugin'
  * @public
  */
 export const extensions: Config.Options['extensions'] = [
-  BudProvide,
+  ProvidePlugin,
   DefineWebpackPlugin,
   HotModuleReplacementPlugin,
   CleanWebpackPlugin,
   CopyWebpackPlugin,
   WebpackManifestPlugin,
   MiniCssExtractPlugin,
+  RemoveEmptyScriptsPlugin,
 ]

--- a/sources/@roots/bud/src/extensions/webpack-remove-empty-scripts/index.ts
+++ b/sources/@roots/bud/src/extensions/webpack-remove-empty-scripts/index.ts
@@ -1,0 +1,18 @@
+import {Extension} from '@roots/bud-framework'
+import {
+  bind,
+  label,
+  plugin,
+} from '@roots/bud-framework/extension/decorators'
+import Plugin from 'webpack-remove-empty-scripts'
+
+@label('webpack-remove-empty-scripts')
+@plugin(Plugin)
+class BudRemoveEmptyScripts extends Extension<null, Plugin> {
+  @bind
+  public async when() {
+    return this.app.isProduction
+  }
+}
+
+export default BudRemoveEmptyScripts

--- a/sources/@roots/bud/src/extensions/webpack-remove-empty-scripts/index.ts
+++ b/sources/@roots/bud/src/extensions/webpack-remove-empty-scripts/index.ts
@@ -1,18 +1,14 @@
 import {Extension} from '@roots/bud-framework'
 import {
-  bind,
   label,
   plugin,
+  production,
 } from '@roots/bud-framework/extension/decorators'
 import Plugin from 'webpack-remove-empty-scripts'
 
 @label('webpack-remove-empty-scripts')
 @plugin(Plugin)
-class BudRemoveEmptyScripts extends Extension<null, Plugin> {
-  @bind
-  public async when() {
-    return this.app.isProduction
-  }
-}
+@production
+class BudRemoveEmptyScripts extends Extension<null, Plugin> {}
 
 export default BudRemoveEmptyScripts

--- a/tests/integration/__snapshots__/sass-tailwindcss.test.ts.snap
+++ b/tests/integration/__snapshots__/sass-tailwindcss.test.ts.snap
@@ -3,13 +3,11 @@
 exports[`sass-tailwindcss npm manifest.json matches snapshot 1`] = `
 Object {
   "app.css": "app.css",
-  "app.js": "app.js",
 }
 `;
 
 exports[`sass-tailwindcss yarn manifest.json matches snapshot 1`] = `
 Object {
   "app.css": "app.css",
-  "app.js": "app.js",
 }
 `;

--- a/tests/integration/__snapshots__/sass.test.ts.snap
+++ b/tests/integration/__snapshots__/sass.test.ts.snap
@@ -8,7 +8,6 @@ exports[`sass npm app.css matches snapshot 1`] = `
 exports[`sass npm manifest.json matches snapshot 1`] = `
 Object {
   "app.css": "app.css",
-  "app.js": "app.js",
 }
 `;
 
@@ -20,6 +19,5 @@ exports[`sass yarn app.css matches snapshot 1`] = `
 exports[`sass yarn manifest.json matches snapshot 1`] = `
 Object {
   "app.css": "app.css",
-  "app.js": "app.js",
 }
 `;

--- a/tests/integration/sage.test.ts
+++ b/tests/integration/sage.test.ts
@@ -13,16 +13,12 @@ const test = (pacman: 'yarn' | 'npm') => () => {
 
   describe('entrypoints.json', () => {
     it('has expected app entries', () => {
-      expect(project.entrypoints.app.js).toBeInstanceOf(Array)
-      expect(project.entrypoints.app.js).toHaveLength(2)
       expect(project.entrypoints.app.css).toBeInstanceOf(Array)
       expect(project.entrypoints.app.css).toHaveLength(1)
       expect(project.entrypoints.app.dependencies).toEqual([])
     })
 
     it('has expected editor entries', () => {
-      expect(project.entrypoints.editor.js).toBeInstanceOf(Array)
-      expect(project.entrypoints.editor.js).toHaveLength(2)
       expect(project.entrypoints.editor.css).toBeInstanceOf(Array)
       expect(project.entrypoints.editor.css).toHaveLength(1)
     })
@@ -70,12 +66,8 @@ const test = (pacman: 'yarn' | 'npm') => () => {
     })
   })
 
-  it('[editor] has contents', () => {
-    expect(project.assets['editor.js'].length).toBeGreaterThan(10)
-  })
-
-  it('[editor] is transpiled', () => {
-    expect(project.assets['editor.js'].includes('import')).toBeFalsy()
+  it('[editor] is not defined', () => {
+    expect(project.assets['editor.js']).toBeUndefined()
   })
 
   it('[editor] css: has contents', () => {
@@ -105,7 +97,6 @@ const test = (pacman: 'yarn' | 'npm') => () => {
   it('[snapshots] public/manifest.json matches expectations', async () => {
     expect(project.manifest['app.js']).toMatch(/app\.[\d|\w]*\.js/)
     expect(project.manifest['app.css']).toMatch(/app\.[\d|\w]*\.css/)
-    expect(project.manifest['editor.js']).toMatch(/editor\.[\d|\w]*\.js/)
     expect(project.manifest['editor.css']).toMatch(/editor\.[\d|\w]*\.css/)
     expect(project.manifest['runtime.js']).toMatch(/runtime\.[\d|\w]*\.js/)
   })

--- a/tests/unit/bud-extensions/__snapshots__/service.development.test.ts.snap
+++ b/tests/unit/bud-extensions/__snapshots__/service.development.test.ts.snap
@@ -12,6 +12,7 @@ Array [
   "copy-webpack-plugin",
   "mini-css-extract-plugin",
   "webpack-manifest-plugin",
+  "webpack-remove-empty-scripts",
   "webpack:define-plugin",
   "webpack:hot-module-replacement-plugin",
   "webpack:provide-plugin",

--- a/tests/unit/bud-extensions/__snapshots__/service.production.test.ts.snap
+++ b/tests/unit/bud-extensions/__snapshots__/service.production.test.ts.snap
@@ -12,6 +12,7 @@ Array [
   "copy-webpack-plugin",
   "mini-css-extract-plugin",
   "webpack-manifest-plugin",
+  "webpack-remove-empty-scripts",
   "webpack:define-plugin",
   "webpack:hot-module-replacement-plugin",
   "webpack:provide-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4261,6 +4261,7 @@ __metadata:
     webpack: 5.72.1
     webpack-cli: ^4.9.1
     webpack-manifest-plugin: ^5.0.0
+    webpack-remove-empty-scripts: 0.8.0
   bin:
     bud: ./bin/bud.js
   languageName: unknown
@@ -6850,6 +6851,13 @@ __metadata:
   version: 0.1.0
   resolution: "ansi-wrap@npm:0.1.0"
   checksum: f24f652a5e450c0561cbc7d298ffa62dcd33c72f9da34fd3c24538dbf82de8fc21b7f924dc30cd9d01360bd2893d1954f0a60eee0550ca629bb148dcbeef5c5b
+  languageName: node
+  linkType: hard
+
+"ansis@npm:^1.3.4":
+  version: 1.3.6
+  resolution: "ansis@npm:1.3.6"
+  checksum: 8d9341558abee49884a34bb4ac3421a1c478a06938f452cbaeec75f6bfa76a8ac24f3e98f3d3a22a9587257e6739ede36fb082af8a004c81814c02a8cff2bf52
   languageName: node
   linkType: hard
 
@@ -21857,6 +21865,14 @@ __metadata:
   languageName: node
   linkType: hard
 
+"test-styles-only@workspace:tests/util/styles-only":
+  version: 0.0.0-use.local
+  resolution: "test-styles-only@workspace:tests/util/styles-only"
+  dependencies:
+    "@roots/bud": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "text-extensions@npm:^1.0.0":
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"
@@ -23466,6 +23482,17 @@ __metadata:
     clone-deep: ^4.0.1
     wildcard: ^2.0.0
   checksum: 88786ab91013f1bd2a683834ff381be81c245a4b0f63304a5103e90f6653f44dab496a0768287f8531761f8ad957d1f9f3ccb2cb55df0de1bd9ee343e079da26
+  languageName: node
+  linkType: hard
+
+"webpack-remove-empty-scripts@npm:0.8.0":
+  version: 0.8.0
+  resolution: "webpack-remove-empty-scripts@npm:0.8.0"
+  dependencies:
+    ansis: ^1.3.4
+  peerDependencies:
+    webpack: ">=5.32.0"
+  checksum: cf78e7516b18321cd234d5a86231d01403d4393f9e802b8552e150315772adb5889a24a4eb8c067aba0dc831e238513196e59f6225e5bb098d31c2da7be19cc7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21865,14 +21865,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"test-styles-only@workspace:tests/util/styles-only":
-  version: 0.0.0-use.local
-  resolution: "test-styles-only@workspace:tests/util/styles-only"
-  dependencies:
-    "@roots/bud": "workspace:*"
-  languageName: unknown
-  linkType: soft
-
 "text-extensions@npm:^1.0.0":
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"


### PR DESCRIPTION
## Overview

Adds [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) plugin extension to prevent empty assets from being emitted. 

See this webpack issue: https://github.com/webpack/webpack/issues/7300. The suggested course of resolution doesn't seem to work. But the plugin works well. 

- 🐛 fix(patch): add webpack-remove-empty-scripts
- 🛼 improve(none): use @production decorator
- 🧪 test(none): update tests
- 📦 deps(patch): lockfile

closes: #1416

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- @roots/bud: [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts)

### Removes

- none
