### PR TITLE
🩹 fix(none): set source-map to true for sass loader

### DIFF
--- a/sources/@roots/bud-sass/src/extension.ts
+++ b/sources/@roots/bud-sass/src/extension.ts
@@ -35,7 +35,7 @@ export default class BudSass extends Extension {
   @bind
   public async register() {
     const implementation = await this.import(`sass`)
-    this.setOptions({implementation})
+    this.setOptions({implementation, sourceMap: true})
   }
 
   /**
@@ -57,11 +57,6 @@ export default class BudSass extends Extension {
         include: [app => app.path(`@src`)],
         use: [`precss`, `css`, `postcss`, `resolveUrl`, `sass`],
       })
-
-    this.app.build.items.resolveUrl.setOptions((_app, options) => ({
-      ...options,
-      sourceMap: true,
-    }))
 
     this.app.hooks.on(`build.resolve.extensions`, ext =>
       ext.add(`.scss`).add(`.sass`),

--- a/sources/@roots/bud-sass/src/resolve-url/extension.ts
+++ b/sources/@roots/bud-sass/src/resolve-url/extension.ts
@@ -16,7 +16,7 @@ export default class BudResolveUrl extends Extension {
       loader: `resolveUrl`,
       options: ({path, hooks}) => ({
         root: path(`@src`),
-        sourceMap: hooks.filter(`build.devtool`) ? true : false,
+        sourceMap: true,
       }),
     })
   }


### PR DESCRIPTION
fixes `sourceMap` option for `@roots/bud-sass`.

refers:

- #1682 

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
