### PR TITLE
fix: missing module error during build

### DIFF
--- a/sources/@roots/bud-tailwindcss/stylelint-config/scss.cjs
+++ b/sources/@roots/bud-tailwindcss/stylelint-config/scss.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    ...require('./common'),
+    ...require('./common.cjs'),
     'no-invalid-position-at-import-rule': null,
     'at-rule-no-unknown': require('./rules/at-rule-no-unknown.cjs'),
     'scss/at-rule-no-unknown': require('./rules/at-rule-no-unknown.cjs'),


### PR DESCRIPTION
```
[stylelint] Cannot find module './common'
Require stack:
- ./node_modules/@roots/bud-tailwindcss/stylelint-config/scss.cjs
- ./node_modules/cosmiconfig/dist/loaders.js
- ./node_modules/cosmiconfig/dist/ExplorerBase.js
- ./node_modules/cosmiconfig/dist/Explorer.js
- ./node_modules/cosmiconfig/dist/index.js
- ./node_modules/stylelint/lib/getConfigForFile.js
- ./node_modules/stylelint/lib/createStylelint.js
- ./node_modules/stylelint/lib/index.js
- ./node_modules/stylelint-webpack-plugin/dist/worker.js
- ./node_modules/stylelint-webpack-plugin/dist/getStylelint.js
- ./node_modules/stylelint-webpack-plugin/dist/linter.js
- ./node_modules/stylelint-webpack-plugin/dist/index.js
```
