### PR TITLE
🐛 fix(patch): default imports

### DIFF
--- a/sources/@roots/bud-server/src/inject.ts
+++ b/sources/@roots/bud-server/src/inject.ts
@@ -17,17 +17,18 @@ export const inject: inject = async (
   injection: Array<(app: Bud) => string>,
 ): Promise<void> => {
   app.hooks.on('build.entry', entrypoints => {
-    const invalidEntrypoints =
-      !entrypoints ||
-      isUndefined(entrypoints) ||
-      isNull(entrypoints) ||
-      !injection
+    if (!injection) return
 
-    if (invalidEntrypoints) {
-      app.warn(`${app.name} entrypoints are malformed`, `skipping inject`)
+    const missing =
+      !entrypoints || isUndefined(entrypoints) || isNull(entrypoints)
 
-      return entrypoints
-    }
+    entrypoints = missing
+      ? {
+          app: {
+            import: ['index'],
+          },
+        }
+      : entrypoints
 
     return Object.entries(entrypoints).reduce(
       (entrypoints, [name, entry]) => {


### PR DESCRIPTION
When the user doesn't specify entrypoints the default assumption is that the entrypoint is  `@src/index.*`. 

The HMR injection script would previously refuse to inject if there were no entrypoint items. Now it sets that default explicitly and then injects from there.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
