### PR TITLE
🛼 improve(patch): set parallelism based on cpu count

### DIFF
--- a/sources/@roots/bud/src/seed.ts
+++ b/sources/@roots/bud/src/seed.ts
@@ -107,7 +107,7 @@ export const seed: Config.Options['seed'] = {
   'build.optimization.minimize': [() => false],
   'build.optimization.minimizer': [() => ['...']],
   'build.optimization.removeEmptyChunks': [() => true],
-  'build.parallelism': [() => Math.max(cpus().length - 1, 1)],
+  'build.parallelism': [() => 10 * Math.max(cpus().length - 1, 1)],
   'build.performance': [() => ({hints: false})],
   'build.resolve.extensions': [
     () =>


### PR DESCRIPTION
## Overview

I misunderstood this originally. It doesn't define the core count, it defines the number of modules which can be processed at once. The default is `100`.

This code changes the value from `x` to `x * 10`, where `x` is the core count. 🤷🏼‍♂️

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
