### PR TITLE
fix(none): invalid registry

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -16,9 +16,9 @@ npmAuthToken: "${NPM_AUTH_TOKEN:-fallback}"
 
 npmPublishAccess: public
 
-npmPublishRegistry: "http://0.0.0.0:4873"
+npmPublishRegistry: "https://registry.npmjs.org"
 
-npmRegistryServer: "http://0.0.0.0:4873"
+npmRegistryServer: "https://registry.npmjs.org"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
@@ -35,10 +35,6 @@ pnpDataPath: .yarn/pnp.data.json
 pnpUnpluggedFolder: .yarn/unplugged
 
 progressBarStyle: default
-
-unsafeHttpWhitelist:
-  - 0.0.0.0
-  - localhost
 
 virtualFolder: .yarn/__virtual__
 


### PR DESCRIPTION
fix: npm registry set to localhost on main

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
