### PR TITLE
🩹 fix(patch): #1702

### DIFF
--- a/sources/@roots/bud-postcss/src/extension.ts
+++ b/sources/@roots/bud-postcss/src/extension.ts
@@ -3,7 +3,6 @@ import {
   bind,
   expose,
   label,
-  once,
 } from '@roots/bud-framework/extension/decorators'
 import {isFunction, isUndefined} from '@roots/bud-support/lodash-es'
 import type {Plugin, Processor} from 'postcss'
@@ -323,10 +322,8 @@ export default class BudPostCss extends Extension {
    *
    * @public
    * @decorator `@bind`
-   * @decorator `@once`
    */
   @bind
-  @once
   public async register() {
     this.setPlugins({
       import: await this.resolve(`postcss-import`),


### PR DESCRIPTION
the `@once` decorator really means business. it's not per instance, it's static.

this means that only the first postcss extension would be registered in a multi-instance setup.

refers:

- #1702 

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
