### PR TITLE
✨ improve(patch): improve sass configuration api

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-sass.mdx
+++ b/sources/@repo/docs/content/extensions/bud-sass.mdx
@@ -8,11 +8,24 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 import {Install} from '@site/src/docs/Install'
 
+import Usage from '@site/../../@roots/bud-sass/docs/01-basics.md'
+import ImportGlobal from '@site/../../@roots/bud-sass/docs/02-global-imports.md'
+import RegisterGlobal from '@site/../../@roots/bud-sass/docs/03-global-values.md'
+
 [Sass](https://sass-lang.com) support can be added by installing the **@roots/bud-sass** extension.
 
 ## Installation
 
-[@roots/bud-sass](/extensions/bud-sass) requires `@roots/bud-postcss` in order to function. As Webpack improves its
-support of CSS we may shed this requirement in the future.
+<Install packages="@roots/bud-sass" />
 
-<Install packages="@roots/bud-sass @roots/bud-postcss" />
+## Usage
+
+<Usage />
+
+## Global imports
+
+<ImportGlobal />
+
+## Global values
+
+<RegisterGlobal />

--- a/sources/@roots/bud-sass/README.md
+++ b/sources/@roots/bud-sass/README.md
@@ -32,6 +32,51 @@ npm install @roots/bud-sass --save-dev
 
 ## Usage
 
+### Basics
+
+After installation, sass will automatically preprocess any `.scss` or `.sass` modules in your project with sass.
+
+Additionally, if [@roots/bud-postcss](https://bud.js.org/extensions/bud-postcss) is available, postcss will be applied to your `.scss` and `.sass` source files.
+
+If you are using [@roots/bud-preset-recommend](https://bud.js.org/extensions/bud-preset-recommend), [@roots/bud-preset-wordpress](https://bud.js.org/extensions/bud-preset-wordpress), or [@roots/sage](https://bud.js.org/extensions/sage) then postcss is automatically applied.
+
+### Global Imports
+
+Use the `bud.sass.importGlobal` function to ensure a module is made available throughout your sass stylesheets, regardless of scope.
+
+```ts
+bud.sass.importGlobal("@src/styles/variables");
+```
+
+If you have more than one stylesheet to import, you may use an array:
+
+```ts
+bud.sass.importGlobal([
+  "@src/styles/variables",
+  "@src/styles/mixins",
+  "@src/styles/functions",
+]);
+```
+
+### Global Values
+
+Use the `bud.sass.registerGlobal` function to ensure global styles are made available throughout your sass stylesheets, regardless of scope.
+
+This function differs from `bud.sass.importGlobal` in that it can be passed arbitrary values.
+
+```ts
+bud.sass.registerGlobal("$foo: rgba(0, 0, 0, 1);");
+```
+
+If you want to divide these values up using an array, you may do so.
+
+```ts
+bud.sass.registerGlobal([
+  "$foo: rgba(0, 0, 0, 1);",
+  "$bar: rgba(255, 255, 255, 1);",
+]);
+```
+
 ## Contributing
 
 Contributions are welcome from everyone.

--- a/sources/@roots/bud-sass/docs/01-basics.md
+++ b/sources/@roots/bud-sass/docs/01-basics.md
@@ -1,0 +1,5 @@
+After installation, sass will automatically preprocess any `.scss` or `.sass` modules in your project with sass.
+
+Additionally, if [@roots/bud-postcss](https://bud.js.org/extensions/bud-postcss) is available, postcss will be applied to your `.scss` and `.sass` source files.
+
+If you are using [@roots/bud-preset-recommend](https://bud.js.org/extensions/bud-preset-recommend), [@roots/bud-preset-wordpress](https://bud.js.org/extensions/bud-preset-wordpress), or [@roots/sage](https://bud.js.org/extensions/sage) then postcss is automatically applied.

--- a/sources/@roots/bud-sass/docs/02-global-imports.md
+++ b/sources/@roots/bud-sass/docs/02-global-imports.md
@@ -1,0 +1,15 @@
+Use the `bud.sass.importGlobal` function to ensure a module is made available throughout your sass stylesheets, regardless of scope.
+
+```ts
+bud.sass.importGlobal('@src/styles/variables')
+```
+
+If you have more than one stylesheet to import, you may use an array:
+
+```ts
+bud.sass.importGlobal([
+  '@src/styles/variables',
+  '@src/styles/mixins',
+  '@src/styles/functions',
+])
+```

--- a/sources/@roots/bud-sass/docs/03-global-values.md
+++ b/sources/@roots/bud-sass/docs/03-global-values.md
@@ -1,0 +1,16 @@
+Use the `bud.sass.registerGlobal` function to ensure global styles are made available throughout your sass stylesheets, regardless of scope.
+
+This function differs from `bud.sass.importGlobal` in that it can be passed arbitrary values.
+
+```ts
+bud.sass.registerGlobal('$foo: rgba(0, 0, 0, 1);')
+```
+
+If you want to divide these values up using an array, you may do so.
+
+```ts
+bud.sass.registerGlobal([
+  '$foo: rgba(0, 0, 0, 1);',
+  '$bar: rgba(255, 255, 255, 1);',
+])
+```

--- a/sources/@roots/bud-sass/src/extension.ts
+++ b/sources/@roots/bud-sass/src/extension.ts
@@ -3,6 +3,7 @@ import {
   bind,
   dependsOn,
   dependsOnOptional,
+  expose,
   label,
 } from '@roots/bud-framework/extension/decorators'
 
@@ -11,12 +12,27 @@ import {
  *
  * @public
  * @decorator `@label`
+ * @decorator `@expose`
  * @decorator `@dependsOn`
+ * @decorator `@dependsOnOptional`
  */
 @label('@roots/bud-sass')
+@expose('sass')
 @dependsOn(['@roots/bud-sass/resolve-url'])
 @dependsOnOptional(['@roots/bud-postcss'])
 export default class BudSass extends Extension {
+  /**
+   * `register` callback
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public async register() {
+    const implementation = await this.import('sass')
+    this.setOptions({implementation, sourceMap: true})
+  }
+
   /**
    * `afterConfig` callback
    *
@@ -25,14 +41,9 @@ export default class BudSass extends Extension {
    */
   @bind
   public async afterConfig() {
-    const implementation = await this.import('sass')
-
     this.app.build
       .setLoader('sass', await this.resolve('sass-loader'))
-      .setItem('sass', {
-        loader: 'sass',
-        options: {implementation, sourceMap: true},
-      })
+      .setItem('sass', {loader: 'sass', options: this.options})
       .setRule('sass', {
         test: app => app.hooks.filter('pattern.sass'),
         include: [app => app.path('@src')],

--- a/sources/@roots/bud-sass/src/extension.ts
+++ b/sources/@roots/bud-sass/src/extension.ts
@@ -43,7 +43,10 @@ export default class BudSass extends Extension {
   public async afterConfig() {
     this.app.build
       .setLoader('sass', await this.resolve('sass-loader'))
-      .setItem('sass', {loader: 'sass', options: this.options})
+      .setItem('sass', {
+        loader: 'sass',
+        options: this.options,
+      })
       .setRule('sass', {
         test: app => app.hooks.filter('pattern.sass'),
         include: [app => app.path('@src')],
@@ -62,5 +65,47 @@ export default class BudSass extends Extension {
     if (this.app.postcss) {
       this.app.postcss.syntax = 'postcss-scss'
     }
+  }
+
+  /**
+   * Register global stylsheet
+   *
+   * @remarks
+   * Used to register styles which are included globally
+   *
+   * @example
+   * ```ts
+   * bud.sass.registerGlobal(`$primary-color: #ff0000;`)
+   * ```
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public registerGlobal(data: string | Array<string>): this {
+    data = Array.isArray(data) ? data : [data]
+    return this.setOption('additionalData', value =>
+      [value ?? null, ...data].filter(Boolean).join('\n'),
+    )
+  }
+
+  /**
+   * Import a partial globally
+   *
+   * @remarks
+   * Used to import a partial globally (such as a `variables.scss` file)
+   *
+   * @example
+   * ```ts
+   * bud.sass.importPartial()
+   * ```
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public importGlobal(data: string | Array<string>): this {
+    data = Array.isArray(data) ? data : [data]
+    return this.registerGlobal(data.map(item => `@import "${item}";`))
   }
 }

--- a/sources/@roots/bud-sass/src/index.ts
+++ b/sources/@roots/bud-sass/src/index.ts
@@ -12,6 +12,9 @@ import type {Build} from '@roots/bud-framework'
 import BudSass from './extension.js'
 
 declare module '@roots/bud-framework' {
+  interface Bud {
+    sass: BudSass
+  }
   interface Modules {
     '@roots/bud-sass': BudSass
   }

--- a/tests/unit/bud-sass/config.test.ts
+++ b/tests/unit/bud-sass/config.test.ts
@@ -4,7 +4,7 @@ import BudSass from '@roots/bud-sass'
 describe('@roots/bud-sass registration', () => {
   let bud: Bud
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     bud = await factory()
     await bud.extensions.add(BudSass)
   })
@@ -24,6 +24,10 @@ describe('@roots/bud-sass registration', () => {
   })
 
   it('uses configured values', async () => {
+    bud.sass.setOption(
+      'additionalData',
+      `@import "@styles/common/variables";`,
+    )
     await bud.extensions.runAll('_afterConfig')
     expect(bud.build.items.sass.getOptions().additionalData).toBe(
       `@import "@styles/common/variables";`,

--- a/tests/unit/bud-sass/config.test.ts
+++ b/tests/unit/bud-sass/config.test.ts
@@ -1,0 +1,32 @@
+import {Bud, factory} from '@repo/test-kit/bud'
+import BudSass from '@roots/bud-sass'
+
+describe('@roots/bud-sass registration', () => {
+  let bud: Bud
+
+  beforeAll(async () => {
+    bud = await factory()
+    await bud.extensions.add(BudSass)
+  })
+
+  it('adds sass as bud property', () => {
+    expect(bud.sass).toBeInstanceOf(BudSass)
+  })
+
+  it('bud.sass.setOption', async () => {
+    bud.sass.setOption(
+      'additionalData',
+      `@import "@styles/common/variables";`,
+    )
+    expect(bud.sass.getOption('additionalData')).toBe(
+      `@import "@styles/common/variables";`,
+    )
+  })
+
+  it('uses configured values', async () => {
+    await bud.extensions.runAll('_afterConfig')
+    expect(bud.build.items.sass.getOptions().additionalData).toBe(
+      `@import "@styles/common/variables";`,
+    )
+  })
+})

--- a/tests/unit/bud-sass/importGlobal.test.ts
+++ b/tests/unit/bud-sass/importGlobal.test.ts
@@ -1,0 +1,35 @@
+import {Bud, factory} from '@repo/test-kit/bud'
+import BudSass from '@roots/bud-sass'
+
+describe('@roots/bud-sass registration', () => {
+  let bud: Bud
+
+  describe('bud.sass.importGlobal', () => {
+    beforeEach(async () => {
+      bud = await factory()
+      await bud.extensions.add(BudSass)
+    })
+
+    it('should import a partial', async () => {
+      bud.sass.importGlobal('@styles/common/variables')
+
+      await bud.extensions.runAll('_afterConfig')
+      expect(bud.build.items.sass.getOptions().additionalData).toBe(
+        `@import "@styles/common/variables";`,
+      )
+    })
+
+    it('should import partials from an array', async () => {
+      bud.sass.importGlobal([
+        '@styles/common/variables',
+        '@styles/common/mixins',
+      ])
+
+      await bud.extensions.runAll('_afterConfig')
+
+      expect(bud.build.items.sass.getOptions().additionalData).toBe(
+        `@import "@styles/common/variables";\n@import "@styles/common/mixins";`,
+      )
+    })
+  })
+})

--- a/tests/unit/bud-sass/registerGlobal.test.ts
+++ b/tests/unit/bud-sass/registerGlobal.test.ts
@@ -1,0 +1,35 @@
+import {Bud, factory} from '@repo/test-kit/bud'
+import BudSass from '@roots/bud-sass'
+
+describe('@roots/bud-sass registration', () => {
+  let bud: Bud
+
+  describe('bud.sass.registerGlobal', () => {
+    beforeEach(async () => {
+      bud = await factory()
+      await bud.extensions.add(BudSass)
+    })
+
+    it('should add global to `additionalData`', async () => {
+      bud.sass.registerGlobal('$foo: rgba(0, 0, 0, 1);')
+
+      await bud.extensions.runAll('_afterConfig')
+      expect(bud.build.items.sass.getOptions().additionalData).toBe(
+        `$foo: rgba(0, 0, 0, 1);`,
+      )
+    })
+
+    it('should import partials from an array', async () => {
+      bud.sass.registerGlobal([
+        '$foo: rgba(0, 0, 0, 1);',
+        '$bar: rgba(255, 255, 255, 1);',
+      ])
+
+      await bud.extensions.runAll('_afterConfig')
+
+      expect(bud.build.items.sass.getOptions().additionalData).toBe(
+        `$foo: rgba(0, 0, 0, 1);\n$bar: rgba(255, 255, 255, 1);`,
+      )
+    })
+  })
+})


### PR DESCRIPTION
people want to use `additionalData` sass loader option but the existing method is pretty cumbersome.

- exposes `@roots/bud-sass` extension instance: `bud.sass`
- adds a couple helper methods for registering global values/imports
- updates documentation
- covered

## modify options

Direct usage of extensions API:

```ts
bud.sass.setOption('additionalData', `@import "@styles/common/variables";`)
```

Use `bud.sass.importGlobal` to globally import a stylesheet or array of stylesheets:

```ts
bud.sass.importGlobal('@src/styles/variables')
```

```ts
bud.sass.importGlobal([
  '@src/styles/variables',
  '@src/styles/mixins',
  '@src/styles/functions',
])
```

Use `bud.sass.registerGlobal` to globally define an arbitrary value or array of values:

```ts
bud.sass.registerGlobal('$foo: rgba(0, 0, 0, 1);')
```

```ts
bud.sass.registerGlobal([
  '$foo: rgba(0, 0, 0, 1);',
  '$bar: rgba(255, 255, 255, 1);',
])
```

refers:

- [discourse topic](https://discourse.roots.io/t/bud-6-3-0-and-sass/23570)

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
