### PR TITLE
🩹 fix(patch): unresolvable optional deps throw fatal error

### DIFF
--- a/sources/@roots/bud-framework/src/module.ts
+++ b/sources/@roots/bud-framework/src/module.ts
@@ -1,7 +1,7 @@
 import {bind, memo} from 'helpful-decorators'
 import {resolve} from 'import-meta-resolve'
 import {createRequire} from 'module'
-import {join, relative} from 'node:path'
+import {join, normalize, relative} from 'node:path'
 
 import type {Bud} from './bud.js'
 
@@ -91,10 +91,12 @@ export class Module {
 
     try {
       const resolvedPath = await resolve(signifier, context)
-      return resolvedPath.replace('file://', '').replace(/%20/g, ' ')
+      const normalized = normalize(
+        resolvedPath.replace('file://', '').replace(/%20/g, ' '),
+      )
+      return normalized
     } catch (err) {
-      this.app.error(signifier, 'not resolvable', `(context: ${context})`)
-      return ''
+      this.app.info(signifier, 'not resolvable', `(context: ${context})`)
     }
   }
 


### PR DESCRIPTION
e2e tests caught that throwing an Error from the change in #1608 will cause the build to fail outside the context of the repo. 

an optional dependency not resolving shouldn't fail a build.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
