### PR TITLE
🐛 fix(patch): fix error when `development` or `production` is in path

### DIFF
--- a/sources/@roots/bud/src/services/Project/index.ts
+++ b/sources/@roots/bud/src/services/Project/index.ts
@@ -131,7 +131,7 @@ export class Project
             )
 
           const hasCondition = (condition: string) =>
-            filePath.includes(condition)
+            filePath.split('/').pop().includes(condition)
 
           const hasExtension = (extension: string) =>
             filePath.endsWith(extension)


### PR DESCRIPTION
## Overview

I believe #1430 is caused by this line in `@roots/bud/src/services/Project/index.ts`:

```ts
const hasCondition = (condition: string) => filePath.includes(condition)
```

This is part of the code that determines what bud config files to apply.

Since `development` is a path segment this test always returns `true` and the `/**/development/**/bud.config.js` file is flagged as a `development` only config. 

Because of that, the config is ignored when running `bud build` & bud proceeds as if it were a zero-config setup.

The fix should be to only consider the last path segment when checking the config:

```ts
const hasCondition = (condition: string) => filePath.split("/").pop().includes(condition);
```

refers: #1432

## Type of change

- PATCH: Backwards compatible bug fix

<!--
- MAJOR: breaking change
- MINOR: feature
- PATCH: bug fix
- NONE: internal change
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

<!--
- [@roots/bud]: [package]@[version]
-->

### Adds

- none

### Removes

- none
