### PR TITLE
🩹 fix(patch): directory containing spaces

### DIFF
--- a/sources/@roots/bud-babel/src/extension.ts
+++ b/sources/@roots/bud-babel/src/extension.ts
@@ -49,23 +49,6 @@ export default class BabelExtension extends Extension<any, null> {
    * @decorator `@bind`
    */
   @bind
-  public setLoader() {
-    return ruleSetItem.setLoader('babel').setOptions(() => ({
-      cacheDirectory: this.cacheDirectory,
-      presets: Object.values(this.app.babel.presets),
-      plugins: Object.values(this.app.babel.plugins),
-      env: this.env,
-      root: this.root,
-    }))
-  }
-
-  /**
-   * Babel RuleSetItem callback
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  @bind
   public setRuleSetItem(ruleSetItem: Build.Item) {
     return ruleSetItem.setLoader('babel').setOptions(() => ({
       cacheDirectory: this.cacheDirectory,
@@ -141,6 +124,11 @@ export default class BabelExtension extends Extension<any, null> {
         '@babel/plugin-syntax-dynamic-import',
         dynamicImport,
       )
+
+    const loader = await this.resolve('babel-loader', import.meta.url)
+    if (!loader) {
+      return this.logger.error('Babel loader not found')
+    }
 
     this.app.build
       .setLoader('babel', loader)

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -517,16 +517,24 @@ export class Extension<E = any, Plugin extends ApplyPlugin = any> {
    * @decorator `@bind`
    */
   @bind
-  public async resolve(signifier: string): Promise<string> {
-    const modulePath = await this.app.module.resolve(signifier)
+  public async resolve(
+    signifier: string,
+    parent?: string,
+  ): Promise<string> {
+    let modulePath: string
+
+    modulePath = await this.app.module.resolve(signifier)
+
     if (!modulePath) {
-      this.app.error('resolve error', `${signifier} not found`)
+      modulePath = await this.app.module.resolve(signifier, parent)
+    }
+    if (!modulePath) {
+      this.logger.error('unresolvable:', signifier)
     }
 
     this.logger.log(
-      'resolving',
       signifier,
-      'to',
+      '=>',
       modulePath.replace(this.app.path(), '.'),
     )
 

--- a/sources/@roots/bud-framework/src/module.ts
+++ b/sources/@roots/bud-framework/src/module.ts
@@ -92,7 +92,7 @@ export class Module {
         parent ? `file://${parent}` : import.meta.url,
       )
 
-      return resolvedPath.replace('file://', '')
+      return resolvedPath.replace('file://', '').replace(/%20/g, ' ')
     } catch (err) {
       throw new Error(err)
     }


### PR DESCRIPTION
## fix: paths containing spaces

`import-meta-resolve` converts spaces to `%20`.

This re-replaces the space.

## improve: bud.module.resolve and bud.module.import

I think these methods were technically resolving peers of `@roots/bud` instead of peers of the project. This resolves module paths relative to the project, if a parent context is not asserted.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
