### PR TITLE
🛼 improve(patch): proxy: unset cookie domain attribute

### DIFF
--- a/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -101,7 +101,7 @@ export class ResponseInterceptorFactory {
 
     Object.entries(request.cookies).map(([k, v]) => {
       this.app.info('setting cookie', k, '=>', v)
-      response.cookie(k, v, {domain: null})
+      response.cookie(k, v, {domain: undefined})
     })
 
     return this.app.hooks


### PR DESCRIPTION
Unsets the domain attribute for proxy cookies.

Previously these were set as `null`, which works. Setting them as `undefined` works, too. It just works _well_.

Now, logins should persist between the dev server and the proxied domain.

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
