### PR TITLE
🔨 dev(none): renovate: adjust react group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,15 @@
       "matchPackagePrefixes": ["@babel/"]
     },
     {
+      "groupName": "react",
+      "matchPackagePrefixes": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "react-reconciler"
+      ]
+    },
+    {
       "groupName": "@yarnpkg",
       "matchPackagePrefixes": ["@yarnpkg/"]
     }


### PR DESCRIPTION
creates a group for react dependencies: `react`, `react-dom`, `@types/react`, `@types/react-dom` and `react-reconciler`

refers:

- none

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
