### PR TITLE
fix: include hash with bud.assets calls

### DIFF
--- a/sources/@repo/docs/content/docs/bud.assets.mdx
+++ b/sources/@repo/docs/content/docs/bud.assets.mdx
@@ -13,7 +13,7 @@ You may specify a path to a specific file or use glob syntax to match many files
 
 This function is pretty flexible and accepts a few different ways of specifying what you want to copy.
 
-```ts
+```ts title='bud.config.js'
   (
     ...request: Array<
       | string
@@ -41,9 +41,29 @@ Use a single `string` to copy the entire images directory. Relative to source di
 bud.assets('images')
 ```
 
+### Copying using source/destination tuples
+
+You can also specify the source and destination using a tuple.
+
+The first item in each tuple is the source and the second is the destination:
+
+```js title='bud.config.js'
+bud.assets([
+  ['images', 'images'], // @src/images => @dist/images
+  ['fonts', 'fonts'],
+])
+```
+
+```js title='bud.config.js'
+bud.assets([
+  [bud.path('@src/assets/asset.png'), bud.path('@dist/asset.png')],
+  [bud.path('@src/fonts'), bud.path('@dist/fonts')],
+])
+```
+
 ### Copying using an object
 
-You can specify `CopyPlugin.ObjectPattern` object(s) directly:
+You can specify [`CopyPlugin.ObjectPattern`](https://github.com/webpack-contrib/copy-webpack-plugin#patterns) object(s) directly:
 
 ```js title='bud.config.js'
 bud.assets({
@@ -53,25 +73,12 @@ bud.assets({
 })
 ```
 
-### Copying using source/destination tuples
-
-You can use an array of tuples to specify a set of copy jobs.
-
-The first item in each tuple is the source and the second is the destination:
-
-```js title='bud.config.js'
-bud.assets([
-  [bud.path('@src/assets/asset.png'), bud.path('@dist/asset.png')],
-  [bud.path('@src/fonts'), bud.path('@dist/fonts')],
-])
-```
-
 ### Copying from multiple sources
 
 To specify additional copy sources you can add additional parameters.
 
 ```js title='bud.config.js'
-bud.assets('fonts/**/*.woff', 'images')
+bud.assets('fonts', 'images')
 ```
 
 ```js title='bud.config.js'
@@ -118,8 +125,4 @@ if you are referencing a font file from your stylesheet, the font will already b
 in your distribution. You don't need to manually require it with **bud.assets**, although
 there is probably no real harm in doing so.
 
-[bud.assets](/docs/bud.assets) is specifically for compiling files which are not already included elsewhere.
-
-```
-
-```
+**bud.assets** is specifically for compiling files which are not already included elsewhere.

--- a/sources/@roots/bud-api/src/methods/assets/assets.method.ts
+++ b/sources/@roots/bud-api/src/methods/assets/assets.method.ts
@@ -1,7 +1,7 @@
 import type {Bud} from '@roots/bud-framework'
 import CopyPlugin from 'copy-webpack-plugin'
 import {isArray, isString} from 'lodash'
-import {normalize} from 'path'
+import {join, normalize} from 'path'
 
 import type {method} from './assets.interface'
 
@@ -22,7 +22,7 @@ export const assets: method = async function assets(
    * when destructuring bud even though the context of
    * this function will be bound.
    */
-  const ctx = this as Bud
+  const app = this as Bud
 
   /**
    * We know it's not a directory
@@ -46,7 +46,7 @@ export const assets: method = async function assets(
    * Replace a leading dot with the project path
    */
   const fromDotRel = (pattern: string) =>
-    pattern?.startsWith('./') ? pattern.replace('./', ctx.path()) : pattern
+    pattern?.startsWith('./') ? pattern.replace('./', app.path()) : pattern
 
   /**
    * Take an input string and return a {@link CopyPlugin.ObjectPattern}
@@ -64,8 +64,8 @@ export const assets: method = async function assets(
 
     return {
       from,
-      to: ctx.path('@name'),
-      context: ctx.path('@src'),
+      to: app.path('@name'),
+      context: app.path('@src'),
       noErrorOnMissing: true,
     }
   }
@@ -89,8 +89,8 @@ export const assets: method = async function assets(
 
     return {
       from,
-      to,
-      context: ctx.path('@src'),
+      to: join(to, app.path('@name')),
+      context: app.path('@src'),
       noErrorOnMissing: true,
     }
   }
@@ -103,7 +103,7 @@ export const assets: method = async function assets(
   }
 
   if (appearsTupled(request)) {
-    ctx.extensions.get('copy-webpack-plugin').setOptions(options => ({
+    app.extensions.get('copy-webpack-plugin').setOptions(options => ({
       ...(options ?? {}),
       patterns: [
         ...(options?.patterns ?? []),
@@ -111,13 +111,13 @@ export const assets: method = async function assets(
       ],
     }))
 
-    return ctx
+    return app
   }
 
-  ctx.extensions.get('copy-webpack-plugin').setOptions(options => ({
+  app.extensions.get('copy-webpack-plugin').setOptions(options => ({
     ...(options ?? {}),
     patterns: [...(options?.patterns ?? []), ...request.flat().map(parse)],
   }))
 
-  return ctx
+  return app
 }

--- a/sources/@roots/bud-framework/src/methods/setPublicPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPublicPath.ts
@@ -12,9 +12,10 @@ export interface setPublicPath {
 }
 
 /**
- * By default it is assumed that assets are served from webroot (`/`).
- * You can use this method to replace this value for apps served from
- * a subdirectory.
+ * Set the application public path (e.g. `/assets`)
+ *
+ * @remarks
+ * The default public path is `/`
  *
  * @example
  * Set the default path using a string
@@ -31,6 +32,8 @@ export interface setPublicPath {
  *   return `web/assets/${publicPath}`
  * })
  * ```
+ *
+ * @see {@link https://bud.js.org/docs/bud.setPublicPath}
  *
  * @public
  */

--- a/sources/@roots/sage/src/acorn.ts
+++ b/sources/@roots/sage/src/acorn.ts
@@ -19,8 +19,10 @@ export const setSvgEmit = ({build}: Bud) =>
  * Not setting an empty string will likely result in duplicative path segments
  * and unresolved assets.
  */
-export const setManifestPublicPath = ({extensions}: Bud) =>
+export const setManifestPublicPath = ({extensions}: Bud) => {
   extensions.get('@roots/bud-entrypoints').setOption('publicPath', '')
+  extensions.get('webpack-manifest-plugin').setOption('publicPath', '')
+}
 
 /**
  * - If publicPath is `/` in production assets will not be locatable by Acorn.

--- a/sources/@roots/sage/src/extension.ts
+++ b/sources/@roots/sage/src/extension.ts
@@ -15,7 +15,6 @@ export default class Sage extends Extension {
   public async boot() {
     acorn.setSvgEmit(this.app)
     acorn.setManifestPublicPath(this.app)
-    acorn.setPublicPath(this.app)
     acorn.hmrJson(this.app)
 
     await this.app.extensions.add(ThemeJSON)

--- a/sources/@roots/sage/src/extension.ts
+++ b/sources/@roots/sage/src/extension.ts
@@ -15,6 +15,7 @@ export default class Sage extends Extension {
   public async boot() {
     acorn.setSvgEmit(this.app)
     acorn.setManifestPublicPath(this.app)
+    acorn.setPublicPath(this.app)
     acorn.hmrJson(this.app)
 
     await this.app.extensions.add(ThemeJSON)

--- a/tests/unit/bud-api/methods/assets.test.ts
+++ b/tests/unit/bud-api/methods/assets.test.ts
@@ -32,7 +32,7 @@ describe('bud.assets', function () {
     expect(JSON.stringify(patterns)).toEqual(
       JSON.stringify([
         {
-          from: 'images/**/*',
+          from: 'images',
           to: bud.path('@name'),
           context: bud.path('@src'),
           noErrorOnMissing: true,
@@ -54,13 +54,13 @@ describe('bud.assets', function () {
     expect(JSON.stringify(options.patterns)).toEqual(
       JSON.stringify([
         {
-          from: 'images/**/*',
+          from: 'images',
           to: bud.path('@name'),
           context: bud.path('@src'),
           noErrorOnMissing: true,
         },
         {
-          from: 'fonts/**/*',
+          from: 'fonts',
           to: bud.path('@name'),
           context: bud.path('@src'),
           noErrorOnMissing: true,
@@ -80,10 +80,7 @@ describe('bud.assets', function () {
   it('adds tupled assets', async () => {
     await bud.api.call('assets', [
       [bud.path('@src/images'), bud.path('@dist/images')],
-      [
-        bud.path('@src/fonts/font.woff'),
-        bud.path('@dist/fonts/font.woff'),
-      ],
+      [bud.path('@src/fonts/font.woff')],
     ])
 
     const patterns = bud.extensions
@@ -93,14 +90,14 @@ describe('bud.assets', function () {
     expect(JSON.stringify(patterns)).toEqual(
       JSON.stringify([
         {
-          from: bud.path('@src/images/**/*'),
-          to: bud.path('@dist/images'),
+          from: bud.path('@src/images'),
+          to: bud.path('@dist/images/@name'),
           context: bud.path('@src'),
           noErrorOnMissing: true,
         },
         {
           from: bud.path('@src/fonts/font.woff'),
-          to: bud.path('@dist/fonts/font.woff'),
+          to: bud.path('@name'),
           context: bud.path('@src'),
           noErrorOnMissing: true,
         },


### PR DESCRIPTION
## Overview

this change adds the content hash to files copied with bud.assets (if hashing is enabled). 

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
