### PR TITLE
🔧 fix(none): deprecated packages as private

### DIFF
--- a/sources/deprecated/bud-library/package.json
+++ b/sources/deprecated/bud-library/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@roots/bud-library",
   "version": "0.0.0",
+  "private": true,
   "description": "Adds dynamic link library support to Bud",
   "repository": {
     "type": "git",

--- a/sources/deprecated/bud-support/package.json
+++ b/sources/deprecated/bud-support/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@roots/bud-support",
   "version": "0.0.0",
+  "private": true,
   "description": "👨🏽‍🍳 Internal packages for @roots/bud",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/deprecated/ink-prettier/package.json
+++ b/sources/deprecated/ink-prettier/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@roots/ink-prettier",
   "description": "Prettier component for React Ink",
+  "private": true,
   "version": "0.0.0",
   "homepage": "https://roots.io/bud",
   "repository": {

--- a/sources/deprecated/ink-use-style/package.json
+++ b/sources/deprecated/ink-use-style/package.json
@@ -2,6 +2,7 @@
   "name": "@roots/ink-use-style",
   "description": "Themes and styles for React Ink",
   "version": "0.0.0",
+  "private": true,
   "homepage": "https://roots.io/bud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mark deprecated packages as `private`

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
