### PR TITLE
📕 docs(none): update @roots/bud-typescript docs

### DIFF
--- a/sources/@repo/docs/content/blog/6.0.0.mdx
+++ b/sources/@repo/docs/content/blog/6.0.0.mdx
@@ -92,18 +92,31 @@ Check the documentation for each tool. Read up on ESM.
 
 ## TypeScript guide
 
+### Update config to either `bud.config.mts` or `bud.config.cts`
+
 TypeScript 4.7.2 offers two new TypeScript extensions to deal with CJS/ESM compatibility issues: `.cts` and `.mts` (they have their own declaration file extensions as well: `.d.cts` and `.d.mts`).
 
 In general, I'd imagine most TS users already author their `bud.config.ts` file with `export` syntax. If that's the case, you will likely just want to update the file name to `bud.config.mts`.
 
-There is one other problem with TypeScript and ESM: it is not possible to hack `import` at runtime the way we can hack `require` at runtime.
+### Use `ts-bud` instead of `bud`
 
-**bud.js** uses [ts-node](https://github.com/typestrong/ts-node)
-to import TS configs when it is available, but with ESM we also need to register an `import` loader so that the config file can be parsed. This can't be done at runtime.
+:::danger Known issue
+
+**`bud.typescript.typecheck.enable()` will die when using `ts-bud`**
+
+It is unclear what the problem is as of right now ([see #1480](https://github.com/roots/bud/issues/1480)). **In order to enable typechecking you must author your config file in JS until this is resolved.**
+
+:::
+
+**Due to the way ESM modules are loaded you'll need to use `ts-bud` instead of `bud` when running cli commands.** Explanation follows:
+
+A problem with TypeScript and ESM: it is not possible to hack `import` at runtime the way we can hack `require` at runtime.
+
+**bud.js** uses [ts-node](https://github.com/typestrong/ts-node) to import TS configs when it is available, but with ESM we also need to register an `import` loader so that the config file can be parsed. This can't be done at runtime.
 
 [ts-node](https://github.com/typestrong/ts-node) offers a flag to set this up:
 
-```bash
+```bash title="shell"
 ts-node --esm --transpileOnly
 ```
 
@@ -111,7 +124,7 @@ And **bud.js** offers a `bin` that wraps the standard `bud` command accordingly:
 
 If this doesn't work for you, or you need to adjust other `ts-node` flags, you may do this yourself:
 
-```sh
+```sh title="shell"
 ts-node --esm --transpileOnly ./node_modules/.bin/bud build
 ```
 
@@ -128,13 +141,13 @@ be able to `require` modules or packages in your config file.
 
 The great news is that it's totally possible import CommonJS from an ES Module, so you can convert `require` statements to use `import` without worrying about it too much:
 
-```js
+```js title="bud.config.cjs"
 const value = require('browsersync-webpack-plugin')
 ```
 
 becomes:
 
-```js
+```js title="bud.config.mjs"
 import value from 'browsersync-webpack-plugin'
 ```
 
@@ -150,8 +163,8 @@ Importing ESM from CommonJS is a little less straight forward than the other way
 
 The easiest way is to use a dynamic `import` statement. The biggest difference is that a dynamic import is asynchronous, whereas require is sync.
 
-```js
-export default async bud => {
+```js title="bud.config.cjs"
+module.exports = async bud => {
   await import('browsersync-webpack-plugin')
 }
 ```
@@ -162,8 +175,8 @@ In these cases you may find that the code returned from a dynamic `import` is se
 
 If you wish you may use `bud.module.import` instead of `import` (which will automatically return the value of `default`, if it is set):
 
-```js
-export default async bud => {
+```js title="bud.config.cjs"
+module.exports = async bud => {
   await bud.module.import('browsersync-webpack-plugin')
 }
 ```
@@ -173,7 +186,7 @@ The `node:module` interface provides a function `createRequire` that will let yo
 
 **bud.js** has an instance of the `Require` function available at `bud.module.require` (it's context is the directory containing the project `package.json`):
 
-```js
+```js title="bud.config.mjs"
 export default async bud => {
   bud.module.require('browser-sync-webpack-plugin')
 
@@ -184,7 +197,7 @@ export default async bud => {
 
 If you just want the path to a module and aren't sure if it is CommonJS or ESM, you may use `bud.module.resolve`:
 
-```js
+```js title="bud.config.mjs"
 export default async bud => {
   await bud.module.resolve('browser-sync-webpack-plugin')
 }

--- a/sources/@repo/docs/content/extensions/bud-typescript.mdx
+++ b/sources/@repo/docs/content/extensions/bud-typescript.mdx
@@ -6,6 +6,9 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 import {Install} from '@site/src/docs/Install'
 
+import Usage from '@site/../../@roots/bud-typescript/docs/usage.mdx'
+import Typechecking from '@site/../../@roots/bud-typescript/docs/typechecking.mdx'
+
 # @roots/bud-typescript
 
 [TypeScript](https://typescript.org) support can be added by installing the **@roots/bud-typescript** extension.
@@ -14,30 +17,10 @@ import {Install} from '@site/src/docs/Install'
 
 <Install packages="@roots/bud-typescript" />
 
+## Usage
+
+<Usage />
+
 ## Enable Typechecking
 
-:::info
-
-This step is optional but recommended.
-
-:::
-
-By default TypeScript files will only be compiled to JS during builds.
-If you also want typechecking, you can enable it in your bud configuration:
-
-```js
-bud.typecheck()
-```
-
-## Configuration
-
-Beyond that, general ts configuration is handled using a standard **tsconfig.json** in your project root. See [the TypeScript docs on tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for more information.
-
-There is a base tsconfig available for you to extend:
-
-```json
-{
-  "extends": "@roots/bud-typescript/tsconfig/tsconfig.json",
-  "compilerOptions": {}
-}
-```
+<Typechecking />

--- a/sources/@roots/bud-typescript/docs/typechecking.mdx
+++ b/sources/@roots/bud-typescript/docs/typechecking.mdx
@@ -1,0 +1,20 @@
+:::info
+
+This step is optional but recommended.
+
+:::
+
+:::danger Known issue
+
+**`bud.typescript.typecheck.enable()` will die when using `ts-bud`**
+
+It is unclear what the problem is as of right now ([see #1480](https://github.com/roots/bud/issues/1480)). **In order to enable typechecking you must author your config file in JS until this is resolved.**
+
+:::
+
+By default TypeScript files will only be compiled to JS during builds.
+If you also want typechecking, you can enable it in your bud configuration:
+
+```js title="bud.config.mjs"
+bud.typescript.typecheck.enable()
+```

--- a/sources/@roots/bud-typescript/docs/usage.mdx
+++ b/sources/@roots/bud-typescript/docs/usage.mdx
@@ -1,0 +1,11 @@
+If you are authoring your config file in TypeScript you must use the `ts-bud` command instead of `bud`.
+
+General ts configuration is handled using a standard **tsconfig.json** in your project root. See [the TypeScript docs on tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) for more information.
+
+There is a base tsconfig available for you to extend:
+
+```json title="tsconfig.json"
+{
+  "extends": "@roots/bud-typescript/tsconfig/tsconfig.json"
+}
+```

--- a/sources/@roots/bud-typescript/package.json
+++ b/sources/@roots/bud-typescript/package.json
@@ -36,8 +36,8 @@
     "type": "extension"
   },
   "files": [
+    "docs/",
     "lib/",
-    "types/",
     "tsconfig/"
   ],
   "type": "module",

--- a/sources/@roots/bud-typescript/src/typecheck/index.ts
+++ b/sources/@roots/bud-typescript/src/typecheck/index.ts
@@ -31,7 +31,10 @@ export default class BudTypeCheckPlugin extends Extension<
 
     this.setOptions(options => ({
       ...options,
-      typescript: {...(options.typescript ?? {}), typescriptPath},
+      typescript: {
+        ...(options.typescript ?? {}),
+        typescriptPath,
+      },
     }))
   }
 }


### PR DESCRIPTION
Update @roots/bud-typescript documentation

refers:

- #1481

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
