### PR TITLE
🛼 improve(patch): hard code /__bud/hmr path

### DIFF
--- a/sources/@roots/bud-server/src/client/bridge.ts
+++ b/sources/@roots/bud-server/src/client/bridge.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
 var options = {
-  path: '/__hmr',
+  path: '/__bud/hmr',
   timeout: 20 * 1000,
   overlay: true,
   reload: false,

--- a/sources/@roots/bud-server/src/client/index.ts
+++ b/sources/@roots/bud-server/src/client/index.ts
@@ -39,7 +39,7 @@ interface Options extends BaseOptions {
     warn: false,
     name: '',
     overlayWarnings: false,
-    path: '/__hmr',
+    path: '/__bud/hmr',
   }
 
   const options: Options = Object.entries(

--- a/sources/@roots/bud-server/src/seed.ts
+++ b/sources/@roots/bud-server/src/seed.ts
@@ -37,10 +37,7 @@ export const seed = (app: Bud) => {
       heartbeat: app.hooks.filter('dev.middleware.hot.options.heartbeat'),
     }))
 
-    .hooks.on(
-      `dev.middleware.hot.options.path`,
-      () => `${app.hooks.filter('build.output.publicPath')}__hmr`,
-    )
+    .hooks.on(`dev.middleware.hot.options.path`, () => `/__bud/hmr`)
     .hooks.on(
       `dev.middleware.hot.options.log`,
       app.logger.instance.scope('hot').info,


### PR DESCRIPTION
## Overview

Hardcodes `/__bud/hmr` as the hmr endpoint. The likelihood of conflict with this path is low and there is no reason to change it on the users end.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
