### PR TITLE
🛼 improve(patch): @roots/sage: allow for use of app.setPublicPath

### DIFF
--- a/sources/@roots/sage/src/acorn.ts
+++ b/sources/@roots/sage/src/acorn.ts
@@ -19,8 +19,10 @@ export const setSvgEmit = ({build}: Bud) =>
  * Not setting an empty string will likely result in duplicative path segments
  * and unresolved assets.
  */
-export const setManifestPublicPath = ({extensions}: Bud) =>
+export const setManifestPublicPath = ({extensions}: Bud) => {
   extensions.get('@roots/bud-entrypoints').setOption('publicPath', '')
+  extensions.get('webpack-manifest-plugin').setOption('publicPath', '')
+}
 
 /**
  * - If publicPath is `/` in production assets will not be locatable by Acorn.

--- a/sources/@roots/sage/src/extension.ts
+++ b/sources/@roots/sage/src/extension.ts
@@ -15,7 +15,6 @@ export default class Sage extends Extension {
   public async boot() {
     acorn.setSvgEmit(this.app)
     acorn.setManifestPublicPath(this.app)
-    acorn.setPublicPath(this.app)
     acorn.hmrJson(this.app)
 
     await this.app.extensions.add(ThemeJSON)

--- a/sources/@roots/sage/src/extension.ts
+++ b/sources/@roots/sage/src/extension.ts
@@ -15,6 +15,7 @@ export default class Sage extends Extension {
   public async boot() {
     acorn.setSvgEmit(this.app)
     acorn.setManifestPublicPath(this.app)
+    acorn.setPublicPath(this.app)
     acorn.hmrJson(this.app)
 
     await this.app.extensions.add(ThemeJSON)


### PR DESCRIPTION
## Overview

This change allows for `@roots/sage` users using dynamic imports to set public path with `app.setPublicPath` [as documented](https://bud.js.org/guides/general-use/dynamic-imports).

Previously, it was required for them to use the `publicPath` property in the `bud.entry` object.

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
