### PR TITLE
🩹 fix(patch): import `@types` & postcss version

### DIFF
--- a/sources/@roots/bud-postcss/package.json
+++ b/sources/@roots/bud-postcss/package.json
@@ -68,11 +68,11 @@
   "dependencies": {
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework",
     "lodash-es": "4.17.21",
-    "postcss": "8.4.14",
+    "postcss": "8.4.16",
     "postcss-import": "14.1.0",
     "postcss-loader": "7.0.1",
     "postcss-nested": "5.0.6",
-    "postcss-preset-env": "7.7.2",
+    "postcss-preset-env": "7.8.0",
     "tslib": "2.4.0"
   },
   "peerDependencies": {
@@ -87,6 +87,9 @@
       "optional": true
     },
     "postcss-import": {
+      "optional": true
+    },
+    "postcss-loader": {
       "optional": true
     },
     "postcss-nested": {

--- a/sources/@roots/bud-purgecss/package.json
+++ b/sources/@roots/bud-purgecss/package.json
@@ -62,11 +62,9 @@
     }
   },
   "devDependencies": {
-    "@fullhuman/postcss-purgecss": "4.1.3",
     "@skypack/package-check": "0.2.2",
-    "@types/lodash": "4.14.182",
     "@types/node": "16.11.48",
-    "postcss": "8.4.14"
+    "postcss": "8.4.16"
   },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "4.1.3",
