### PR TITLE
Small fixes to file-config

### DIFF
--- a/sources/@repo/docs/content/guides/config/file-config/env.mdx
+++ b/sources/@repo/docs/content/guides/config/file-config/env.mdx
@@ -99,13 +99,13 @@ import type {Bud} from '@roots/bud'
 export default (app: Bud) => app.entry('app', 'app.js')
 ```
 
-```js title='bud.config.development.ts'
+```js title='bud.config.production.ts'
 import type {Bud} from '@roots/bud'
 
-export default (app: Bud) => app.hash().minify()
+export default (app: Bud) => app.hash().minimize()
 ```
 
-```ts title='bud.config.production.ts'
+```ts title='bud.config.development.ts'
 import type {Bud} from '@roots/bud'
 
 export default (app: Bud) => app.devtool()


### PR DESCRIPTION
- Production and development examples were the wrong way round 
- minify() replaced with minimize()

To fix: 
1. In the JS example for bud.config.js, in the "using files for when" section, the production and development examples are the wrong way round.
2. Also in there, minify() doesn't seem to work, but my usual minimize() does.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
