### PR TITLE
WIP: @roots/bud-preact

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -47,6 +47,7 @@
     {"path": "./../sources/@roots/bud-imagemin/tsconfig.json"},
     {"path": "./../sources/@roots/bud-mdx/tsconfig.json"},
     {"path": "./../sources/@roots/bud-postcss/tsconfig.json"},
+    {"path": "./../sources/@roots/bud-preact/tsconfig.json"},
     {"path": "./../sources/@roots/bud-preset-recommend/tsconfig.json"},
     {"path": "./../sources/@roots/bud-preset-wordpress/tsconfig.json"},
     {"path": "./../sources/@roots/bud-prettier/tsconfig.json"},

--- a/sources/@roots/bud-preact/LICENSE.md
+++ b/sources/@roots/bud-preact/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright © Roots Software Foundation LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sources/@roots/bud-preact/README.md
+++ b/sources/@roots/bud-preact/README.md
@@ -1,0 +1,120 @@
+<p align="center"><img src="https://cdn.roots.io/app/uploads/logo-bud.svg" height="100" alt="bud.js" /></p>
+
+<p align="center">
+  <img alt="MIT License" src="https://img.shields.io/github/license/roots/bud?color=%23525ddc&style=flat-square" />
+  <img alt="npm" src="https://img.shields.io/npm/v/@roots/bud.svg?color=%23525ddc&style=flat-square" />
+  <img alt="Follow Roots" src="https://img.shields.io/twitter/follow/rootswp.svg?color=%23525ddc&style=flat-square" />
+</p>
+
+<h1 align="center"><strong>@roots/bud-react</strong></h1>
+
+<p align="center">
+  React support for @roots/bud projects.
+</p>
+
+---
+
+## Installation
+
+Install **@roots/bud-react** to your project.
+
+Yarn:
+
+```sh
+yarn add @roots/bud-react --dev
+```
+
+npm:
+
+```sh
+npm install @roots/bud-react --save-dev
+```
+
+## Usage
+
+### React Refresh
+
+This extension enables [react-refresh](https://www.npmjs.com/package/react-refresh) in development. It uses [@pmmmwh/react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin).
+
+For usage guidance, consult [the react-refresh-webpack-plugin API documentation](https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/API.md).
+
+### Configuring react-refresh
+
+To enable react-refresh:
+
+```ts
+bud.react.refresh.enable();
+```
+
+To disable react-refresh:
+
+```ts
+bud.react.refresh.disable();
+```
+
+Any [@pmmmwh/react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin) options can can be passed to `bud.react.refresh.configure`:
+
+```ts
+bud.react.refresh.configure({ forceEnable: true });
+```
+
+### Compatibility
+
+#### Babel
+
+react-refresh is automatically enabled when using [@roots/bud-babel](https://bud.js.org/extensions/bud-babel). This is the integration that is supported out-of-the-box.
+
+#### TypeScript
+
+react-refresh is automatically enabled when using [@roots/bud-typescript](https://bud.js.org/extensions/bud-typescript).
+
+If you are using `babel` then react-refresh will be handled using the standard babel plugin.
+If you are not then the `react-refresh-typescript` tsc plugin will be used instead.
+
+#### SWC
+
+react-refresh is automatically enabled when using [@roots/bud-swc](https://bud.js.org/extensions/bud-swc).
+
+If you are using a custom `.swcrc` file you will need to supply your own configuration.
+
+#### ESBuild
+
+There isn't currently any support for esbuild mentioned in the documentation.
+
+## Contributing
+
+Contributions are welcome from everyone.
+
+We have [contribution guidelines](https://github.com/roots/guidelines/blob/master/CONTRIBUTING.md) to help you get started.
+
+## License
+
+@roots/bud-react is licensed under MIT.
+
+## Community
+
+Keep track of development and community news.
+
+- Join us on Roots Slack by becoming a [GitHub
+  sponsor](https://github.com/sponsors/roots)
+- Participate on the [Roots Discourse](https://discourse.roots.io/)
+- Follow [@rootswp on Twitter](https://twitter.com/rootswp)
+- Read and subscribe to the [Roots Blog](https://roots.io/blog/)
+- Subscribe to the [Roots Newsletter](https://roots.io/subscribe/)
+
+## Sponsors
+
+Help support our open-source development efforts by [becoming a patron](https://www.patreon.com/rootsdev).
+
+<a href="https://k-m.com/">
+<img src="https://cdn.roots.io/app/uploads/km-digital.svg" alt="KM Digital" width="200" height="150"/>
+</a>
+<a href="https://carrot.com/">
+<img src="https://cdn.roots.io/app/uploads/carrot.svg" alt="Carrot" width="200" height="150"/>
+</a>
+<a href="https://wordpress.com/">
+<img src="https://cdn.roots.io/app/uploads/wordpress.svg" alt="WordPress.com" width="200" height="150"/>
+</a>
+<a href="https://pantheon.io/">
+<img src="https://cdn.roots.io/app/uploads/pantheon.svg" alt="Pantheon" width="200" height="150"/>
+</a>

--- a/sources/@roots/bud-preact/package.json
+++ b/sources/@roots/bud-preact/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@roots/bud-preact",
+  "version": "0.0.0",
+  "description": "Preact support for @roots/bud projects.",
+  "homepage": "https://roots.io/bud",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/roots/bud",
+    "directory": "sources/@roots/bud-preact"
+  },
+  "contributors": [
+    {
+      "name": "kellymears",
+      "url": "https://github.com/kellymears"
+    },
+    {
+      "name": "QWp6t",
+      "url": "https://github.com/QWp6t"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/roots/bud/issues"
+  },
+  "funding": {
+    "type": "github sponsors",
+    "url": "https://github.com/sponsors/roots"
+  },
+  "keywords": [
+    "bud",
+    "bud-extension",
+    "preact"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "bud": {
+    "type": "extension"
+  },
+  "files": [
+    "lib/"
+  ],
+  "type": "module",
+  "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./lib/index.d.ts"
+      ]
+    }
+  },
+  "devDependencies": {
+    "@babel/core": "7.19.1",
+    "@jest/globals": "29.0.3",
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc",
+    "@roots/bud-typescript": "workspace:sources/@roots/bud-typescript",
+    "@skypack/package-check": "0.2.2",
+    "@types/babel__core": "7.1.19",
+    "@types/node": "16.11.48",
+    "type-fest": "2.19.0",
+    "webpack": "5.74.0"
+  },
+  "dependencies": {
+    "@babel/plugin-transform-react-jsx": "7.19.0",
+    "@roots/bud-babel": "workspace:sources/@roots/bud-babel",
+    "@roots/bud-framework": "workspace:sources/@roots/bud-framework",
+    "@roots/bud-support": "workspace:sources/@roots/bud-support",
+    "preact": "10.11.0",
+    "tslib": "2.4.0"
+  },
+  "peerDependencies": {
+    "@babel/plugin-transform-react-jsx": "*",
+    "preact": "*"
+  },
+  "peerDependenciesMeta": {
+    "@babel/plugin-transform-react-jsx": {
+      "optional": true
+    },
+    "preact": {
+      "optional": true
+    }
+  },
+  "volta": {
+    "extends": "../../../package.json"
+  }
+}

--- a/sources/@roots/bud-preact/src/extension.ts
+++ b/sources/@roots/bud-preact/src/extension.ts
@@ -1,0 +1,53 @@
+import {Extension} from '@roots/bud-framework/extension'
+import {
+  bind,
+  dependsOn,
+  label,
+} from '@roots/bud-framework/extension/decorators'
+
+/**
+ * Preact support extension
+ *
+ * @remarks
+ * If `@roots/bud-esbuild` or `@roots/bud-swc` is registered, the babel preset registration is skipped
+ *
+ * @public
+ * @decorator `@label`
+ * @decorator `@dependsOn`
+ * @decorator `@dependsOnOptional`
+ * @decorator `@options`
+ * @decorator `@expose`
+ */
+@label(`@roots/bud-preact`)
+@dependsOn([`@roots/bud-babel`])
+export default class BudPreact extends Extension {
+  /**
+   * `configAfter` callback
+   *
+   * @remarks
+   * Adds the `@babel/plugin-transform-react-jsx` preset to babel if:
+   * - `@roots/bud-esbuild` is not registered
+   * - `@roots/bud-swc` is not registered
+   * - `@roots/bud-babel` is available.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public async configAfter() {
+    const preset = await this.resolve(`@babel/plugin-transform-react-jsx`)
+
+    this.app.babel.setPlugin(`@babel/plugin-transform-react-jsx`, [
+      preset,
+      {pragma: `h`, pragmaFrag: `Fragment`},
+    ])
+
+    this.app.hooks.async(`build.resolve.modules`, async modules => ({
+      ...modules,
+      react: `preact/compat`,
+      'react-dom/test-utils': `preact/test-utils`,
+      'react-dom': `preact/compat`,
+      'react/jsx-runtime': `preact/jsx-runtime`,
+    }))
+  }
+}

--- a/sources/@roots/bud-preact/src/index.ts
+++ b/sources/@roots/bud-preact/src/index.ts
@@ -1,0 +1,25 @@
+// Copyright © Roots Software Foundation LLC
+// Licensed under the MIT license.
+
+/**
+ * Adds support for preact to bud projects.
+ *
+ * @see https://bud.js.org
+ * @see https://github.com/roots/bud
+ *
+ * @packageDocumentation
+ */
+
+import BudPreact from './extension.js'
+
+declare module '@roots/bud-framework' {
+  interface Bud {
+    react: BudPreact
+  }
+
+  interface Modules {
+    '@roots/bud-preact': BudPreact
+  }
+}
+
+export default BudPreact

--- a/sources/@roots/bud-preact/tsconfig.json
+++ b/sources/@roots/bud-preact/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../config/tsconfig.json",
+  "compilerOptions": {
+
+    "rootDir": "src",
+    "outDir": "lib",
+    "module": "esnext",
+    "types": ["node", "@roots/bud-framework", "@roots/bud-babel", "@roots/bud-api"]
+  },
+  "include": ["src"],
+  "exclude": ["lib", "node_modules"],
+  "references": [
+    {"path": "./../bud-babel/tsconfig.json"},
+    {"path": "./../bud-framework/tsconfig.json"},
+    {"path": "./../bud-support/tsconfig.json"},
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,6 +1342,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx@npm:7.19.0":
+  version: 7.19.0
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.19.0"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-module-imports": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/plugin-syntax-jsx": ^7.18.6
+    "@babel/types": ^7.19.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d7d6f0b8f24b1f6b7cf8062c4e91c59af82489a993e51859bd49c2d62a2d2b77fd40b02a9a1d0e6d874cf4ce56a05fa3564b964587d00c94ebc62593524052ec
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-transform-react-jsx@npm:7.18.6"
@@ -4781,6 +4796,36 @@ __metadata:
     postcss-nested:
       optional: true
     postcss-preset-env:
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"@roots/bud-preact@workspace:sources/@roots/bud-preact":
+  version: 0.0.0-use.local
+  resolution: "@roots/bud-preact@workspace:sources/@roots/bud-preact"
+  dependencies:
+    "@babel/core": 7.19.1
+    "@babel/plugin-transform-react-jsx": 7.19.0
+    "@jest/globals": 29.0.3
+    "@roots/bud-babel": "workspace:sources/@roots/bud-babel"
+    "@roots/bud-framework": "workspace:sources/@roots/bud-framework"
+    "@roots/bud-support": "workspace:sources/@roots/bud-support"
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc"
+    "@roots/bud-typescript": "workspace:sources/@roots/bud-typescript"
+    "@skypack/package-check": 0.2.2
+    "@types/babel__core": 7.1.19
+    "@types/node": 16.11.48
+    preact: 10.11.0
+    tslib: 2.4.0
+    type-fest: 2.19.0
+    webpack: 5.74.0
+  peerDependencies:
+    "@babel/plugin-transform-react-jsx": "*"
+    preact: "*"
+  peerDependenciesMeta:
+    "@babel/plugin-transform-react-jsx":
+      optional: true
+    preact:
       optional: true
   languageName: unknown
   linkType: soft
@@ -24600,6 +24645,13 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
+  languageName: node
+  linkType: hard
+
+"preact@npm:10.11.0":
+  version: 10.11.0
+  resolution: "preact@npm:10.11.0"
+  checksum: 1e3f8e6fe88f26a2896826f69121b70eb69c63a46bfc1160da8672b37618fcfd294128979ed27e37499604df90c1505c30545f75683f23d8f7e6ac0693d2ff14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Package supporting use of preact.

Right now this only handles preact with `@roots/bud-babel`.

Todo:

- implement for @roots/bud-typescript
- implement for @roots/bud-swc
- implement for @roots/bud-esbuild

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- preact
- @babel/plugin-transform-react-jsx

### Removes

- none
