### PR TITLE
🧪 test(none): fix failing @roots/bud-emotion test

### DIFF
--- a/tests/integration/__snapshots__/emotion.test.ts.snap
+++ b/tests/integration/__snapshots__/emotion.test.ts.snap
@@ -1,21 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`emotion npm manifest.json matches snapshot 1`] = `
-Object {
-  "app.js": "js/app.js",
-  "index.html": "index.html",
-  "js/69.js": "js/69.js",
-  "runtime.js": "js/runtime.js",
-  "svg/logo.svg": "svg/logo.svg",
-}
-`;
+exports[`emotion npm app.js should be present in the manifest 1`] = `"js/app.js"`;
 
-exports[`emotion yarn manifest.json matches snapshot 1`] = `
-Object {
-  "app.js": "js/app.js",
-  "index.html": "index.html",
-  "js/69.js": "js/69.js",
-  "runtime.js": "js/runtime.js",
-  "svg/logo.svg": "svg/logo.svg",
-}
-`;
+exports[`emotion npm index.html should be present in the manifest 1`] = `"index.html"`;
+
+exports[`emotion npm runtime.js should be present in the manifest 1`] = `"js/runtime.js"`;
+
+exports[`emotion npm svg/logo.svg should be present in the manifest 1`] = `"svg/logo.svg"`;
+
+exports[`emotion yarn app.js should be present in the manifest 1`] = `"js/app.js"`;
+
+exports[`emotion yarn index.html should be present in the manifest 1`] = `"index.html"`;
+
+exports[`emotion yarn runtime.js should be present in the manifest 1`] = `"js/runtime.js"`;
+
+exports[`emotion yarn svg/logo.svg should be present in the manifest 1`] = `"svg/logo.svg"`;

--- a/tests/integration/emotion.test.ts
+++ b/tests/integration/emotion.test.ts
@@ -13,18 +13,64 @@ const run = pacman => () => {
   })
 
   describe('app.js', () => {
-    it('has contents', () => {
+    it('should not be empty', () => {
       expect(project.assets['app.js'].length).toBeGreaterThan(10)
     })
 
-    it('is transpiled', () => {
-      expect(project.assets['app.js'].includes('import')).toBeFalsy()
+    it('should not contain import statements', () => {
+      expect(project.assets['app.js'].includes('import ')).toBeFalsy()
+    })
+
+    it('should be present in the manifest', () => {
+      expect(project.manifest['app.js']).toMatchSnapshot()
+    })
+  })
+
+  describe('runtime.js', () => {
+    it('should not be empty', () => {
+      expect(project.assets['runtime.js'].length).toBeGreaterThan(10)
+    })
+
+    it('should not contain import statements', () => {
+      expect(project.assets['runtime.js'].includes('import ')).toBeFalsy()
+    })
+
+    it('should be present in the manifest', () => {
+      expect(project.manifest['runtime.js']).toMatchSnapshot()
+    })
+  })
+
+  describe('index.html', () => {
+    it('should not be empty', () => {
+      expect(project.assets['index.html'].length).toBeGreaterThan(10)
+    })
+
+    it('should contain a script tag', () => {
+      expect(project.assets['index.html'].includes('<script')).toBeTruthy()
+    })
+
+    it('should be present in the manifest', () => {
+      expect(project.manifest['index.html']).toMatchSnapshot()
+    })
+  })
+
+  describe('svg/logo.svg', () => {
+    it('should not be empty', () => {
+      expect(project.assets['svg/logo.svg'].length).toBeGreaterThan(10)
+    })
+
+    it('should contain svg tag', () => {
+      expect(project.assets['svg/logo.svg'].includes('<svg')).toBeTruthy()
+    })
+
+    it('should be present in the manifest', () => {
+      expect(project.manifest['svg/logo.svg']).toMatchSnapshot()
     })
   })
 
   describe('manifest.json', () => {
-    it('matches snapshot', () => {
-      expect(project.manifest).toMatchSnapshot()
+    it('should have expected number of items', () => {
+      expect(Object.keys(project.manifest)).toHaveLength(5)
     })
   })
 }


### PR DESCRIPTION
This test was super flimsy. It should gives us more assurance now and break less.

refers:

- none

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
