### PR TITLE
🩹 fix(patch): correct extensions api inconsistencies

### DIFF
--- a/sources/@repo/docs/content/guides/extending/index.mdx
+++ b/sources/@repo/docs/content/guides/extending/index.mdx
@@ -57,36 +57,10 @@ class MyExtension extends Extension {
 
 The rest of this document assumes that extensions are being authored as a class and are being exported from an ESM package.
 
-## Binding extension methods
-
-If your extension method references the class context (`this`), you should bind it to the class instance.
-
-```ts title="extension.ts"
-import {Extension} from '@roots/bud-framework/extension'
-
-export default class MyExtension extends Extension {
-  public constructor(...params) {
-    super(...params)
-    this.register = this.register.bind(this)
-  }
-
-  public async register() {}
-}
-```
-
-Alternatively, you can use [the `@bind` decorator](/guides/extending/decorators#bind).
-
-```ts title="extension.ts"
-import {Extension} from '@roots/bud-framework/extension'
-import {bind} from '@roots/bud-framework/extension/decorators'
-
-export default class MyExtension extends Extension {
-  @bind
-  public async register() {}
-}
-```
-
 ## Interface
+
+Any extension method from the Extension base class prefixed with an underscore should be considered private. This method needs to be public
+for compatibility with class decorators, but it is not intended to be used as a public method. These methods can and will change without notice.
 
 ### label
 
@@ -172,8 +146,8 @@ export default class MyExtension extends Extension {
 
 Now, if the user makes a change to the `@src` path, the reference will be updated in the extension.
 
-The only "gotcha" here is that if you have an extension option which is itself callable, you will need to account for that. It should be as simple
-as wrapping the option in a function.
+The only "gotcha" here is that if you have an extension option which is itself callable, you will need to account for that. Otherwise, bud will try to call the
+option fn.
 
 ```ts title="extension.ts"
 import {Bud} from '@roots/bud-framework'
@@ -211,31 +185,87 @@ extension.setOptions({
 
 Async callback. Called first. Useful to avoid needing to deal with `super` and the constructor.
 
-This method has an internal wrapper prefixed with an underscore: `_init`. This method needs to be public
-for compatibility with any class decorators, but it is not intended to be used as a public method.
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async init(app, options) {
+    // do something
+  }
+}
+```
 
 ### register
 
 Async callback. Try to do things in this method, when possible.
 
-This method has an internal wrapper prefixed with an underscore: `_register`. This method needs to be public
-for compatibility with any class decorators, but it is not intended to be used as a public method.
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async register(app, options) {
+    // do something
+  }
+}
+```
 
 ### boot
 
 Async callback. Called after `register`. Good for business which requires another
 extension to have already had `register` called on it.
 
-This method has an internal wrapper prefixed with an underscore: `_boot`. This method needs to be public
-for compatibility with any class decorators, but it is not intended to be used as a public method.
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async boot(app, options) {
+    // do something
+  }
+}
+```
+
+### afterConfig
+
+Async callback. Called after user configuration has been processed.
+
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async afterConfig(app, options) {
+    // do something
+  }
+}
+```
 
 ### beforeBuild
 
-Async callback. Called after user configuration has been processed (directly before
-configuration is constructed and passed to the compiler).
+Async callback. Called directly before configuration is constructed and passed to the compiler).
 
-This method has an internal wrapper prefixed with an underscore: `_beforeBuild`. This method needs to be public
-for compatibility with any class decorators, but it is not intended to be used as a public method.
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async beforeBuild(app, options) {
+    // do something
+  }
+}
+```
 
 ### make
 
@@ -321,5 +351,19 @@ export default class MyExtension extends Extension {
 ### apply
 
 An `apply` method indicates to **bud.js** that the extension is doing double duty as a compiler plugin and a bud extension.
+
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+import Plugin from 'some-webpack-plugin'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public apply() {
+    // see webpack documentation. this is treated exactly the same as a pure webpack plugin.
+  }
+}
+```
 
 When present **bud.js** will pass the extension itself to the compiler's `plugin` array.

--- a/sources/@roots/bud-api/src/methods/template/interpolate-html-plugin.extension.ts
+++ b/sources/@roots/bud-api/src/methods/template/interpolate-html-plugin.extension.ts
@@ -1,3 +1,4 @@
+import type {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import {bind, label} from '@roots/bud-framework/extension/decorators'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
@@ -33,7 +34,7 @@ export default class BudInterpolateHtmlPlugin extends Extension<
    * @public
    */
   @bind
-  public async when(options: Record<string, RegExp>) {
+  public async when(_app: Bud, options: Record<string, RegExp>) {
     return options ? true : false
   }
 }

--- a/sources/@roots/bud-framework/src/extension/decorators/development.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/development.ts
@@ -10,11 +10,17 @@ export const development = <Type extends {new (...args: any[]): any}>(
   constructor: Type,
 ) =>
   class extends constructor {
-    public when() {
-      return this.app.isDevelopment
-    }
-
     public constructor(...args: any[]) {
       super(...args)
+    }
+
+    /**
+     * `when` callback
+     *
+     * @returns `true` when mode is `development`
+     * @public
+     */
+    public when({isDevelopment}) {
+      return isDevelopment
     }
   }

--- a/sources/@roots/bud-framework/src/extension/decorators/production.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/production.ts
@@ -28,7 +28,7 @@ export const production = <Type extends {new (...args: any[]): any}>(
      * @returns `true` when mode is `production`
      * @public
      */
-    public when() {
-      return this.app.isProduction
+    public when({isProduction}) {
+      return isProduction
     }
   }

--- a/sources/@roots/bud-purgecss/src/extension.ts
+++ b/sources/@roots/bud-purgecss/src/extension.ts
@@ -1,9 +1,11 @@
+import type {Bud} from '@roots/bud-framework'
+
 import {purgecss} from './api.js'
 
 export const label = '@roots/bud-purgecss'
 
 export const dependsOn = new Set(['@roots/bud-postcss'])
 
-export const register = async (_options, app) => {
+export const register = async (app: Bud) => {
   app.api.bindFacade('purgecss', purgecss)
 }

--- a/sources/@roots/bud-terser/src/extension.ts
+++ b/sources/@roots/bud-terser/src/extension.ts
@@ -1,4 +1,3 @@
-import type {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import {
   bind,
@@ -38,8 +37,8 @@ export type Options = TerserPlugin.BasePluginOptions & {
 @dependsOnOptional(['@roots/bud-swc'])
 @expose('terser')
 @options<Options>({
-  include: (bud: Bud) => bud.hooks.filter('pattern.js'),
-  exclude: (bud: Bud) => bud.hooks.filter('pattern.modules'),
+  include: ({hooks}) => hooks.filter('pattern.js'),
+  exclude: ({hooks}) => hooks.filter('pattern.modules'),
   extractComments: false,
   parallel: true,
   terserOptions: {

--- a/sources/@roots/bud-typescript/src/typecheck/index.ts
+++ b/sources/@roots/bud-typescript/src/typecheck/index.ts
@@ -30,6 +30,7 @@ export default class BudTypeCheckPlugin extends Extension<
    * Enable typechecking
    *
    * @override {@link Extension.enable}
+   * @decorator `@bind`
    */
   @bind public async enable(state: boolean = true) {
     this.app.extensions
@@ -43,6 +44,12 @@ export default class BudTypeCheckPlugin extends Extension<
     )
   }
 
+  /**
+   * `init` callback
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind public async init() {
     const typescriptPath = await this.resolve('typescript')
 

--- a/sources/@roots/bud/src/extensions/clean-webpack-plugin/index.ts
+++ b/sources/@roots/bud/src/extensions/clean-webpack-plugin/index.ts
@@ -44,7 +44,7 @@ import {
   cleanOnceBeforeBuildPatterns: ['**/*'],
 })
 @when(
-  async (_opt, {hooks, isProduction}) =>
+  async ({hooks, isProduction}) =>
     hooks.filter('feature.clean') && isProduction,
 )
 export default class BudClean extends Extension<

--- a/sources/@roots/bud/src/extensions/copy-webpack-plugin/index.ts
+++ b/sources/@roots/bud/src/extensions/copy-webpack-plugin/index.ts
@@ -19,7 +19,7 @@ import CopyWebpackPlugin, {PluginOptions} from 'copy-webpack-plugin'
 @label('copy-webpack-plugin')
 @plugin(CopyWebpackPlugin)
 @options<PluginOptions>({patterns: []})
-@when(async options => options.patterns?.length > 0)
+@when(async (_app, options) => options.patterns?.length > 0)
 export default class BudCopyPlugin extends Extension<
   PluginOptions,
   CopyWebpackPlugin

--- a/sources/@roots/sage/src/sage/extension.ts
+++ b/sources/@roots/sage/src/sage/extension.ts
@@ -26,32 +26,39 @@ export default class Sage extends Extension {
    * @decorator `@bind`
    */
   @bind
-  public async boot() {
+  public async boot({isProduction, path}) {
     /**
      * Set paths
      */
-    this.app
-      .setPath({
-        '@src': 'resources',
-        '@dist': 'public',
-        '@resources': '@src',
-        '@public': '@dist',
-        '@fonts': '@src/fonts',
-        '@images': '@src/images',
-        '@scripts': '@src/scripts',
-        '@styles': '@src/styles',
-        '@views': '@src/views',
-      })
-      .alias({
-        '@fonts': this.app.path('@fonts'),
-        '@images': this.app.path('@images'),
-        '@scripts': this.app.path('@scripts'),
-        '@styles': this.app.path('@styles'),
-      })
-      .when(
-        this.app.isProduction,
-        () => this.app.minimize().hash().runtime('single').splitChunks(),
-        () => this.app.devtool(),
-      )
+    this.app.setPath({
+      '@src': 'resources',
+      '@dist': 'public',
+      '@resources': '@src',
+      '@public': '@dist',
+      '@fonts': '@src/fonts',
+      '@images': '@src/images',
+      '@scripts': '@src/scripts',
+      '@styles': '@src/styles',
+      '@views': '@src/views',
+    })
+
+    /**
+     * Set aliases
+     */
+    this.app.alias({
+      '@fonts': path('@fonts'),
+      '@images': path('@images'),
+      '@scripts': path('@scripts'),
+      '@styles': path('@styles'),
+    })
+
+    /**
+     * Optimize
+     */
+    this.app.when(
+      isProduction,
+      () => this.app.minimize().hash().runtime('single').splitChunks(),
+      () => this.app.devtool(),
+    )
   }
 }

--- a/sources/@roots/sage/src/wp-theme-json/extension.ts
+++ b/sources/@roots/sage/src/wp-theme-json/extension.ts
@@ -50,7 +50,7 @@ export interface Mutator {
  */
 @label('@roots/sage/wp-theme-json')
 @options({
-  path: app => app.path('./theme.json'),
+  path: ({path}) => path('./theme.json'),
   settings: {
     color: {
       custom: false,

--- a/tests/unit/bud-purgecss/extension.test.ts
+++ b/tests/unit/bud-purgecss/extension.test.ts
@@ -4,47 +4,30 @@ import * as extension from '@roots/bud-purgecss'
 import {purgecss} from '@roots/bud-purgecss/api'
 
 describe('@roots/bud-purgecss', () => {
-  describe('purgecss extension', () => {
-    it('has name prop', () => {
-      expect(extension.label).toBe('@roots/bud-purgecss')
-    })
-    it('has a registration method', () => {
-      expect(extension.register).toBeInstanceOf(Function)
-    })
+  let bud: Bud
+  beforeEach(async () => {
+    bud = await factory()
+    await bud.build.make()
+    await bud.extensions.add(postcss)
   })
 
-  describe('register', () => {
-    let bud: Bud
-
-    beforeAll(async () => {
-      bud = await factory()
-      await bud.build.make()
-      await bud.extensions.add(postcss)
-    })
-
-    it('has a registration method', async () => {
-      await (extension as any).register(null, bud)
-      expect(bud.purgecss).toBeInstanceOf(Function)
-    })
+  it('should have a name prop', () => {
+    expect(extension.label).toBe('@roots/bud-purgecss')
+  })
+  it('should have a register method', () => {
+    expect(extension.register).toBeInstanceOf(Function)
   })
 
-  describe('bud.purgecss', () => {
-    let bud: Bud
+  it('should register bud.purgecss', async () => {
+    bud = await factory()
+    await bud.build.make()
+    await bud.extensions.add(postcss)
+    await extension.register(bud)
+    expect(bud.purgecss).toBeInstanceOf(Function)
+  })
 
-    beforeAll(async () => {
-      bud = await factory()
-      await bud.build.make()
-      await bud.extensions.add(postcss)
-    })
-
-    it('is a fn', () => {
-      expect(purgecss).toBeInstanceOf(Function)
-    })
-
-    it('adds the purgecss plugin to the postcss repository', () => {
-      purgecss.bind(bud)({content: ['**/*.html']})
-
-      expect(bud.postcss.plugins.has('purgecss')).toBe(true)
-    })
+  it('should add plugin to the postcss plugins repository', () => {
+    purgecss.bind(bud)({content: ['**/*.html']})
+    expect(bud.postcss.plugins.has('purgecss')).toBe(true)
   })
 })


### PR DESCRIPTION
this hasn't been a problem with extensions so far as I usually use `this` to access the bud object and options

- fix some internal issues with extensions lifecycle methods
- add some missing information to docs


refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
