### PR TITLE
📕 docs(none): bud v6.3.4 release notes

### DIFF
--- a/sources/@repo/docs/content/blog/6.3.4.mdx
+++ b/sources/@repo/docs/content/blog/6.3.4.mdx
@@ -1,0 +1,61 @@
+---
+slug: '6.3.4'
+title: 'Release: 6.3.4'
+description: 'Release notes for bud.js 6.3.4'
+date: 2022-07-25
+author: Kelly Mears
+author_title: Lead developer
+author_url: https://github.com/kellymears
+author_image_url: https://avatars.githubusercontent.com/u/397606?v=4
+tags: [release]
+---
+
+<!--truncate-->
+
+## 🩹 Fix: conditionally add/remove `bud-error` component
+
+The `bud-error` component is now only added to the DOM only when there is an error and is removed when there is not.
+
+## ✨ Improve: public env values
+
+The [bud.env docs have been updated](https://bud.js.org/docs/bud.env) to reflect the actual intended use of public env variables:
+
+```env tile=".env"
+PUBLIC_APP_NAME="My App"
+```
+
+```js title="app.js"
+console.log(APP_NAME)
+```
+
+Previously, the envvars would have needed to include quotations in order to be output as a string (as in: `PUBLIC_APP_NAME="'My App'"`).
+Now, they are passed through `JSON.stringify` automatically.
+
+## ✨ Improve: prevent repeated attempts to import optional dependencies
+
+A number of extensions will attempt to use dependencies if they are available, falling back to more common
+dependencies if they are not. Previously, bud.js would attempt to import the dependencies repeatedly, in cases
+where more than one extension tried for the same optional, uninstalled dependency.
+
+Not sure that this matters much in terms of performance because of the way that esmodules are cached. But, at the very least,
+it cleans up the logs a bit.
+
+## 🩹 Fix: `@roots/bud-tailwindcss/stylelint-config/scss` error
+
+Hattip to @joshuafredrickson for the PR fixing this module import error.
+
+## ℹ️ Release information
+
+- ✨ improve(patch): stringify env values (#1604)
+- 🩹 fix(patch): conditionally add/remove bud-error (#1603)
+- 📦 deps: update html-loader to v4 (#1599)
+- 📦 deps: update npm to v8.15.0 (#1602)
+- 📦 deps: update @yarnpkg (#1600)
+- 📦 deps: update Yarn to v3.2.2 (#1601)
+- ✨ improve(patch): prevent repeated attempts to import optional deps (#1598)
+- 🩹 fix: missing module error during build (#1596)
+- 📦 deps: update typedoc to v0.23.8
+- 📦 deps: update wordpress monorepo (#1593)
+- 📦 deps: update react
+
+For more information [review the diff to see what's changed](https://github.com/roots/bud/compare/v6.3.3...v6.3.4).

--- a/sources/@roots/bud-client/src/components/overlay/overlay.component.cts
+++ b/sources/@roots/bud-client/src/components/overlay/overlay.component.cts
@@ -19,6 +19,11 @@ export class Component extends HTMLElement {
     return this.getAttribute('message')
   }
 
+  public constructor() {
+    super()
+    this.renderShadow()
+  }
+
   public renderShadow(): void {
     const container = document.createElement('div')
     container.classList.add('overlay')
@@ -162,6 +167,5 @@ export class Component extends HTMLElement {
 
   public connectedCallback() {
     if (document.body?.style) this.documentBodyStyle = document.body.style
-    this.renderShadow()
   }
 }


### PR DESCRIPTION
6.3.4 release notes

makes one small fix to `bud-error` that became apparent in e2e tests.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