@@ -75,7 +73,7 @@
     "tslib": "2.4.0"
   },
   "peerDependencies": {
-    "@fullhuman/postcss-purgecss": "^4.1.3"
+    "@fullhuman/postcss-purgecss": "*"
   },
   "peerDependenciesMeta": {
     "@fullhuman/postcss-purgecss": {

--- a/sources/@roots/bud-sass/package.json
+++ b/sources/@roots/bud-sass/package.json
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@skypack/package-check": "0.2.2",
     "@types/node": "16.11.48",
-    "postcss": "8.4.14",
+    "postcss": "8.4.16",
     "stylelint": "14.9.1",
     "webpack": "5.73.0"
   },

--- a/sources/@roots/bud-tailwindcss/package.json
+++ b/sources/@roots/bud-tailwindcss/package.json
@@ -74,8 +74,8 @@
   "dependencies": {
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework",
     "@roots/bud-postcss": "workspace:sources/@roots/bud-postcss",
-    "autoprefixer": "^10.4.0",
-    "tailwindcss": "^3.0.24",
+    "autoprefixer": "^10.4.8",
+    "tailwindcss": "^3.1.8",
     "tslib": "2.4.0"
   },
   "peerDependencies": {
@@ -84,9 +84,6 @@
   },
   "peerDependenciesMeta": {
     "autoprefixer": {
-      "optional": true
-    },
-    "postcss": {
       "optional": true
     },
     "tailwindcss": {

--- a/storage/package.json
+++ b/storage/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "pm2": "5.2.0",
-    "verdaccio": "5.14.0"
+    "pm2": "^5.2.0",
+    "verdaccio": "^5.14.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1786,7 +1786,7 @@ __metadata:
 
 "@csstools/postcss-cascade-layers@npm:^1.0.5":
   version: 1.0.5
-  resolution: "@csstools/postcss-cascade-layers@npm:1.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-cascade-layers%2F-%2Fpostcss-cascade-layers-1.0.5.tgz"
+  resolution: "@csstools/postcss-cascade-layers@npm:1.0.5"
   dependencies:
     "@csstools/selector-specificity": ^2.0.2
     postcss-selector-parser: ^6.0.10
@@ -1798,7 +1798,7 @@ __metadata:
 
 "@csstools/postcss-color-function@npm:^1.1.1":
   version: 1.1.1
-  resolution: "@csstools/postcss-color-function@npm:1.1.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-color-function%2F-%2Fpostcss-color-function-1.1.1.tgz"
+  resolution: "@csstools/postcss-color-function@npm:1.1.1"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
@@ -1810,7 +1810,7 @@ __metadata:
 
 "@csstools/postcss-font-format-keywords@npm:^1.0.1":
   version: 1.0.1
-  resolution: "@csstools/postcss-font-format-keywords@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-font-format-keywords%2F-%2Fpostcss-font-format-keywords-1.0.1.tgz"
+  resolution: "@csstools/postcss-font-format-keywords@npm:1.0.1"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1821,7 +1821,7 @@ __metadata:
 
 "@csstools/postcss-hwb-function@npm:^1.0.2":
   version: 1.0.2
-  resolution: "@csstools/postcss-hwb-function@npm:1.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-hwb-function%2F-%2Fpostcss-hwb-function-1.0.2.tgz"
+  resolution: "@csstools/postcss-hwb-function@npm:1.0.2"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1832,7 +1832,7 @@ __metadata:
 
 "@csstools/postcss-ic-unit@npm:^1.0.1":
   version: 1.0.1
-  resolution: "@csstools/postcss-ic-unit@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-ic-unit%2F-%2Fpostcss-ic-unit-1.0.1.tgz"
+  resolution: "@csstools/postcss-ic-unit@npm:1.0.1"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
@@ -1844,7 +1844,7 @@ __metadata:
 
 "@csstools/postcss-is-pseudo-class@npm:^2.0.7":
   version: 2.0.7
-  resolution: "@csstools/postcss-is-pseudo-class@npm:2.0.7::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-is-pseudo-class%2F-%2Fpostcss-is-pseudo-class-2.0.7.tgz"
+  resolution: "@csstools/postcss-is-pseudo-class@npm:2.0.7"
   dependencies:
     "@csstools/selector-specificity": ^2.0.0
     postcss-selector-parser: ^6.0.10
@@ -1856,7 +1856,7 @@ __metadata:
 
 "@csstools/postcss-nested-calc@npm:^1.0.0":
   version: 1.0.0
-  resolution: "@csstools/postcss-nested-calc@npm:1.0.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-nested-calc%2F-%2Fpostcss-nested-calc-1.0.0.tgz"
+  resolution: "@csstools/postcss-nested-calc@npm:1.0.0"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1867,7 +1867,7 @@ __metadata:
 
 "@csstools/postcss-normalize-display-values@npm:^1.0.1":
   version: 1.0.1
-  resolution: "@csstools/postcss-normalize-display-values@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-normalize-display-values%2F-%2Fpostcss-normalize-display-values-1.0.1.tgz"
+  resolution: "@csstools/postcss-normalize-display-values@npm:1.0.1"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1878,7 +1878,7 @@ __metadata:
 
 "@csstools/postcss-oklab-function@npm:^1.1.1":
   version: 1.1.1
-  resolution: "@csstools/postcss-oklab-function@npm:1.1.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-oklab-function%2F-%2Fpostcss-oklab-function-1.1.1.tgz"
+  resolution: "@csstools/postcss-oklab-function@npm:1.1.1"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
@@ -1901,7 +1901,7 @@ __metadata:
 
 "@csstools/postcss-stepped-value-functions@npm:^1.0.1":
   version: 1.0.1
-  resolution: "@csstools/postcss-stepped-value-functions@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-stepped-value-functions%2F-%2Fpostcss-stepped-value-functions-1.0.1.tgz"
+  resolution: "@csstools/postcss-stepped-value-functions@npm:1.0.1"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1912,7 +1912,7 @@ __metadata:
 
 "@csstools/postcss-text-decoration-shorthand@npm:^1.0.0":
   version: 1.0.0
-  resolution: "@csstools/postcss-text-decoration-shorthand@npm:1.0.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-text-decoration-shorthand%2F-%2Fpostcss-text-decoration-shorthand-1.0.0.tgz"
+  resolution: "@csstools/postcss-text-decoration-shorthand@npm:1.0.0"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1923,7 +1923,7 @@ __metadata:
 
 "@csstools/postcss-trigonometric-functions@npm:^1.0.2":
   version: 1.0.2
-  resolution: "@csstools/postcss-trigonometric-functions@npm:1.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-trigonometric-functions%2F-%2Fpostcss-trigonometric-functions-1.0.2.tgz"
+  resolution: "@csstools/postcss-trigonometric-functions@npm:1.0.2"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -1934,26 +1934,16 @@ __metadata:
 
 "@csstools/postcss-unset-value@npm:^1.0.2":
   version: 1.0.2
-  resolution: "@csstools/postcss-unset-value@npm:1.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-unset-value%2F-%2Fpostcss-unset-value-1.0.2.tgz"
+  resolution: "@csstools/postcss-unset-value@npm:1.0.2"
   peerDependencies:
     postcss: ^8.2
   checksum: 3facdae154d6516ffd964f7582696f406465f11cf8dead503e0afdfecc99ebc25638ab2830affce4516131aa2db004458a235e439f575b04e9ef72ad82f55835
   languageName: node
   linkType: hard
 
-"@csstools/selector-specificity@npm:^2.0.0, @csstools/selector-specificity@npm:^2.0.1":
+"@csstools/selector-specificity@npm:^2.0.0, @csstools/selector-specificity@npm:^2.0.1, @csstools/selector-specificity@npm:^2.0.2":
   version: 2.0.2
   resolution: "@csstools/selector-specificity@npm:2.0.2"
-  peerDependencies:
-    postcss: ^8.2
-    postcss-selector-parser: ^6.0.10
-  checksum: a2045a27276a6cfe645b6e212afc217d9a43174ea7a1fa1ab8918d5a0ace72380fbd9837fe1920c547985c11a9070dc48c5c80d483d3f581ddf7aa688204d44f
-  languageName: node
-  linkType: hard
-
-"@csstools/selector-specificity@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@csstools/selector-specificity@npm:2.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fselector-specificity%2F-%2Fselector-specificity-2.0.2.tgz"
   peerDependencies:
     postcss: ^8.2
     postcss-selector-parser: ^6.0.10
@@ -8484,7 +8474,7 @@ __metadata:
 
 "acorn-node@npm:^1.8.2":
   version: 1.8.2
-  resolution: "acorn-node@npm:1.8.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Facorn-node%2F-%2Facorn-node-1.8.2.tgz"
+  resolution: "acorn-node@npm:1.8.2"
   dependencies:
     acorn: ^7.0.0
     acorn-walk: ^7.0.0
@@ -9023,7 +9013,7 @@ __metadata:
 
 "arg@npm:^5.0.2":
   version: 5.0.2
-  resolution: "arg@npm:5.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Farg%2F-%2Farg-5.0.2.tgz"
+  resolution: "arg@npm:5.0.2"
   checksum: 6c69ada1a9943d332d9e5382393e897c500908d91d5cb735a01120d5f71daf1b339b7b8980cbeaba8fd1afc68e658a739746179e4315a26e8a28951ff9930078
   languageName: node
   linkType: hard
@@ -9388,7 +9378,7 @@ __metadata:
 
 "autoprefixer@npm:^10.4.8":
   version: 10.4.8
-  resolution: "autoprefixer@npm:10.4.8::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fautoprefixer%2F-%2Fautoprefixer-10.4.8.tgz"
+  resolution: "autoprefixer@npm:10.4.8"
   dependencies:
     browserslist: ^4.21.3
     caniuse-lite: ^1.0.30001373
@@ -9981,7 +9971,7 @@ __metadata:
 
 "browserslist@npm:^4.21.3":
   version: 4.21.3
-  resolution: "browserslist@npm:4.21.3::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fbrowserslist%2F-%2Fbrowserslist-4.21.3.tgz"
+  resolution: "browserslist@npm:4.21.3"
   dependencies:
     caniuse-lite: ^1.0.30001370
     electron-to-chromium: ^1.4.202
@@ -10339,7 +10329,7 @@ __metadata:
 
 "caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001373":
   version: 1.0.30001378
-  resolution: "caniuse-lite@npm:1.0.30001378::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fcaniuse-lite%2F-%2Fcaniuse-lite-1.0.30001378.tgz"
+  resolution: "caniuse-lite@npm:1.0.30001378"
   checksum: 19f1774da1f62d393ddde55dc091eb3e4f5c5b0ce43f9a9d20e75307a0f329cf8591c836a35a9f6f9fd7c27db7a75e0682245a194acec2e2ba1bc25ef1c3300c
   languageName: node
   linkType: hard
@@ -11987,7 +11977,7 @@ __metadata:
 
 "cssdb@npm:^7.0.0":
   version: 7.0.0
-  resolution: "cssdb@npm:7.0.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fcssdb%2F-%2Fcssdb-7.0.0.tgz"
+  resolution: "cssdb@npm:7.0.0"
   checksum: ae7e91fc812647ae542b1a7c737a8c517e6ea8b7811e165a503061a3cd999b4577852e84ed54d7010517923576a7fc5f0bceddb9eae40b160fa268dd3dc29fe7
   languageName: node
   linkType: hard
@@ -12802,7 +12792,7 @@ __metadata:
 
 "detective@npm:^5.2.1":
   version: 5.2.1
-  resolution: "detective@npm:5.2.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fdetective%2F-%2Fdetective-5.2.1.tgz"
+  resolution: "detective@npm:5.2.1"
   dependencies:
     acorn-node: ^1.8.2
     defined: ^1.0.0
@@ -13284,7 +13274,7 @@ __metadata:
 
 "electron-to-chromium@npm:^1.4.202":
   version: 1.4.222
-  resolution: "electron-to-chromium@npm:1.4.222::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Felectron-to-chromium%2F-%2Felectron-to-chromium-1.4.222.tgz"
+  resolution: "electron-to-chromium@npm:1.4.222"
   checksum: acae758e1cfb647cfaa7ac662200e3d2c15a66c50da999cac2c08e98908e61c276c4ef336e0f9d0f42d75b68f08cdc4efe6cb7b8031cfe5aed47645ebd07632c
   languageName: node
   linkType: hard
@@ -19494,7 +19484,7 @@ __metadata:
 
 "lilconfig@npm:^2.0.6":
   version: 2.0.6
-  resolution: "lilconfig@npm:2.0.6::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Flilconfig%2F-%2Flilconfig-2.0.6.tgz"
+  resolution: "lilconfig@npm:2.0.6"
   checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
   languageName: node
   linkType: hard
@@ -23583,7 +23573,7 @@ __metadata:
 
 "postcss-attribute-case-insensitive@npm:^5.0.2":
   version: 5.0.2
-  resolution: "postcss-attribute-case-insensitive@npm:5.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-attribute-case-insensitive%2F-%2Fpostcss-attribute-case-insensitive-5.0.2.tgz"
+  resolution: "postcss-attribute-case-insensitive@npm:5.0.2"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
@@ -23617,7 +23607,7 @@ __metadata:
 
 "postcss-color-functional-notation@npm:^4.2.4":
   version: 4.2.4
-  resolution: "postcss-color-functional-notation@npm:4.2.4::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-color-functional-notation%2F-%2Fpostcss-color-functional-notation-4.2.4.tgz"
+  resolution: "postcss-color-functional-notation@npm:4.2.4"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -23639,7 +23629,7 @@ __metadata:
 
 "postcss-color-rebeccapurple@npm:^7.1.1":
   version: 7.1.1
-  resolution: "postcss-color-rebeccapurple@npm:7.1.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-color-rebeccapurple%2F-%2Fpostcss-color-rebeccapurple-7.1.1.tgz"
+  resolution: "postcss-color-rebeccapurple@npm:7.1.1"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -23709,7 +23699,7 @@ __metadata:
 
 "postcss-dir-pseudo-class@npm:^6.0.5":
   version: 6.0.5
-  resolution: "postcss-dir-pseudo-class@npm:6.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-dir-pseudo-class%2F-%2Fpostcss-dir-pseudo-class-6.0.5.tgz"
+  resolution: "postcss-dir-pseudo-class@npm:6.0.5"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
@@ -23779,7 +23769,7 @@ __metadata:
 
 "postcss-double-position-gradients@npm:^3.1.2":
   version: 3.1.2
-  resolution: "postcss-double-position-gradients@npm:3.1.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-double-position-gradients%2F-%2Fpostcss-double-position-gradients-3.1.2.tgz"
+  resolution: "postcss-double-position-gradients@npm:3.1.2"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
@@ -23833,7 +23823,7 @@ __metadata:
 
 "postcss-gap-properties@npm:^3.0.5":
   version: 3.0.5
-  resolution: "postcss-gap-properties@npm:3.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-gap-properties%2F-%2Fpostcss-gap-properties-3.0.5.tgz"
+  resolution: "postcss-gap-properties@npm:3.0.5"
   peerDependencies:
     postcss: ^8.2
   checksum: aed559d6d375203a08a006c9ae8cf5ae90d9edaec5cadd20fe65c1b8ce63c2bc8dfe752d4331880a6e24a300541cde61058be790b7bd9b5d04d470c250fbcd39
@@ -23857,7 +23847,7 @@ __metadata:
 
 "postcss-image-set-function@npm:^4.0.7":
   version: 4.0.7
-  resolution: "postcss-image-set-function@npm:4.0.7::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-image-set-function%2F-%2Fpostcss-image-set-function-4.0.7.tgz"
+  resolution: "postcss-image-set-function@npm:4.0.7"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -23866,22 +23856,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-import@npm:14.1.0":
+"postcss-import@npm:14.1.0, postcss-import@npm:^14.1.0":
   version: 14.1.0
   resolution: "postcss-import@npm:14.1.0"
-  dependencies:
-    postcss-value-parser: ^4.0.0
-    read-cache: ^1.0.0
-    resolve: ^1.1.7
-  peerDependencies:
-    postcss: ^8.0.0
-  checksum: cd45d406e90f67cdab9524352e573cc6b4462b790934a05954e929a6653ebd31288ceebc8ce3c3ed7117ae672d9ebbec57df0bceec0a56e9b259c2e71d47ca86
-  languageName: node
-  linkType: hard
-
-"postcss-import@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "postcss-import@npm:14.1.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-import%2F-%2Fpostcss-import-14.1.0.tgz"
   dependencies:
     postcss-value-parser: ^4.0.0
     read-cache: ^1.0.0
@@ -23914,7 +23891,7 @@ __metadata:
 
 "postcss-lab-function@npm:^4.2.1":
   version: 4.2.1
-  resolution: "postcss-lab-function@npm:4.2.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-lab-function%2F-%2Fpostcss-lab-function-4.2.1.tgz"
+  resolution: "postcss-lab-function@npm:4.2.1"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
@@ -24124,7 +24101,7 @@ __metadata:
 
 "postcss-nesting@npm:^10.1.10":
   version: 10.1.10
-  resolution: "postcss-nesting@npm:10.1.10::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-nesting%2F-%2Fpostcss-nesting-10.1.10.tgz"
+  resolution: "postcss-nesting@npm:10.1.10"
   dependencies:
     "@csstools/selector-specificity": ^2.0.0
     postcss-selector-parser: ^6.0.10
@@ -24254,7 +24231,7 @@ __metadata:
 
 "postcss-overflow-shorthand@npm:^3.0.4":
   version: 3.0.4
-  resolution: "postcss-overflow-shorthand@npm:3.0.4::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-overflow-shorthand%2F-%2Fpostcss-overflow-shorthand-3.0.4.tgz"
+  resolution: "postcss-overflow-shorthand@npm:3.0.4"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -24274,7 +24251,7 @@ __metadata:
 
 "postcss-place@npm:^7.0.5":
   version: 7.0.5
-  resolution: "postcss-place@npm:7.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-place%2F-%2Fpostcss-place-7.0.5.tgz"
+  resolution: "postcss-place@npm:7.0.5"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
@@ -24285,7 +24262,7 @@ __metadata:
 
 "postcss-preset-env@npm:7.8.0":
   version: 7.8.0
-  resolution: "postcss-preset-env@npm:7.8.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-preset-env%2F-%2Fpostcss-preset-env-7.8.0.tgz"
+  resolution: "postcss-preset-env@npm:7.8.0"
   dependencies:
     "@csstools/postcss-cascade-layers": ^1.0.5
     "@csstools/postcss-color-function": ^1.1.1
@@ -24344,7 +24321,7 @@ __metadata:
 
 "postcss-pseudo-class-any-link@npm:^7.1.6":
   version: 7.1.6
-  resolution: "postcss-pseudo-class-any-link@npm:7.1.6::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-pseudo-class-any-link%2F-%2Fpostcss-pseudo-class-any-link-7.1.6.tgz"
+  resolution: "postcss-pseudo-class-any-link@npm:7.1.6"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
@@ -24423,7 +24400,7 @@ __metadata:
 
 "postcss-selector-not@npm:^6.0.1":
   version: 6.0.1
-  resolution: "postcss-selector-not@npm:6.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-selector-not%2F-%2Fpostcss-selector-not-6.0.1.tgz"
+  resolution: "postcss-selector-not@npm:6.0.1"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
@@ -24521,7 +24498,7 @@ __metadata:
 
 "postcss@npm:8.4.16":
   version: 8.4.16
-  resolution: "postcss@npm:8.4.16::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss%2F-%2Fpostcss-8.4.16.tgz"
+  resolution: "postcss@npm:8.4.16"
   dependencies:
     nanoid: ^3.3.4
     picocolors: ^1.0.0
@@ -26291,7 +26268,7 @@ __metadata:
 
 "resolve@npm:^1.22.1":
   version: 1.22.1
-  resolution: "resolve@npm:1.22.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fresolve%2F-%2Fresolve-1.22.1.tgz"
+  resolution: "resolve@npm:1.22.1"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -26340,7 +26317,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1%3A%3A__archiveUrl=http%253A%252F%252Flocalhost%253A4873%252Fresolve%252F-%252Fresolve-1.22.1.tgz#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7
@@ -28404,7 +28381,7 @@ __metadata:
 
 "tailwindcss@npm:^3.1.8":
   version: 3.1.8
-  resolution: "tailwindcss@npm:3.1.8::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Ftailwindcss%2F-%2Ftailwindcss-3.1.8.tgz"
+  resolution: "tailwindcss@npm:3.1.8"
   dependencies:
     arg: ^5.0.2
     chokidar: ^3.5.3
@@ -29819,7 +29796,7 @@ __metadata:
 
 "update-browserslist-db@npm:^1.0.5":
   version: 1.0.5
-  resolution: "update-browserslist-db@npm:1.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fupdate-browserslist-db%2F-%2Fupdate-browserslist-db-1.0.5.tgz"
+  resolution: "update-browserslist-db@npm:1.0.5"
   dependencies:
     escalade: ^3.1.1
     picocolors: ^1.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,96 +1784,107 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/postcss-cascade-layers@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@csstools/postcss-cascade-layers@npm:1.0.4"
+"@csstools/postcss-cascade-layers@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "@csstools/postcss-cascade-layers@npm:1.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-cascade-layers%2F-%2Fpostcss-cascade-layers-1.0.5.tgz"
   dependencies:
-    "@csstools/selector-specificity": ^2.0.0
+    "@csstools/selector-specificity": ^2.0.2
     postcss-selector-parser: ^6.0.10
   peerDependencies:
     postcss: ^8.2
-  checksum: 1edaa13111f316c85b5288da9429829661edef20bd5cb70f5906d94d00d3d9e1033ba48b40363328da346a62597048eb6019ca306276d19a9b8d27dd521c4f7b
+  checksum: f9d6954d7d7b888af9ecc6160e1a1d3dac3d11de7520007e198689c703249c7e66d6e7643828b76952a77576193f295dbcaea897ac21d01a217f94cc7935dc73
   languageName: node
   linkType: hard
 
-"@csstools/postcss-color-function@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@csstools/postcss-color-function@npm:1.1.0"
+"@csstools/postcss-color-function@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@csstools/postcss-color-function@npm:1.1.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-color-function%2F-%2Fpostcss-color-function-1.1.1.tgz"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: 1378858848067fce67b5b7d1daeb3082bddeacddc588cea0fd85e5d7a0bb5cd4f43fea9b96fced2bc1c45171f8900d1f5ebfe13f574c360164c79e055868befb
+    postcss: ^8.2
+  checksum: 087595985ebcc2fc42013d6305185d4cdc842d87fb261185db905dc31eaa24fc23a7cc068fa3da814b3c8b98164107ddaf1b4ab24f4ff5b2a7b5fbcd4c6ceec9
   languageName: node
   linkType: hard
 
-"@csstools/postcss-font-format-keywords@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@csstools/postcss-font-format-keywords@npm:1.0.0"
-  dependencies:
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.3
-  checksum: 4f41dccc46b51568b0517420d150ca105c31a2652f028f070e7457213f4e950420385d72ee869d75f592811da3a03cb46d11935d51f29b73d9ab24c10b3140e5
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-hwb-function@npm:^1.0.1":
+"@csstools/postcss-font-format-keywords@npm:^1.0.1":
   version: 1.0.1
-  resolution: "@csstools/postcss-hwb-function@npm:1.0.1"
+  resolution: "@csstools/postcss-font-format-keywords@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-font-format-keywords%2F-%2Fpostcss-font-format-keywords-1.0.1.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: c57a74ac5c2ca9d209b325b8995932262b0498300eaab80cffb64278c2b3cb47b2203b3b5bb47e0b00532f985449be9f60f3496ed1c9cec57e4b07047a36f7a6
+    postcss: ^8.2
+  checksum: ed8d9eab9793f0184e000709bcb155d4eb96c49a312e3ea9e549e006b74fd4aafac63cb9f9f01bec5b717a833539ff085c3f1ef7d273b97d587769ef637d50c1
   languageName: node
   linkType: hard
 
-"@csstools/postcss-ic-unit@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@csstools/postcss-ic-unit@npm:1.0.0"
+"@csstools/postcss-hwb-function@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@csstools/postcss-hwb-function@npm:1.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-hwb-function%2F-%2Fpostcss-hwb-function-1.0.2.tgz"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2
+  checksum: 352ead754a692f7ed33a712c491012cab5c2f2946136a669a354237cfe8e6faca90c7389ee793cb329b9b0ddec984faa06d47e2f875933aaca417afff74ce6aa
+  languageName: node
+  linkType: hard
+
+"@csstools/postcss-ic-unit@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@csstools/postcss-ic-unit@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-ic-unit%2F-%2Fpostcss-ic-unit-1.0.1.tgz"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.3
-  checksum: d194b13a66027558d2d0dd3be3b795167b5e751bb3a3e62928c77ef1c524f0d672a7658852f07e589abbb64e827096eac00d9b6d7ec79e21006fd4f6f0b3ce87
+    postcss: ^8.2
+  checksum: 09c414c9b7762b5fbe837ff451d7a11e4890f1ed3c92edc3573f02f3d89747f6ac3f2270799b68a332bd7f5de05bb0dfffddb6323fc4020c2bea33ff58314533
   languageName: node
   linkType: hard
 
-"@csstools/postcss-is-pseudo-class@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "@csstools/postcss-is-pseudo-class@npm:2.0.6"
+"@csstools/postcss-is-pseudo-class@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@csstools/postcss-is-pseudo-class@npm:2.0.7::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-is-pseudo-class%2F-%2Fpostcss-is-pseudo-class-2.0.7.tgz"
   dependencies:
     "@csstools/selector-specificity": ^2.0.0
     postcss-selector-parser: ^6.0.10
   peerDependencies:
     postcss: ^8.2
-  checksum: 66206ca4fa40f0fdac2a7bf6650ca8edecbc7dc1053d338c57338e19e543dedb82a324feb38254531026130010b00b663d95c1f95873478c9680fb04fafdc8ff
+  checksum: a4494bb8e9a34826944ba6872c91c1e88268caab6d06968897f1a0cc75ca5cfc4989435961fc668a9c6842a6d17f4cda0055fa256d23e598b8bbc6f022956125
   languageName: node
   linkType: hard
 
-"@csstools/postcss-normalize-display-values@npm:^1.0.0":
+"@csstools/postcss-nested-calc@npm:^1.0.0":
   version: 1.0.0
-  resolution: "@csstools/postcss-normalize-display-values@npm:1.0.0"
+  resolution: "@csstools/postcss-nested-calc@npm:1.0.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-nested-calc%2F-%2Fpostcss-nested-calc-1.0.0.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.3
-  checksum: 5751a171f3ccd5d411bf1945e306b7a3191a82a52743b65c9f04ec4beffc0e087c32f024929fb51e46388bd197545699e279d87a53acfbc40dd5594e862b24af
+    postcss: ^8.2
+  checksum: 53bb783dd61621c11c1e6e352f079577e2eb908de67947ceef31a178e070c06c223baae87acd5c3bd51c664515d2adc16166a129159168626111aff548583790
   languageName: node
   linkType: hard
 
-"@csstools/postcss-oklab-function@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@csstools/postcss-oklab-function@npm:1.1.0"
+"@csstools/postcss-normalize-display-values@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@csstools/postcss-normalize-display-values@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-normalize-display-values%2F-%2Fpostcss-normalize-display-values-1.0.1.tgz"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2
+  checksum: 75901daec3869ba15e0adfd50d8e2e754ec06d55ac44fbd540748476388d223d53710fb3a3cbfe6695a2bab015a489fb47d9e3914ff211736923f8deb818dc0b
+  languageName: node
+  linkType: hard
+
+"@csstools/postcss-oklab-function@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@csstools/postcss-oklab-function@npm:1.1.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-oklab-function%2F-%2Fpostcss-oklab-function-1.1.1.tgz"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: d59616e6acc0466ce87626c50b519a26391ac643d135c0316a4bfca27396c922b67a57cbe6adda3864123f8b9c1b48a0427e499a357887f5c0f3a0aa00b1b71b
+    postcss: ^8.2
+  checksum: d66b789060b37ed810450d9a7d8319a0ae14e913c091f3e0ee482b3471538762e801d5eae3d62fda2f1eb1e88c76786d2c2b06c1172166eba1cca5e2a0dc95f2
   languageName: node
   linkType: hard
 
@@ -1888,40 +1899,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/postcss-stepped-value-functions@npm:^1.0.0":
+"@csstools/postcss-stepped-value-functions@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@csstools/postcss-stepped-value-functions@npm:1.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-stepped-value-functions%2F-%2Fpostcss-stepped-value-functions-1.0.1.tgz"
+  dependencies:
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.2
+  checksum: 2fc88713a0d49d142010652be8139b00719e407df1173e46047284f1befd0647e1fff67f259f9f55ac3b46bba6462b21f0aa192bd10a2989c51a8ce0d25fc495
+  languageName: node
+  linkType: hard
+
+"@csstools/postcss-text-decoration-shorthand@npm:^1.0.0":
   version: 1.0.0
-  resolution: "@csstools/postcss-stepped-value-functions@npm:1.0.0"
+  resolution: "@csstools/postcss-text-decoration-shorthand@npm:1.0.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-text-decoration-shorthand%2F-%2Fpostcss-text-decoration-shorthand-1.0.0.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.3
-  checksum: 48e9c20a84f58555c0c26889db76d3cef90413e6b4e47c6d2f3895afd713181405ce2afcf3230447ee139e56fe19d568c665de0c7a19d0c16dc834f439b71d72
+    postcss: ^8.2
+  checksum: d27aaf97872c42bec9f6fde4d8bf924e89f7886f0aca8e4fc5aaf2f9083b09bb43dbbfa29124fa36fcdeb2d4d3e0459a095acf62188260cd1577e9811bb1276e
   languageName: node
   linkType: hard
 
-"@csstools/postcss-trigonometric-functions@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-trigonometric-functions@npm:1.0.1"
+"@csstools/postcss-trigonometric-functions@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@csstools/postcss-trigonometric-functions@npm:1.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-trigonometric-functions%2F-%2Fpostcss-trigonometric-functions-1.0.2.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: 28de7e355016c7dde09cd292b75e4d48945997480c49bbe2ebcd4f88a960f424943bee0d5a54f832de4e1e99313eaac983c2bbbf885500919fef477351e52794
+    postcss: ^8.2
+  checksum: f7f5b5f2492606b79a56f09e814ae8f10a2ae9e9c5fb8019f0e347a4a6c07953b2cc663fd4fa43a60e6994dfd958958f39df8ec760e2a646cfe71fe2bb119382
   languageName: node
   linkType: hard
 
-"@csstools/postcss-unset-value@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-unset-value@npm:1.0.1"
+"@csstools/postcss-unset-value@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@csstools/postcss-unset-value@npm:1.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fpostcss-unset-value%2F-%2Fpostcss-unset-value-1.0.2.tgz"
   peerDependencies:
-    postcss: ^8.3
-  checksum: 4d355a88ec9fd3fa80a44ffa16d3b95cf3c8b5e369780a15d58ad51dbefabfd7e5be7def239cf98d20f5a1e634ab589620be5d6c9964a335ab33cef36f3ca197
+    postcss: ^8.2
+  checksum: 3facdae154d6516ffd964f7582696f406465f11cf8dead503e0afdfecc99ebc25638ab2830affce4516131aa2db004458a235e439f575b04e9ef72ad82f55835
   languageName: node
   linkType: hard
 
 "@csstools/selector-specificity@npm:^2.0.0, @csstools/selector-specificity@npm:^2.0.1":
   version: 2.0.2
   resolution: "@csstools/selector-specificity@npm:2.0.2"
+  peerDependencies:
+    postcss: ^8.2
+    postcss-selector-parser: ^6.0.10
+  checksum: a2045a27276a6cfe645b6e212afc217d9a43174ea7a1fa1ab8918d5a0ace72380fbd9837fe1920c547985c11a9070dc48c5c80d483d3f581ddf7aa688204d44f
+  languageName: node
+  linkType: hard
+
+"@csstools/selector-specificity@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@csstools/selector-specificity@npm:2.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40csstools%252fselector-specificity%2F-%2Fselector-specificity-2.0.2.tgz"
   peerDependencies:
     postcss: ^8.2
     postcss-selector-parser: ^6.0.10
@@ -4711,11 +4743,11 @@ __metadata:
     "@types/node": 16.11.48
     "@types/signale": 1.4.4
     lodash-es: 4.17.21
-    postcss: 8.4.14
+    postcss: 8.4.16
     postcss-import: 14.1.0
     postcss-loader: 7.0.1
     postcss-nested: 5.0.6
-    postcss-preset-env: 7.7.2
+    postcss-preset-env: 7.8.0
     tslib: 2.4.0
     webpack: 5.73.0
   peerDependencies:
@@ -4728,6 +4760,8 @@ __metadata:
     postcss:
       optional: true
     postcss-import:
+      optional: true
+    postcss-loader:
       optional: true
     postcss-nested:
       optional: true
@@ -4844,12 +4878,11 @@ __metadata:
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework"
     "@roots/bud-postcss": "workspace:sources/@roots/bud-postcss"
     "@skypack/package-check": 0.2.2
-    "@types/lodash": 4.14.182
     "@types/node": 16.11.48
-    postcss: 8.4.14
+    postcss: 8.4.16
     tslib: 2.4.0
   peerDependencies:
-    "@fullhuman/postcss-purgecss": ^4.1.3
+    "@fullhuman/postcss-purgecss": "*"
   peerDependenciesMeta:
     "@fullhuman/postcss-purgecss":
       optional: true
@@ -4904,7 +4937,7 @@ __metadata:
     "@roots/bud-postcss": "workspace:sources/@roots/bud-postcss"
     "@skypack/package-check": 0.2.2
     "@types/node": 16.11.48
-    postcss: 8.4.14
+    postcss: 8.4.16
     postcss-scss: ^4.0.4
     resolve-url-loader: 5.0.0
     sass: ^1.52.2
@@ -5058,16 +5091,14 @@ __metadata:
     "@skypack/package-check": 0.2.2
     "@types/node": 16.11.48
     "@types/tailwindcss": 3.0.11
-    autoprefixer: ^10.4.0
-    tailwindcss: ^3.0.24
+    autoprefixer: ^10.4.8
+    tailwindcss: ^3.1.8
     tslib: 2.4.0
   peerDependencies:
     autoprefixer: "*"
     tailwindcss: "*"
   peerDependenciesMeta:
     autoprefixer:
-      optional: true
-    postcss:
       optional: true
     tailwindcss:
       optional: true
@@ -8451,9 +8482,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-node@npm:^1.6.1":
+"acorn-node@npm:^1.8.2":
   version: 1.8.2
-  resolution: "acorn-node@npm:1.8.2"
+  resolution: "acorn-node@npm:1.8.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Facorn-node%2F-%2Facorn-node-1.8.2.tgz"
   dependencies:
     acorn: ^7.0.0
     acorn-walk: ^7.0.0
@@ -8983,10 +9014,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arg@npm:^5.0.0, arg@npm:^5.0.1":
+"arg@npm:^5.0.0":
   version: 5.0.1
   resolution: "arg@npm:5.0.1"
   checksum: 9aefbcb1204f8dbd541a045bfe99b6515b4dc697c2f704ef2bb5e9fe5464575d97571e91e673a6f23ad72dd1cc24d7d8cf2d1d828e72c08e4d4f6f9237adc761
+  languageName: node
+  linkType: hard
+
+"arg@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "arg@npm:5.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Farg%2F-%2Farg-5.0.2.tgz"
+  checksum: 6c69ada1a9943d332d9e5382393e897c500908d91d5cb735a01120d5f71daf1b339b7b8980cbeaba8fd1afc68e658a739746179e4315a26e8a28951ff9930078
   languageName: node
   linkType: hard
 
@@ -9330,7 +9368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"autoprefixer@npm:^10.3.7, autoprefixer@npm:^10.4.0, autoprefixer@npm:^10.4.7":
+"autoprefixer@npm:^10.3.7, autoprefixer@npm:^10.4.7":
   version: 10.4.7
   resolution: "autoprefixer@npm:10.4.7"
   dependencies:
@@ -9345,6 +9383,24 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: 0e55d0d19806c672ec0c79cc23c27cf77e90edf2600670735266ba33ec5294458f404baaa2f7cd4cfe359cf7a97b3c86f01886bdbdc129a4f2f76ca5977a91af
+  languageName: node
+  linkType: hard
+
+"autoprefixer@npm:^10.4.8":
+  version: 10.4.8
+  resolution: "autoprefixer@npm:10.4.8::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fautoprefixer%2F-%2Fautoprefixer-10.4.8.tgz"
+  dependencies:
+    browserslist: ^4.21.3
+    caniuse-lite: ^1.0.30001373
+    fraction.js: ^4.2.0
+    normalize-range: ^0.1.2
+    picocolors: ^1.0.0
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.1.0
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: 06cb4c497bb948714d5b1b4f7e7465fd88c50f90788fc2020b3d97d7661fb4dd0d9918c1b09dd3e909acd4485cbb27ad99085487d8ed5d75915e646d2b535770
   languageName: node
   linkType: hard
 
@@ -9923,6 +9979,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.21.3":
+  version: 4.21.3
+  resolution: "browserslist@npm:4.21.3::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fbrowserslist%2F-%2Fbrowserslist-4.21.3.tgz"
+  dependencies:
+    caniuse-lite: ^1.0.30001370
+    electron-to-chromium: ^1.4.202
+    node-releases: ^2.0.6
+    update-browserslist-db: ^1.0.5
+  bin:
+    browserslist: cli.js
+  checksum: ff512a7bcca1c530e2854bbdfc7be2791d0fb524097a6340e56e1d5924164c7e4e0a9b070de04cdc4c149d15cb4d4275cb7c626ebbce954278a2823aaad2452a
+  languageName: node
+  linkType: hard
+
 "bser@npm:2.1.1":
   version: 2.1.1
   resolution: "bser@npm:2.1.1"
@@ -10264,6 +10334,13 @@ __metadata:
   version: 1.0.30001366
   resolution: "caniuse-lite@npm:1.0.30001366"
   checksum: eeb878e0be4090a4247dd3de5392ff1a864d086e5401790c7c81697918ce6ce3dac75956a21f9404b5ac770bfdabdb18619d0f920dc2295f3211ee893355f697
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001373":
+  version: 1.0.30001378
+  resolution: "caniuse-lite@npm:1.0.30001378::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fcaniuse-lite%2F-%2Fcaniuse-lite-1.0.30001378.tgz"
+  checksum: 19f1774da1f62d393ddde55dc091eb3e4f5c5b0ce43f9a9d20e75307a0f329cf8591c836a35a9f6f9fd7c27db7a75e0682245a194acec2e2ba1bc25ef1c3300c
   languageName: node
   linkType: hard
 
@@ -11908,10 +11985,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssdb@npm:^6.6.3":
-  version: 6.6.3
-  resolution: "cssdb@npm:6.6.3"
-  checksum: 0d5bd77bbffae8d5236f7e7af5fb22d54ac0f88f6ffcde736e2759a9db34042cc28491a8b7499d0c7887c2848a4597544620847e2baf5fc108b766f1f30cb1b0
+"cssdb@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cssdb@npm:7.0.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fcssdb%2F-%2Fcssdb-7.0.0.tgz"
+  checksum: ae7e91fc812647ae542b1a7c737a8c517e6ea8b7811e165a503061a3cd999b4577852e84ed54d7010517923576a7fc5f0bceddb9eae40b160fa268dd3dc29fe7
   languageName: node
   linkType: hard
 
@@ -12723,16 +12800,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detective@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "detective@npm:5.2.0"
+"detective@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "detective@npm:5.2.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fdetective%2F-%2Fdetective-5.2.1.tgz"
   dependencies:
-    acorn-node: ^1.6.1
+    acorn-node: ^1.8.2
     defined: ^1.0.0
-    minimist: ^1.1.1
+    minimist: ^1.2.6
   bin:
     detective: bin/detective.js
-  checksum: 2ab266aecbd695b42e4703cfa560178ceac4308a74baece58185775426e65573d563d84f33e6a3b28ef3a544aa0c039c0730ada939c6458862e6643f66044f32
+  checksum: dc4601bbc6be850edb3c2dab7a0eaf5a6169a15ad201679c66d40ea1986df816eeaecd590047f15b0780285f3eeea13b82dca0d4c52a47e744a571e326a72dc9
   languageName: node
   linkType: hard
 
@@ -13202,6 +13279,13 @@ __metadata:
   version: 1.4.191
   resolution: "electron-to-chromium@npm:1.4.191"
   checksum: d7bd39517da1fc6c392e87f18df0ce8697814105a663fbc8df51a346f230920ef31adb465cc355fea0ee9c6c9fba6da653ee04f99d515f7280a50f3d394801e4
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.202":
+  version: 1.4.222
+  resolution: "electron-to-chromium@npm:1.4.222::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Felectron-to-chromium%2F-%2Felectron-to-chromium-1.4.222.tgz"
+  checksum: acae758e1cfb647cfaa7ac662200e3d2c15a66c50da999cac2c08e98908e61c276c4ef336e0f9d0f42d75b68f08cdc4efe6cb7b8031cfe5aed47645ebd07632c
   languageName: node
   linkType: hard
 
@@ -19408,6 +19492,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "lilconfig@npm:2.0.6::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Flilconfig%2F-%2Flilconfig-2.0.6.tgz"
+  checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
+  languageName: node
+  linkType: hard
+
 "line-column-path@npm:^3.0.0":
   version: 3.0.0
   resolution: "line-column-path@npm:3.0.0"
@@ -21157,7 +21248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.0, minimist@npm:^1.1.1, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+"minimist@npm:^1.1.0, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb
@@ -23490,14 +23581,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-attribute-case-insensitive@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "postcss-attribute-case-insensitive@npm:5.0.1"
+"postcss-attribute-case-insensitive@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "postcss-attribute-case-insensitive@npm:5.0.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-attribute-case-insensitive%2F-%2Fpostcss-attribute-case-insensitive-5.0.2.tgz"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
-    postcss: ^8.3
-  checksum: 9abfe72b7c36863da742b9287203d04b0ae9fee09679180588b24e4a086ee1c2da135baf78e4f9762c984b4f250f286999e2b0c76d77ee616665c5776bd15c64
+    postcss: ^8.2
+  checksum: c0b8139f37e68dba372724cba03a53c30716224f0085f98485cada99489beb7c3da9d598ffc1d81519b59d9899291712c9041c250205e6ec0b034bb2c144dcf9
   languageName: node
   linkType: hard
 
@@ -23524,14 +23615,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-color-functional-notation@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "postcss-color-functional-notation@npm:4.2.3"
+"postcss-color-functional-notation@npm:^4.2.4":
+  version: 4.2.4
+  resolution: "postcss-color-functional-notation@npm:4.2.4::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-color-functional-notation%2F-%2Fpostcss-color-functional-notation-4.2.4.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: 1be72dd64b99a33dd8827aec0373067568721cc06d1e059d72d9680280d06546fe67bc30ed508c89c7878a9bf8ac455ec8f12af9335dcfee45a4be872476abf1
+    postcss: ^8.2
+  checksum: b763e164fe3577a1de96f75e4bf451585c4f80b8ce60799763a51582cc9402d76faed57324a5d5e5556d90ca7ea0ebde565acb820c95e04bee6f36a91b019831
   languageName: node
   linkType: hard
 
@@ -23546,14 +23637,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-color-rebeccapurple@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "postcss-color-rebeccapurple@npm:7.1.0"
+"postcss-color-rebeccapurple@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "postcss-color-rebeccapurple@npm:7.1.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-color-rebeccapurple%2F-%2Fpostcss-color-rebeccapurple-7.1.1.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.3
-  checksum: 48a3bb51d49ffeff964cfd049ba594c08ee045bad6d9d8eb49bc6c31be17526c3b968af3794965d0bfb3b8d4a0994db590aa8ff3d9c138859a7e6baff8d98478
+    postcss: ^8.2
+  checksum: 03482f9b8170da0fa014c41a5d88bce7b987471fb73fc456d397222a2455c89ac7f974dd6ddf40fd31907e768aad158057164b7c5f62cee63a6ecf29d47d7467
   languageName: node
   linkType: hard
 
@@ -23616,14 +23707,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-dir-pseudo-class@npm:^6.0.4":
-  version: 6.0.4
-  resolution: "postcss-dir-pseudo-class@npm:6.0.4"
+"postcss-dir-pseudo-class@npm:^6.0.5":
+  version: 6.0.5
+  resolution: "postcss-dir-pseudo-class@npm:6.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-dir-pseudo-class%2F-%2Fpostcss-dir-pseudo-class-6.0.5.tgz"
   dependencies:
-    postcss-selector-parser: ^6.0.9
+    postcss-selector-parser: ^6.0.10
   peerDependencies:
-    postcss: ^8.4
-  checksum: e493e6ed54c50b8b1bda1a0cde55fc2dec04d22983e5af178090ff592854a29866c1c255637cb047b2b40c18e6ef15c1aa45aa354735f79a7709e9add5ea2e3e
+    postcss: ^8.2
+  checksum: 7810c439d8d1a9072c00f8ab39261a1492873ad170425745bd2819c59767db2f352f906588fc2a7d814e91117900563d7e569ecd640367c7332b26b9829927ef
   languageName: node
   linkType: hard
 
@@ -23686,15 +23777,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-double-position-gradients@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "postcss-double-position-gradients@npm:3.1.1"
+"postcss-double-position-gradients@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "postcss-double-position-gradients@npm:3.1.2::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-double-position-gradients%2F-%2Fpostcss-double-position-gradients-3.1.2.tgz"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: c59131b2d03022fbb69336766786e8cc33f6e78c8040e17d2ba499fce789c675c5dcdc4fd3abe1e76e0ecd3dc910ad8c56d49a307c0115047d21a59544afc527
+    postcss: ^8.2
+  checksum: ca09bf2aefddc180f1c1413f379eef30d492b8147543413f7251216f23f413c394b2ed10b7cd255e87b18e0c8efe36087ea8b9bfb26a09813f9607a0b8e538b6
   languageName: node
   linkType: hard
 
@@ -23740,12 +23831,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-gap-properties@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "postcss-gap-properties@npm:3.0.3"
+"postcss-gap-properties@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "postcss-gap-properties@npm:3.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-gap-properties%2F-%2Fpostcss-gap-properties-3.0.5.tgz"
   peerDependencies:
-    postcss: ^8.4
-  checksum: 8b7bb4292093fa66fa874143b69297d25ab83e5b8aef643f0a39cff900d9754cae55f0fb267f9230dbccbf31d538f2e885c59274daabe57a7b56716292dd89d5
+    postcss: ^8.2
+  checksum: aed559d6d375203a08a006c9ae8cf5ae90d9edaec5cadd20fe65c1b8ce63c2bc8dfe752d4331880a6e24a300541cde61058be790b7bd9b5d04d470c250fbcd39
   languageName: node
   linkType: hard
 
@@ -23764,20 +23855,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-image-set-function@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "postcss-image-set-function@npm:4.0.6"
+"postcss-image-set-function@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "postcss-image-set-function@npm:4.0.7::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-image-set-function%2F-%2Fpostcss-image-set-function-4.0.7.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: bdcd11d5ef9e5beb8ce14888125e8b526b7e01902dcb78b47ea4418297f64cf188343194670a5beb8ee5831cc902a591a8887e3512403a6b932cff921be85de3
+    postcss: ^8.2
+  checksum: 7e509330986de14250ead1a557e8da8baaf66ebe8a40354a5dff60ab40d99a483d92aa57d52713251ca1adbf0055ef476c5702b0d0ba5f85a4f407367cdabac0
   languageName: node
   linkType: hard
 
 "postcss-import@npm:14.1.0":
   version: 14.1.0
   resolution: "postcss-import@npm:14.1.0"
+  dependencies:
+    postcss-value-parser: ^4.0.0
+    read-cache: ^1.0.0
+    resolve: ^1.1.7
+  peerDependencies:
+    postcss: ^8.0.0
+  checksum: cd45d406e90f67cdab9524352e573cc6b4462b790934a05954e929a6653ebd31288ceebc8ce3c3ed7117ae672d9ebbec57df0bceec0a56e9b259c2e71d47ca86
+  languageName: node
+  linkType: hard
+
+"postcss-import@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "postcss-import@npm:14.1.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-import%2F-%2Fpostcss-import-14.1.0.tgz"
   dependencies:
     postcss-value-parser: ^4.0.0
     read-cache: ^1.0.0
@@ -23808,15 +23912,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-lab-function@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "postcss-lab-function@npm:4.2.0"
+"postcss-lab-function@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "postcss-lab-function@npm:4.2.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-lab-function%2F-%2Fpostcss-lab-function-4.2.1.tgz"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: 89ca828b8ed16feb201be7b050254560786c76392ce0a4262732438521ce13d083d1e542addf9d14da75249c58802d721df3152316bb591c9f627c7038166c2a
+    postcss: ^8.2
+  checksum: 26ac74b430011271b5581beba69b2cd788f56375fcb64c90f6ec1577379af85f6022dc38c410ff471dac520c7ddc289160a6a16cca3c7ff76f5af7e90d31eaa3
   languageName: node
   linkType: hard
 
@@ -24018,9 +24122,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-nesting@npm:^10.1.9":
+"postcss-nesting@npm:^10.1.10":
   version: 10.1.10
-  resolution: "postcss-nesting@npm:10.1.10"
+  resolution: "postcss-nesting@npm:10.1.10::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-nesting%2F-%2Fpostcss-nesting-10.1.10.tgz"
   dependencies:
     "@csstools/selector-specificity": ^2.0.0
     postcss-selector-parser: ^6.0.10
@@ -24148,12 +24252,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-overflow-shorthand@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "postcss-overflow-shorthand@npm:3.0.3"
+"postcss-overflow-shorthand@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "postcss-overflow-shorthand@npm:3.0.4::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-overflow-shorthand%2F-%2Fpostcss-overflow-shorthand-3.0.4.tgz"
+  dependencies:
+    postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: 52080efd1cefbc01a0f931f247c69470a565684cd8e3585c3f5bfa45e849abe12cd4997b031179ea66fc1339eaf72dc9e3d87a218822fd6b958ce71632da23cb
+    postcss: ^8.2
+  checksum: 74009022491e3901263f8f5811630393480323e51f5d23ef17f3fdc7e03bf9c2502a632f3ba8fe6a468b57590f13b2fa3b17a68ef19653589e76277607696743
   languageName: node
   linkType: hard
 
@@ -24166,82 +24272,84 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-place@npm:^7.0.4":
-  version: 7.0.4
-  resolution: "postcss-place@npm:7.0.4"
+"postcss-place@npm:^7.0.5":
+  version: 7.0.5
+  resolution: "postcss-place@npm:7.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-place%2F-%2Fpostcss-place-7.0.5.tgz"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4
-  checksum: dd1738ec9bf324889e4c51f390b4e2774c3b7a040ff277ce88c6e2f139374cf2a5d921d78b156347d57ee618e9029c1907790a50290f48918afb67c5e53bc36e
+    postcss: ^8.2
+  checksum: 903fec0c313bb7ec20f2c8f0a125866fb7804aa3186b5b2c7c2d58cb9039ff301461677a060e9db643d1aaffaf80a0ff71e900a6da16705dad6b49c804cb3c73
   languageName: node
   linkType: hard
 
-"postcss-preset-env@npm:7.7.2":
-  version: 7.7.2
-  resolution: "postcss-preset-env@npm:7.7.2"
+"postcss-preset-env@npm:7.8.0":
+  version: 7.8.0
+  resolution: "postcss-preset-env@npm:7.8.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-preset-env%2F-%2Fpostcss-preset-env-7.8.0.tgz"
   dependencies:
-    "@csstools/postcss-cascade-layers": ^1.0.4
-    "@csstools/postcss-color-function": ^1.1.0
-    "@csstools/postcss-font-format-keywords": ^1.0.0
-    "@csstools/postcss-hwb-function": ^1.0.1
-    "@csstools/postcss-ic-unit": ^1.0.0
-    "@csstools/postcss-is-pseudo-class": ^2.0.6
-    "@csstools/postcss-normalize-display-values": ^1.0.0
-    "@csstools/postcss-oklab-function": ^1.1.0
+    "@csstools/postcss-cascade-layers": ^1.0.5
+    "@csstools/postcss-color-function": ^1.1.1
+    "@csstools/postcss-font-format-keywords": ^1.0.1
+    "@csstools/postcss-hwb-function": ^1.0.2
+    "@csstools/postcss-ic-unit": ^1.0.1
+    "@csstools/postcss-is-pseudo-class": ^2.0.7
+    "@csstools/postcss-nested-calc": ^1.0.0
+    "@csstools/postcss-normalize-display-values": ^1.0.1
+    "@csstools/postcss-oklab-function": ^1.1.1
     "@csstools/postcss-progressive-custom-properties": ^1.3.0
-    "@csstools/postcss-stepped-value-functions": ^1.0.0
-    "@csstools/postcss-trigonometric-functions": ^1.0.1
-    "@csstools/postcss-unset-value": ^1.0.1
-    autoprefixer: ^10.4.7
-    browserslist: ^4.21.0
+    "@csstools/postcss-stepped-value-functions": ^1.0.1
+    "@csstools/postcss-text-decoration-shorthand": ^1.0.0
+    "@csstools/postcss-trigonometric-functions": ^1.0.2
+    "@csstools/postcss-unset-value": ^1.0.2
+    autoprefixer: ^10.4.8
+    browserslist: ^4.21.3
     css-blank-pseudo: ^3.0.3
     css-has-pseudo: ^3.0.4
     css-prefers-color-scheme: ^6.0.3
-    cssdb: ^6.6.3
-    postcss-attribute-case-insensitive: ^5.0.1
+    cssdb: ^7.0.0
+    postcss-attribute-case-insensitive: ^5.0.2
     postcss-clamp: ^4.1.0
-    postcss-color-functional-notation: ^4.2.3
+    postcss-color-functional-notation: ^4.2.4
     postcss-color-hex-alpha: ^8.0.4
-    postcss-color-rebeccapurple: ^7.1.0
+    postcss-color-rebeccapurple: ^7.1.1
     postcss-custom-media: ^8.0.2
     postcss-custom-properties: ^12.1.8
     postcss-custom-selectors: ^6.0.3
-    postcss-dir-pseudo-class: ^6.0.4
-    postcss-double-position-gradients: ^3.1.1
+    postcss-dir-pseudo-class: ^6.0.5
+    postcss-double-position-gradients: ^3.1.2
     postcss-env-function: ^4.0.6
     postcss-focus-visible: ^6.0.4
     postcss-focus-within: ^5.0.4
     postcss-font-variant: ^5.0.0
-    postcss-gap-properties: ^3.0.3
-    postcss-image-set-function: ^4.0.6
+    postcss-gap-properties: ^3.0.5
+    postcss-image-set-function: ^4.0.7
     postcss-initial: ^4.0.1
-    postcss-lab-function: ^4.2.0
+    postcss-lab-function: ^4.2.1
     postcss-logical: ^5.0.4
     postcss-media-minmax: ^5.0.0
-    postcss-nesting: ^10.1.9
+    postcss-nesting: ^10.1.10
     postcss-opacity-percentage: ^1.1.2
-    postcss-overflow-shorthand: ^3.0.3
+    postcss-overflow-shorthand: ^3.0.4
     postcss-page-break: ^3.0.4
-    postcss-place: ^7.0.4
-    postcss-pseudo-class-any-link: ^7.1.5
+    postcss-place: ^7.0.5
+    postcss-pseudo-class-any-link: ^7.1.6
     postcss-replace-overflow-wrap: ^4.0.0
-    postcss-selector-not: ^6.0.0
+    postcss-selector-not: ^6.0.1
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.2
-  checksum: 15648b4f4efe45e3e8e9d7b7d6c714bf118e529c7728a615d211605fe7be6a5d46d41954676a2b23ea56696bd728dfc189d0a0f867a37404cd7ff820c00d32f5
+  checksum: 7c07f6ecc776dc8063bfffbb8e44b88730cde0c8951c9960263c38bdb0c5103ace41f34b01eac0ff4861b00384e44ff450f7861f34072a50850afb862af4d6a8
   languageName: node
   linkType: hard
 
-"postcss-pseudo-class-any-link@npm:^7.1.5":
-  version: 7.1.5
-  resolution: "postcss-pseudo-class-any-link@npm:7.1.5"
+"postcss-pseudo-class-any-link@npm:^7.1.6":
+  version: 7.1.6
+  resolution: "postcss-pseudo-class-any-link@npm:7.1.6::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-pseudo-class-any-link%2F-%2Fpostcss-pseudo-class-any-link-7.1.6.tgz"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
     postcss: ^8.2
-  checksum: b2aaa1e75d5343c4f6e8765d8a5cc6d9c740cfa9680d559478cafb799492479818c5b232b34396bf5bce8a3d66f19ce848bd049aa9a00bb8b8091dd84e6df729
+  checksum: 43aa18ea1ef1b168f61310856dd92f46ceb3dc60b6cf820e079ca1a849df5cc0f12a1511bdc1811a23f03d60ddcc959200c80c3f9a7b57feebe32bab226afb39
   languageName: node
   linkType: hard
 
@@ -24313,14 +24421,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-selector-not@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "postcss-selector-not@npm:6.0.0"
+"postcss-selector-not@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "postcss-selector-not@npm:6.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss-selector-not%2F-%2Fpostcss-selector-not-6.0.1.tgz"
   dependencies:
     postcss-selector-parser: ^6.0.10
   peerDependencies:
-    postcss: ^8.3
-  checksum: d7aac5810acd58a3b0268dfc27ce346ffa7324f0ca49b22ef4303d828bb15dff90fbbd439ccba25587504c30f6a1b778a9bb67645fd432bf9daa0fe9d109010e
+    postcss: ^8.2
+  checksum: fe523a0219e4bd34f04498534bb9e8aec3193f3585eafe4c388d086955b41201cae71fd20980ca465acade7f182029b43dbd5ca7e9d50bf34bbcaf1d19fe3ee6
   languageName: node
   linkType: hard
 
@@ -24411,7 +24519,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.14, postcss@npm:^8.1.10, postcss@npm:^8.2.14, postcss@npm:^8.3.0, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.4.12, postcss@npm:^8.4.13, postcss@npm:^8.4.14, postcss@npm:^8.4.7":
+"postcss@npm:8.4.16":
+  version: 8.4.16
+  resolution: "postcss@npm:8.4.16::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fpostcss%2F-%2Fpostcss-8.4.16.tgz"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.1.10, postcss@npm:^8.2.14, postcss@npm:^8.3.0, postcss@npm:^8.3.11, postcss@npm:^8.3.5, postcss@npm:^8.4.12, postcss@npm:^8.4.13, postcss@npm:^8.4.14, postcss@npm:^8.4.7":
   version: 8.4.14
   resolution: "postcss@npm:8.4.14"
   dependencies:
@@ -26170,6 +26289,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.22.1":
+  version: 1.22.1
+  resolution: "resolve@npm:1.22.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fresolve%2F-%2Fresolve-1.22.1.tgz"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 07af5fc1e81aa1d866cbc9e9460fbb67318a10fa3c4deadc35c3ad8a898ee9a71a86a65e4755ac3195e0ea0cfbe201eb323ebe655ce90526fd61917313a34e4e
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^2.0.0-next.1, resolve@npm:^2.0.0-next.3":
   version: 2.0.0-next.4
   resolution: "resolve@npm:2.0.0-next.4"
@@ -26203,6 +26335,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: c79ecaea36c872ee4a79e3db0d3d4160b593f2ca16e031d8283735acd01715a203607e9ded3f91f68899c2937fa0d49390cddbe0fb2852629212f3cda283f4a7
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
+  version: 1.22.1
+  resolution: "resolve@patch:resolve@npm%3A1.22.1%3A%3A__archiveUrl=http%253A%252F%252Flocalhost%253A4873%252Fresolve%252F-%252Fresolve-1.22.1.tgz#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
   languageName: node
   linkType: hard
 
@@ -28257,37 +28402,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.0.24":
-  version: 3.0.24
-  resolution: "tailwindcss@npm:3.0.24"
+"tailwindcss@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "tailwindcss@npm:3.1.8::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Ftailwindcss%2F-%2Ftailwindcss-3.1.8.tgz"
   dependencies:
-    arg: ^5.0.1
+    arg: ^5.0.2
     chokidar: ^3.5.3
     color-name: ^1.1.4
-    detective: ^5.2.0
+    detective: ^5.2.1
     didyoumean: ^1.2.2
     dlv: ^1.1.3
     fast-glob: ^3.2.11
     glob-parent: ^6.0.2
     is-glob: ^4.0.3
-    lilconfig: ^2.0.5
+    lilconfig: ^2.0.6
     normalize-path: ^3.0.0
     object-hash: ^3.0.0
     picocolors: ^1.0.0
-    postcss: ^8.4.12
+    postcss: ^8.4.14
+    postcss-import: ^14.1.0
     postcss-js: ^4.0.0
     postcss-load-config: ^3.1.4
     postcss-nested: 5.0.6
     postcss-selector-parser: ^6.0.10
     postcss-value-parser: ^4.2.0
     quick-lru: ^5.1.1
-    resolve: ^1.22.0
+    resolve: ^1.22.1
   peerDependencies:
     postcss: ^8.0.9
   bin:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
-  checksum: 52a21192b70ab90678d6cec24ca6f93b3a396599e2d842f6077b670be14e577b1e3fbae8776e64505d383118746287353ed99d2a047258254f4ce3879b996b58
+  checksum: 86480301fc6ae1e392c2aba8264ab425bd919078176b010fda724518a7c265e950da5f4120c69c9041509c318207985fa9d680b6f5021e23f8214135a61a54b6
   languageName: node
   linkType: hard
 
@@ -29668,6 +29814,20 @@ __metadata:
   bin:
     browserslist-lint: cli.js
   checksum: 7c7da28d0fc733b17e01c8fa9385ab909eadce64b8ea644e9603867dc368c2e2a6611af8247e72612b23f9e7cb87ac7c7585a05ff94e1759e9d646cbe9bf49a7
+  languageName: node
+  linkType: hard
+
+"update-browserslist-db@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "update-browserslist-db@npm:1.0.5::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fupdate-browserslist-db%2F-%2Fupdate-browserslist-db-1.0.5.tgz"
+  dependencies:
+    escalade: ^3.1.1
+    picocolors: ^1.0.0
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    browserslist-lint: cli.js
+  checksum: 7e425fe5dbbebdccf72a84ce70ec47fc74dce561d28f47bc2b84a1c2b84179a862c2261b18ab66a5e73e261c7e2ef9e11c6129112989d4d52e8f75a56bb923f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Solves two problems:
- pre-boot pkg discovery should not attempt to import `@types` packages
- postcss version mismatch causes postcss-preset-env and postcss-loader resolution issues.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
