### PR TITLE
✨ improve(patch): prevent repeated attempts to import optional deps

### DIFF
--- a/sources/@roots/bud-framework/src/extension/decorators/index.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/index.ts
@@ -1,4 +1,4 @@
-import {bind} from 'helpful-decorators'
+import {bind, once} from 'helpful-decorators'
 
 import {dependsOn} from './dependsOn.js'
 import {dependsOnOptional} from './dependsOnOptional.js'
@@ -18,6 +18,7 @@ export {
   development,
   expose,
   label,
+  once,
   options,
   plugin,
   production,

--- a/sources/@roots/bud-postcss/src/extension.ts
+++ b/sources/@roots/bud-postcss/src/extension.ts
@@ -3,6 +3,7 @@ import {
   bind,
   expose,
   label,
+  once,
 } from '@roots/bud-framework/extension/decorators'
 import {isFunction, isUndefined} from 'lodash-es'
 import type {Plugin, Processor} from 'postcss'
@@ -86,8 +87,6 @@ export default class BudPostCss extends Extension {
       .forEach(([k, v]) => plugins.push(v))
 
     this.plugins.has('env') && plugins.push(this.plugins.get('env'))
-
-    this.logger.log('final postcss plugins:', ...plugins)
 
     return plugins.filter(Boolean)
   }
@@ -338,8 +337,10 @@ export default class BudPostCss extends Extension {
    *
    * @public
    * @decorator `@bind`
+   * @decorator `@once`
    */
   @bind
+  @once
   public async register() {
     this.setPlugins({
       import: await this.resolve('postcss-import'),


### PR DESCRIPTION
Internal change in `@roots/bud-extensions` which monitors import attempts for optionalDependencies. Once an import is attempted and failed it won't be tried again.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
