### PR TITLE
🛼 improve(patch): improve @roots/bud-terser extension

### DIFF
--- a/sources/@roots/bud-terser/src/extension.ts
+++ b/sources/@roots/bud-terser/src/extension.ts
@@ -12,6 +12,17 @@ type Options = TerserPlugin.BasePluginOptions & {
   terserOptions?: TerserPlugin.MinimizerOptions<any>
 }
 
+/**
+ * Bud Terser extension
+ *
+ * @remarks
+ * Offers a more comprehensive terser API than bud core.
+ *
+ * @public
+ * @decorator `@label`
+ * @decorator `@expose`
+ * @decorator `@options`
+ */
 @label('@roots/bud-terser')
 @expose('terser')
 @options({
@@ -25,48 +36,131 @@ type Options = TerserPlugin.BasePluginOptions & {
     output: {
       comments: false,
       ascii_only: true,
+      preamble: `/**
+  * Minified by @roots/bud
+  */`,
     },
+    sourceMap: 'inline',
   },
 })
 export default class Terser extends Extension<Options> {
+  /**
+   * Terser options getter/setter
+   */
+  public get terserOptions() {
+    return this.getOption('terserOptions')
+  }
+  public set terserOptions(terserOptions: Options['terserOptions']) {
+    this.setOption('terserOptions', terserOptions)
+  }
+
+  /**
+   * Drop console
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind
   public dropConsole(enable: boolean = true): this {
-    this.options.terserOptions.compress = {
-      ...(this.options.terserOptions.compress ?? {}),
-      drop_console: enable,
+    this.terserOptions = {
+      ...(this.terserOptions ?? {}),
+      compress: {
+        ...(this.terserOptions.compress ?? {}),
+        drop_console: enable,
+      },
     }
+
     return this
   }
 
+  /**
+   * Drop comments
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind
   public dropComments(enable: boolean = true): this {
-    this.options.terserOptions.output = {
-      ...(this.options.terserOptions.output ?? {}),
-      comments: !enable,
-    }
+    this.comments(enable === false)
+
     return this
   }
 
+  /**
+   * Output comments
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind
-  public comments(enable: boolean = true): this {
-    this.options.terserOptions.output = {
-      ...(this.options.terserOptions.output ?? {}),
-      comments: enable,
+  public comments(comments: boolean = true): this {
+    this.terserOptions = {
+      ...(this.terserOptions ?? {}),
+      output: {
+        ...(this.terserOptions.output ?? {}),
+        comments,
+      },
     }
+
     return this
   }
 
+  /**
+   * Output comments
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public debugger(enable: boolean = true): this {
+    this.terserOptions = {
+      ...(this.terserOptions ?? {}),
+      output: {
+        ...(this.terserOptions.output ?? {}),
+        debugger: enable,
+      },
+    }
+
+    return this
+  }
+
+  /**
+   * Drop comments
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public dropDebugger(enable: boolean = true): this {
+    this.debugger(enable === false)
+
+    return this
+  }
+
+  /**
+   * Mangle
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind
   public mangle(mangle: Options['terserOptions']['mangle']): this {
-    this.options.terserOptions.mangle = mangle
+    this.terserOptions = {
+      ...(this.terserOptions ?? {}),
+      mangle,
+    }
 
     return this
   }
 
+  /**
+   * `beforeBuild` callback
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind
   public async beforeBuild() {
-    if (!this.app.hooks.filter('build.optimization.minimize')) return
-
     const {default: TerserPlugin} = await this.import(
       'terser-webpack-plugin',
     )
@@ -75,5 +169,16 @@ export default class Terser extends Extension<Options> {
       minimizer.push(new TerserPlugin(this.options))
       return minimizer.filter(item => item !== '...')
     })
+  }
+
+  /**
+   * `when` callback
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public async when() {
+    return this.app.hooks.filter('build.optimization.minimize')
   }
 }

--- a/tests/unit/bud-terser/extension.test.ts
+++ b/tests/unit/bud-terser/extension.test.ts
@@ -28,13 +28,45 @@ describe('@roots/bud-terser', () => {
         output: {
           ascii_only: true,
           comments: false,
+          preamble: `/**
+  * Minified by @roots/bud
+  */`,
         },
+        sourceMap: 'inline',
       },
     })
   })
 
   it('exposes self @ bud.terser', async () => {
-    await bud.extensions.add([BudTerser])
     expect(bud.terser).toBeInstanceOf(BudTerser)
+  })
+
+  it('bud.terser.comments', async () => {
+    bud.terser.comments(true)
+    expect(bud.terser.options.terserOptions.output.comments).toBe(true)
+  })
+
+  it('bud.terser.dropComments', async () => {
+    bud.terser.dropComments()
+    expect(bud.terser.options.terserOptions.output.comments).toBe(false)
+  })
+
+  it('bud.terser.dropDebugger', async () => {
+    bud.terser.dropDebugger()
+    expect(bud.terser.options.terserOptions.output.debugger).toBe(false)
+  })
+
+  it('bud.terser.dropConsole', async () => {
+    bud.terser.dropConsole()
+    expect(bud.terser.options.terserOptions.compress.drop_console).toBe(
+      true,
+    )
+  })
+
+  it('bud.terser.mangle', async () => {
+    bud.terser.mangle({topLevel: true})
+    expect(bud.terser.options.terserOptions.mangle).toStrictEqual({
+      topLevel: true,
+    })
   })
 })


### PR DESCRIPTION
## Overview

Improve `@roots/bud-terser` api.

- add `dropDebugger` method: drops `debugger` statements from code
- improves `dropComments` method
- improves `dropConsole` method
- adds additional unit tests

## Changes

- 🛼 improve(patch): improve bud-terser api
- 🧪 test(none): add unit tests

refers: none
closes: none

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
