### PR TITLE
✨ feature(patch): filter tailwind values by `extend`

### DIFF
--- a/sources/@roots/bud-tailwindcss/src/__snapshots__/extension.unit.test.ts.snap
+++ b/sources/@roots/bud-tailwindcss/src/__snapshots__/extension.unit.test.ts.snap
@@ -5,6 +5,12 @@ exports[`@roots/bud-tailwindcss extension should produce a static module 1`] = `
 "
 `;
 
+exports[`@roots/bud-tailwindcss extension should resolve tailwind config values (filter extends) 1`] = `
+{
+  "primary": "red",
+}
+`;
+
 exports[`@roots/bud-tailwindcss extension should resolve tailwind config values 1`] = `
 {
   "amber": {
@@ -513,3 +519,7 @@ exports[`@roots/bud-tailwindcss extension should set importables when generateIm
   "zIndex",
 ]
 `;
+
+exports[`@roots/bud-tailwindcss extension should throw when key does not exist 1`] = `"@roots/bud-tailwindcss: foo is not a valid tailwind theme key."`;
+
+exports[`@roots/bud-tailwindcss extension should throw when key does not exist in extended config (filter extends) 1`] = `"The key "lineHeight" is not extended in your tailwind config."`;

--- a/sources/@roots/sage/docs/05-managing-theme.json.mdx
+++ b/sources/@roots/sage/docs/05-managing-theme.json.mdx
@@ -37,9 +37,9 @@ bud.wptheme
 If you use [@roots/bud-tailwindcss](https://bud.js.org/extensions/bud-tailwindcss) in your project there are several
 opt-in config functions that allow you to generate `theme.json` values directly from your tailwind config.
 
-#### wpjson.useTailwindColors
+#### wpjson.useTailwindColors()
 
-Convert `theme.extends.colors` to a `theme.json` palette.
+Convert `theme.colors` to a `theme.json` palette.
 
 ```ts title="bud.config.mjs"
 bud.wpjson.useTailwindColors().enable()
@@ -47,7 +47,7 @@ bud.wpjson.useTailwindColors().enable()
 
 #### wpjson.useTailwindFontSize()
 
-Emits values from `theme.extends.fontSize` as the `typography.fontSizes` property of `theme.json`.
+Emits values from `theme.fontSize` as the `typography.fontSizes` property of `theme.json`.
 
 ```ts title="bud.config.mjs"
 bud.wpjson.useTailwindFontSize().enable()
@@ -55,10 +55,18 @@ bud.wpjson.useTailwindFontSize().enable()
 
 #### wpjson.useTailwindFontFamily()
 
-Emits values from `theme.extends.fontFamily` as the `typography.fontFamilies` property of `theme.json`.
+Emits values from `theme.fontFamily` as the `typography.fontFamilies` property of `theme.json`.
 
 ```ts title="bud.config.mjs"
 bud.wpjson.useTailwindFontFamily().enable()
+```
+
+#### Limiting values to those defined in `theme.extend`
+
+You can pass `true` to any of the the above functions to limit the values emitted to those defined under tailwind's `theme.extend` key.
+
+```ts title="bud.config.mjs"
+bud.wpjson.useTailwindColors(true).enable()
 ```
 
 ### In combination

--- a/sources/@roots/sage/src/wp-theme-json/extension.ts
+++ b/sources/@roots/sage/src/wp-theme-json/extension.ts
@@ -111,7 +111,7 @@ export default class ThemeJson extends Extension<
   }
 
   @bind
-  public useTailwindColors(): this {
+  public useTailwindColors(extendOnly?: boolean): this {
     if (!this.app.extensions.has(`@roots/bud-tailwindcss`))
       throw new Error(
         `@roots/bud-tailwindcss is required in order to call \`useTailwindColors\``,
@@ -122,7 +122,7 @@ export default class ThemeJson extends Extension<
       color: {
         ...(this.options.settings?.color ?? {}),
         palette: tailwindAdapter.palette.transform(
-          this.app.tailwind.theme.colors,
+          this.app.tailwind.resolveThemeValue(`colors`, extendOnly),
         ),
       },
     })
@@ -131,13 +131,13 @@ export default class ThemeJson extends Extension<
   }
 
   @bind
-  public useTailwindFontFamily(): this {
+  public useTailwindFontFamily(extendOnly?: boolean): this {
     this.setOption(`settings`, {
       ...(this.options.settings ?? {}),
       typography: {
         ...(this.options.settings?.typography ?? {}),
         fontFamilies: tailwindAdapter.fontFamily.transform(
-          this.app.tailwind.theme.fontFamily,
+          this.app.tailwind.resolveThemeValue(`fontFamily`, extendOnly),
         ),
       },
     })
@@ -146,13 +146,13 @@ export default class ThemeJson extends Extension<
   }
 
   @bind
-  public useTailwindFontSize(): this {
+  public useTailwindFontSize(extendOnly?: boolean): this {
     this.setOption(`settings`, {
       ...(this.options.settings ?? {}),
       typography: {
         ...(this.options.settings?.typography ?? {}),
         fontSizes: tailwindAdapter.fontSize.transform(
-          this.app.tailwind.theme.fontSize,
+          this.app.tailwind.resolveThemeValue(`fontSize`, extendOnly),
         ),
       },
     })


### PR DESCRIPTION
- `useTailwindFontFamily`, `useTailwindColors`, `useTailwindFontSize` all take an optional `boolean` parameter to limit generated values to the values found in the `extend` key of `tailwind.config.js`.
- `bud.tailwind.resolveTailwindThemeValue` renamed to `bud.tailwind.resolveThemeValue`
- `bud.tailwind.resolveThemeValue` now takes an optional `boolean` parameter to limit returned values to those found in the `extend` key of `tailwind.config.js`.
- adds unit tests to cover new functionality

refers:

- #1714

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
