### PR TITLE
🐛 fix(patch): do not inject proxy click handler for no proxy dev

### DIFF
--- a/sources/@roots/bud-server/src/client/inject.ts
+++ b/sources/@roots/bud-server/src/client/inject.ts
@@ -36,10 +36,12 @@ export const inject: inject = async (
         if (!entry) return entrypoints
 
         entry.import = Array.from(
-          new Set([
-            ...injection.map(inject => inject(app)),
-            ...(entry.import ?? []),
-          ]),
+          new Set(
+            [
+              ...injection.map(inject => inject(app)),
+              ...(entry.import ?? []),
+            ].filter(Boolean),
+          ),
         )
 
         return {...entrypoints, [name]: entry}

--- a/sources/@roots/bud-server/src/hooks/dev.client.scripts.ts
+++ b/sources/@roots/bud-server/src/hooks/dev.client.scripts.ts
@@ -1,0 +1,44 @@
+import {Bud} from '@roots/bud-framework/src'
+
+export const src = (modulePath: string) =>
+  `@roots/bud-server/client/${modulePath}`
+
+/**
+ * Proxy click interceptor
+ *
+ * @param app - Bud instance
+ * @returns string
+ *
+ * @public
+ */
+export const proxyClickInterceptor = (app: Bud) =>
+  app.hooks.filter('dev.middleware.enabled', []).includes('proxy')
+    ? src(`proxy-click-interceptor.js`)
+    : null
+
+/**
+ * Overlay
+ *
+ * @param app - Bud instance
+ * @returns string
+ *
+ * @public
+ */
+export const overlay = (app: Bud) =>
+  src(
+    `index.js?name=${app.name}&bud.overlay=${
+      app.context.args.overlay
+    }&bud.indicator=${app.context.args.indicator}&path=${app.hooks.filter(
+      'dev.middleware.hot.options.path',
+    )}`,
+  )
+
+/**
+ * Overlay
+ *
+ * @param app - Bud instance
+ * @returns set of client scripts
+ *
+ * @public
+ */
+export const callback = () => new Set([overlay, proxyClickInterceptor])

--- a/sources/@roots/bud-server/src/seed.ts
+++ b/sources/@roots/bud-server/src/seed.ts
@@ -1,7 +1,6 @@
 import {Bud} from '@roots/bud-framework'
 
-const src = (modulePath: string) =>
-  `@roots/bud-server/client/${modulePath}`
+import * as clientScripts from './hooks/dev.client.scripts'
 
 /**
  * Initial values
@@ -37,35 +36,13 @@ export const seed = (app: Bud) => {
       heartbeat: app.hooks.filter('dev.middleware.hot.options.heartbeat'),
     }))
 
-    .hooks.on(
-      `dev.middleware.hot.options.path`,
-      () => `${app.hooks.filter('build.output.publicPath')}__hmr`,
-    )
+    .hooks.on(`dev.middleware.hot.options.path`, () => `/__bud/hmr`)
     .hooks.on(
       `dev.middleware.hot.options.log`,
       app.logger.instance.scope('hot').info,
     )
     .hooks.on(`dev.middleware.hot.options.heartbeat`, 2000)
-    .hooks.on(
-      `dev.client.scripts`,
-      () =>
-        new Set([
-          app =>
-            src(
-              `index.js?name=${app.name}&bud.overlay=${
-                app.context.args.overlay
-              }&bud.indicator=${
-                app.context.args.indicator
-              }&path=${app.hooks.filter(
-                'dev.middleware.hot.options.path',
-              )}`,
-            ),
-          app =>
-            app.hooks.filter('dev.middleware.enabled').includes('proxy')
-              ? src(`proxy-click-interceptor.js`)
-              : null,
-        ]),
-    )
+    .hooks.on(`dev.client.scripts`, clientScripts.callback)
     .hooks.on(`dev.watch.files`, new Set([]))
     .hooks.on(`dev.watch.options`, {})
 }

--- a/sources/@roots/bud-server/src/seed.ts
+++ b/sources/@roots/bud-server/src/seed.ts
@@ -60,7 +60,10 @@ export const seed = (app: Bud) => {
                 'dev.middleware.hot.options.path',
               )}`,
             ),
-          () => src(`proxy-click-interceptor.js`),
+          app =>
+            app.hooks.filter('dev.middleware.enabled').includes('proxy')
+              ? src(`proxy-click-interceptor.js`)
+              : null,
         ]),
     )
     .hooks.on(`dev.watch.files`, new Set([]))


### PR DESCRIPTION
## Overview

Do not inject proxy click handler if no proxy is being used.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
