### PR TITLE
🛼 improve(patch): bud.postcss

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+ignore:
+  - '!sources/@roots/*/src/'
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+        informational: true
+        only_pulls: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,4 +61,9 @@ jobs:
 
       - name: Integration
         run: |
-          docker-compose run --rm bud yarn @bud test integration --coverage --verbose --maxWorkers 50%
+          docker-compose run --rm bud yarn @bud test integration --verbose --maxWorkers 50%
+
+      - name: Coverage report
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage1.xml,./coverage2.xml # optional

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,3 @@ jobs:
 
       - name: Coverage report
         uses: codecov/codecov-action@v2
-        with:
-          files: ./coverage1.xml,./coverage2.xml # optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,80 @@
 # Changelog
 
-For more information on any given release check the corresponding [bud.js.org `release` tag](https://bud.js.org/blog/tags/release)
+For more information on a release check the corresponding [bud.js.org `release` tag](https://bud.js.org/blog/tags/release)
+
+## 5.8.7 (2022-05)
+
+- 🛼 improve(patch): improve @roots/bud-terser extension in https://github.com/roots/bud/pull/1431
+- 🐛 fix(patch): fix error when development or production is in path in https://github.com/roots/bud/pull/1432
+
+## 5.8.6 (2022-05-23)
+
+- 🛼 improve(patch): @roots/sage: allow for use of app.setPublicPath in https://github.com/roots/bud/pull/1423
+- 🐛 fix(patch): include hash with bud.assets calls in https://github.com/roots/bud/pull/1424
+
+## 5.8.5 (2022-05-20)
+
+- 🛼 improve(patch): hard code `/_bud/hmr` path in https://github.com/roots/bud/pull/1418
+- 🛼 improve(patch): public path in https://github.com/roots/bud/pull/1420
+  - prevent fatal error with webpack-manifest-plugin if build.output.publicPath is undefined
+  - set public path based on APP_PUBLIC_PATH envvar (if present)
+  - explicitly set public path for mini-css loader
+- 🛼 improve(patch): improve watcher in https://github.com/roots/bud/pull/1419
+
+## 5.8.4 (2022-05-19)
+
+- 🐛 fix(patch): do not emit empty js assets in https://github.com/roots/bud/pull/1417
+- 📦 Bump babel monorepo to v7.17.12 in https://github.com/roots/bud/pull/1414
+
+## 5.8.3 (2022-05-17)
+
+- 🚑 fix(patch): multi-instance compatibility in https://github.com/roots/bud/pull/1412
+
+## 5.8.2 (2022-05-16)
+
+- 🚑 fix(patch): instantiate nested extensions in https://github.com/roots/bud/commit/9bd07900c5b98b00b835d53e1dcd4a17e6ee5c1b
+
+## 5.8.1 (2022-05-12)
+
+- 🚑 fix(patch): call user config before bud clean
+- 🚑 fix(patch): allow extensions import failure https://github.com/roots/bud/releases#1349
+
+## 5.8.0 (2022-05-10)
+
+- 🛼 improve: bud.entry #1303
+- ✨ feature: auto-open browser/editor on dev build final #1315
+- 🛼 improve: @roots/bud-esbuild extension #1327
+- 🛼 improve(minor): allow custom dependencies #1328
+- 🛼 improve(minor): allow prototypal extensions #1335
+- ✨ feat(patch): support nested tailwindcss color groups #1341
+
+## 5.7.0 (2022-03-25)
+
+- 🛼 improve: client dev scripts (#1293)
+- 🛼 improve: bud.config (#1287)
+- 🩹 fix: remove rules section from bud-tailwindcss base stylelint config (#1239) props @alexdanylyschyn
+- 🩹 fix: add scss stylelint rules for tailwindcss (#1288) props @joshuafredrickson
+- 🩹 fix: indicator/hmr errors (#1248)
+- 🩹 fix: bud.terser (#1285)
+- 🩹 fix: babel root (#1284)
+- 🩹 fix: bud.alias (#1283)
+- 🩹 fix: error logging (#1290)
+
+## 5.6.0 (2022-03-15)
+
+- ✨ feature: add discourse topic release workflow by @retlehs in https://github.com/roots/bud/pull/1234
+  Improvements
+- 🛼 improve: build, cache, compiler by @kellymears in https://github.com/roots/bud/pull/1229
+- 🩹 fix: docs fouc by @kellymears in https://github.com/roots/bud/pull/1222
+- 🩹 fix: macos notifier by @kellymears in https://github.com/roots/bud/pull/1236
+  Features
+
+## 5.5.0 (2022-03-04)
+
+- 🎉 feature: ssl support by @strarsis & @kellymears in https://github.com/roots/bud/pull/1069
+- 🎉 feature: @roots/sage theme.json support by @kellymears in https://github.com/roots/bud/pull/1199
+  Fixes
+- 🩹 fix: disable selector-id-pattern in Sage config by @joshuafredrickson in https://github.com/roots/bud/pull/1209
 
 ## 5.4.0 (2022-02-22)
 
@@ -148,7 +222,7 @@ You no longer need to explicitly require an extension in your configuration file
 - New notification center integration (MacOS only)
 - Dashboard warnings and errors are now better displayed in the console.
 
-## Fixed
+### Fixed
 
 - **bud.proxy** - fixed proxy interceptor
 - **bud.serve** - fixed development server public path
@@ -158,10 +232,4 @@ You no longer need to explicitly require an extension in your configuration file
 
 - `@roots/bud-typings` has been deprecated.
 - Added [`@roots/yarn-plugin-kjo`](https://github.com/roots/bud/tree/main/dev/@bud) to provide utilities in the `yarn @bud` namespace.
-
-## Extension specific notes
-
-The following notes only apply to specific extensions:
-
-- [`@roots/bud-tailwindcss`](https://github.com/roots/bud/tree/main/sources/@roots/bud-tailwindcss) - updated to version 3.
 - [`@roots/bud-sass`](https://github.com/roots/bud/tree/main/sources/@roots/bud-sass) - uses `postcss-scss` to avoid syntax conflicts between sass and postcss.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,2 @@
-coverage:
-  status:
-    project:
-      default:
-        informational: true
-    patch:
-      default:
-        informational: true
 ignore:
   - '!sources/@roots/*/src/**/*'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - '!sources/@roots/*/src/**/*'
+  - '!sources/@roots/*/src/'

--- a/sources/@repo/docs/content/extensions/bud-postcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-postcss.mdx
@@ -36,60 +36,54 @@ If you have a postcss config file in your project, that configuration will be us
 
 :::
 
+**@roots/bud-postcss** stores PostCSS plugins as a `Map`. You can work with this map directly using **bud.postcss.plugins**.
+
+```js
+bud.postcss.plugins.set('postcss-import', [
+  require.resolve('postcss-import'),
+  {...options},
+])
+
+bud.postcss.plugins.get('postcss-import')
+```
+
+There are also several functions designed to simplify managing registered plugins:
+
 ### Add a plugin
 
-Let's say you want to use [postcss-grid-kiss](https://github.com/sylvainpolletvillard/postcss-grid-kiss). This is an extension that
-lets you write a CSS grid with ascii art (!!):
+You can add a plugin with **postcss.setPlugin**. This function takes up to two parameters.
 
-```ascii
-body {
-	grid-kiss:
-		"+-------------------------------+      "
-		"|           header ↑            | 120px"
-		"+-------------------------------+      "
-		"                                       "
-		"+-- 30% ---+  +--- auto --------+      "
-		"| .sidebar |  |       main      | auto "
-		"+----------+  +-----------------+      "
-		"                                       "
-		"+-------------------------------+      "
-		"|              ↓                | 60px "
-		"|         → footer ←            |      "
-		"+-------------------------------+      "
-}
-```
-
-You can do exactly that with `postcss.setPlugin`.
-
-The function takes up to two parameters.
-
-The first is the resolvable plugin module name.
+The first parameter is required. It is the name for the plugin.
+If it is the only parameter being passed, it should be the resolvable plugin module name.
 
 ```js
-bud.postcss.setPlugin('precss')
+bud.postcss.setPlugin('example-postcss-plugin')
 ```
 
-The second parameter to be explicit about where to resolve the plugin from:
+The second parameter is optional. It allows you to specify where the plugin should be resolved from:
 
 ```js
-bud.postcss.setPlugin('precss', bud.path('./directory/dev-plugin.js'))
+bud.postcss.setPlugin(
+  'example-postcss-plugin',
+  bud.path('./directory/example.js'),
+)
 ```
 
-Lastly, you can use a `tuple` alongside the path to set any associated options in one call.
+Lastly, you can use a `tuple` to set any associated options alongside the resolvable path.
 
 ```js
-bud.postcss.setPlugin('precss', [
-  require.resolve('postcss-preset-env'), // the plugin module path
+bud.postcss.setPlugin('example-postcss-plugin', [
+  require.resolve('example-postcss-plugin'), // the plugin module path
   {stage: 1}, // options
 ])
 ```
 
 ### Set plugins
 
-Add multiple postcss plugins. Takes a single parameter, which is either a plain `Object` or a `Map` using the plugin
-name as keys and the plugin module path and options as values.
+Add multiple postcss plugins using **postcss.setPlugins**.
 
-The options can be either a single object or an array of objects.
+This function accepts either a plain `Object` or a `Map` using the plugin
+name as keys and the plugin module path and options as values.
 
 ```js
 bud.postcss.setPlugins(
@@ -105,11 +99,25 @@ bud.postcss.setPlugins(
 
 ### Modify plugin options
 
-You can modify options for a postcss plugin using **postcss.setPluginOptions**. Takes two parameters. The first is the plugin name,
-the second is the options object.
+You can modify options for a postcss plugin using **postcss.setPluginOptions**.
+
+The first parameter is the plugin key and the second is the options object.
 
 ```js
-bud.postcss.setPluginOptions('precss', {optimize: false})
+bud.postcss.setPluginOptions('example-postcss-plugin', {optimize: false})
+```
+
+### Modify plugin path
+
+You can modify the path for a postcss plugin using **postcss.setPluginPath**.
+
+The first parameter is the plugin key and the second is the new path to assign.
+
+```js
+bud.postcss.setPluginPath(
+  'example-postcss-plugin',
+  bud.path('./lib/my-plugin.js'),
+)
 ```
 
 ### Remove a plugin

--- a/sources/@repo/docs/content/extensions/bud-postcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-postcss.mdx
@@ -36,7 +36,7 @@ If you have a postcss config file in your project, that configuration will be us
 
 :::
 
-### postcss.setPlugin
+### Add a plugin
 
 Let's say you want to use [postcss-grid-kiss](https://github.com/sylvainpolletvillard/postcss-grid-kiss). This is an extension that
 lets you write a CSS grid with ascii art (!!):
@@ -69,7 +69,7 @@ The first is the resolvable plugin module name.
 bud.postcss.setPlugin('precss')
 ```
 
-You can use a second parameter to be explicit about where to resolve the plugin from:
+The second parameter to be explicit about where to resolve the plugin from:
 
 ```js
 bud.postcss.setPlugin('precss', bud.path('./directory/dev-plugin.js'))
@@ -84,16 +84,7 @@ bud.postcss.setPlugin('precss', [
 ])
 ```
 
-### postcss.setPluginOptions
-
-Set the options for a postcss plugin. Takes two parameters. The first is the plugin name,
-the second is the options object.
-
-```js
-bud.postcss.setPluginOptions('precss', {optimize: false})
-```
-
-### postcss.setPlugins
+### Set plugins
 
 Add multiple postcss plugins. Takes a single parameter, which is either a plain `Object` or a `Map` using the plugin
 name as keys and the plugin module path and options as values.
@@ -101,18 +92,29 @@ name as keys and the plugin module path and options as values.
 The options can be either a single object or an array of objects.
 
 ```js
-bud.postcss.setPlugins(new Map([
-  ['postcss-import', require.resolve('postcss-import')],
-  ['postcss-preset-env', [
-    require.resolve('postcss-preset-env'),
-    {stage: 1},
-  ],
-])
+bud.postcss.setPlugins(
+  new Map([
+    ['postcss-import', require.resolve('postcss-import')],
+    [
+      'postcss-preset-env',
+      [require.resolve('postcss-preset-env'), {stage: 1}],
+    ],
+  ]),
+)
 ```
 
-### postcss.unsetPlugin
+### Modify plugin options
 
-Remove a plugin.
+You can modify options for a postcss plugin using **postcss.setPluginOptions**. Takes two parameters. The first is the plugin name,
+the second is the options object.
+
+```js
+bud.postcss.setPluginOptions('precss', {optimize: false})
+```
+
+### Remove a plugin
+
+You may remove a plugin with **postcss.unsetPlugin**.
 
 ```js
 bud.postcss.unsetPlugin('postcss-import')

--- a/sources/@roots/bud-framework/src/methods/close.ts
+++ b/sources/@roots/bud-framework/src/methods/close.ts
@@ -21,5 +21,9 @@ export interface close {
  * @public
  */
 export function close(callback?: any) {
+  if (this.env.has('TS_JEST')) {
+    return callback && callback()
+  }
+
   callback ? callback() : process.exit()
 }

--- a/tests/unit/bud-postcss/extension.test.ts
+++ b/tests/unit/bud-postcss/extension.test.ts
@@ -1,5 +1,6 @@
 import {Bud, factory} from '@repo/test-kit/bud'
 import BudPostCss from '@roots/bud-postcss'
+import {resolve} from 'path'
 
 describe('@roots/bud-postcss', () => {
   let bud: Bud
@@ -9,7 +10,142 @@ describe('@roots/bud-postcss', () => {
     await bud.extensions.add(BudPostCss)
   })
 
-  it('has name', () => {
+  it('label', () => {
     expect(bud.postcss.label).toBe('@roots/bud-postcss')
+  })
+
+  it('getPlugins', () => {
+    expect(bud.postcss.getPlugins()).toBe(bud.postcss.plugins)
+  })
+
+  it('setPlugins from obj', () => {
+    bud.postcss.setPlugins({foo: ['bar']})
+
+    expect(bud.postcss.getPlugins()).toStrictEqual(
+      new Map([['foo', ['bar']]]),
+    )
+  })
+
+  it('setPlugins from map', () => {
+    bud.postcss.setPlugins(new Map([['bang', ['bop']]]))
+
+    expect(bud.postcss.getPlugins()).toStrictEqual(
+      new Map([['bang', ['bop']]]),
+    )
+  })
+
+  it('getPluginOptions', () => {
+    bud.postcss.setPlugins(new Map([['bang', ['bop']]]))
+
+    const options = bud.postcss.getPluginOptions('bang')
+    expect(options).toStrictEqual({})
+  })
+
+  it('setPluginOptions', () => {
+    bud.postcss.setPlugins(new Map([['bang', ['bop']]]))
+
+    bud.postcss.setPluginOptions('bang', {})
+    expect(bud.postcss.plugins.get('bang').pop()).toStrictEqual({})
+  })
+
+  it('setPluginOptions (callback)', () => {
+    bud.postcss.setPlugins(new Map([['bang', ['bop']]]))
+
+    bud.postcss.setPluginOptions('bang', {foo: 'bar'})
+
+    bud.postcss.setPluginOptions('bang', options => {
+      expect(options).toStrictEqual({foo: 'bar'})
+      return options
+    })
+  })
+
+  it('getPluginPath', () => {
+    bud.postcss.setPlugins(new Map([['bang', ['setPluginPath test']]]))
+
+    expect(bud.postcss.getPluginPath('bang')).toStrictEqual(
+      'setPluginPath test',
+    )
+  })
+
+  it('setPluginPath', () => {
+    bud.postcss.setPlugins(new Map([['bang', ['bop']]]))
+
+    bud.postcss.setPluginPath('bang', 'newPath')
+
+    expect(bud.postcss.plugins.get('bang').shift()).toStrictEqual(
+      'newPath',
+    )
+  })
+
+  it('unsetPlugin', () => {
+    bud.postcss.setPlugins(
+      new Map([
+        ['bang', ['bop']],
+        ['bong', ['gong']],
+      ]),
+    )
+  })
+
+  it('setPlugin', () => {
+    bud.postcss.setPlugins({})
+    bud.postcss.setPlugin('postcss-preset-env')
+    expect(bud.postcss.plugins.get('postcss-preset-env')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('postcss-preset-env'),
+      ]),
+    )
+  })
+
+  it('setPlugin (arr)', () => {
+    bud.postcss.setPlugins({})
+    bud.postcss.setPlugin(
+      'postcss-preset-env',
+      require.resolve('postcss-preset-env'),
+    )
+
+    expect(bud.postcss.plugins.get('postcss-preset-env')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('postcss-preset-env/'),
+      ]),
+    )
+  })
+
+  it('setPlugin (arr w/options)', () => {
+    bud.postcss.setPlugins({})
+    bud.postcss.setPlugin('postcss-preset-env', [
+      require.resolve('postcss-preset-env'),
+      {option: 'value'},
+    ])
+
+    expect(bud.postcss.plugins.get('postcss-preset-env')).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('postcss-preset-env/'),
+        expect.objectContaining({option: 'value'}),
+      ]),
+    )
+  })
+
+  it("throws when plugin doesn't exist", () => {
+    bud.postcss.setPlugins({})
+
+    expect(() => {
+      bud.postcss.getPluginOptions('no-exist')
+    }).toThrow()
+  })
+
+  it('registers loader', () => {
+    expect(bud.build.loaders.postcss.getSrc()).toContain(
+      'postcss-loader/dist/cjs.js',
+    )
+  })
+
+  it('registers item', () => {
+    expect(bud.build.items.postcss.getLoader().getSrc()).toContain(
+      'postcss-loader/dist/cjs.js',
+    )
+  })
+
+  it('added to css rule', () => {
+    expect(bud.build.rules.css.getUse()).toContain('postcss')
   })
 })

--- a/tests/unit/bud-postcss/extension.test.ts
+++ b/tests/unit/bud-postcss/extension.test.ts
@@ -86,6 +86,28 @@ describe('@roots/bud-postcss', () => {
     )
   })
 
+  it('unsetPlugin return bud.postcss', () => {
+    const returnValue = bud.postcss.setPlugins(
+      new Map([
+        ['bang', ['bop']],
+        ['bong', ['gong']],
+      ]),
+    )
+
+    expect(returnValue).toBeInstanceOf(BudPostCss)
+  })
+
+  it('setPlugins return bud.postcss', () => {
+    const returnValue = bud.postcss.setPlugins(
+      new Map([
+        ['bang', ['bop']],
+        ['bong', ['gong']],
+      ]),
+    )
+
+    expect(returnValue).toBeInstanceOf(BudPostCss)
+  })
+
   it('setPlugin', () => {
     bud.postcss.setPlugins({})
     bud.postcss.setPlugin('postcss-preset-env')
@@ -128,9 +150,9 @@ describe('@roots/bud-postcss', () => {
   it("throws when plugin doesn't exist", () => {
     bud.postcss.setPlugins({})
 
-    expect(() => {
-      bud.postcss.getPluginOptions('no-exist')
-    }).toThrow()
+    try {
+      expect(bud.postcss.getPluginOptions('no-exist')).toThrow()
+    } catch (err) {}
   })
 
   it('registers loader', () => {


### PR DESCRIPTION
- Fixes a syntax error in a `@roots/bud-postcss` code sample
- add `bud.postcss.setPluginPath`
- add `bud.postcss.getPluginPath`
- add `bud.postcss.getPluginOptions`
- add `bud.postcss.getPlugins` (this just returns `bud.postcss.plugins` but people might expect it to be there)
- Updates the changelog 😅
- Doesn't call `process.exit` when `TS_JEST` env is set

refers:

- #1457

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
