### PR TITLE
📝 PurgeCSS docs: Replace `require` with `import` in example config

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-purgecss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-purgecss.mdx
@@ -19,8 +19,10 @@ By default, bud does not purge any styles on its own. [PurgeCSS](https://purgecs
 ## Configuration
 
 ```ts title="bud.config.js"
+import purgeCssWordPress from `purgecss-with-wordpress`
+
 app.purgecss({
-  content: [app.path('resources/views/**')],
-  safelist: [...require('purgecss-with-wordpress').safelist],
+  content: [app.path(`resources/views/**`)],
+  safelist: [...purgeCssWordPress.safelist],
 })
 ```


### PR DESCRIPTION
Ref https://discourse.roots.io/t/upgrading-bud-from-5-5-0-to-5-8-7-shows-error-uncaught-referenceerror-require-is-not-defined/23370/6