### PR TITLE
⚠️ deprecate bud.js and bud.css

### DIFF
--- a/sources/@roots/bud-api/src/facade/facade.interface.ts
+++ b/sources/@roots/bud-api/src/facade/facade.interface.ts
@@ -415,6 +415,12 @@ export class Facade {
    * })
    * ```
    *
+   *
+   * @deprecated
+   * Use `entry` method
+   *
+   * @see {@link https://bud.js.org/docs/bud.entry}
+   *
    * @public
    */
   public js: entryFacade
@@ -480,6 +486,11 @@ export class Facade {
    *  },
    * })
    * ```
+   *
+   * @deprecated
+   * Use `entry` method
+   *
+   * @see {@link https://bud.js.org/docs/bud.entry}
    *
    * @public
    */


### PR DESCRIPTION
These are meant to be a mix compatibility layer, but i'd like to remove them in the next major version. 

Just adds `@deprecated` to docblocks

refers:

- none

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
