### PR TITLE
🩹 fix(patch): tailwindcss theme mutations

### DIFF
--- a/examples/sage/bud.config.mjs
+++ b/examples/sage/bud.config.mjs
@@ -8,7 +8,8 @@ export default async app => {
     .watch(['resources/views/*.blade.php'])
     .serve(3000)
     .proxy('http://example.test')
-    .wpjson.useTailwindColors()
+    .wpjson.useTailwindColors(true)
     .useTailwindFontFamily()
+    .useTailwindFontSize()
     .enable()
 }

--- a/examples/sage/resources/scripts/components/main.js
+++ b/examples/sage/resources/scripts/components/main.js
@@ -8,4 +8,7 @@ export const main = () => {
    */
   document.body.classList.contains('no-js') &&
     document.body.classList.remove('no-js')
+
+  document.body.classList.add(`text-xl`)
+  document.body.classList.add(`text-custom`)
 }

--- a/examples/sage/resources/styles/common/global.css
+++ b/examples/sage/resources/styles/common/global.css
@@ -1,9 +1,9 @@
 body {
-  @apply font-sans;
+  @apply font-sans text-custom;
 }
 
 #root {
-  @apply text-3xl font-medium text-indigo-500;
+  @apply font-medium text-indigo-500 text-xl;
 
   background: url('~@images/image.jpeg');
 }

--- a/examples/sage/tailwind.config.js
+++ b/examples/sage/tailwind.config.js
@@ -1,12 +1,19 @@
 module.exports = {
-  content: ['resources/**/*.{js,html}'],
+  content: ['resources/**/*.{js,css,html}'],
   theme: {
     extend: {
-      colors: ({theme}) => ({
+      colors: {
         gray: '#f7fafc',
-      }),
+        brand: {
+          gray: '#f7fafc',
+        },
+      },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
+      },
+      fontSize: {
+        xl: '1.25rem',
+        custom: '.625rem',
       },
     },
   },

--- a/sources/@roots/sage/src/wp-theme-json/extension.ts
+++ b/sources/@roots/sage/src/wp-theme-json/extension.ts
@@ -48,6 +48,7 @@ export interface Mutator {
  * @decorator `@options`
  * @decorator `@when`
  * @decorator `@plugin`
+ * @decorator `@expose`
  */
 @label(`@roots/sage/wp-theme-json`)
 @dependsOnOptional([`@roots/bud-tailwindcss`])
@@ -137,7 +138,15 @@ export default class ThemeJson extends Extension<
       typography: {
         ...(this.options.settings?.typography ?? {}),
         fontFamilies: tailwindAdapter.fontFamily.transform(
-          this.app.tailwind.resolveThemeValue(`fontFamily`, extendOnly),
+          Object.assign(
+            {},
+            {
+              ...this.app.tailwind.resolveThemeValue(
+                `fontFamily`,
+                extendOnly,
+              ),
+            },
+          ),
         ),
       },
     })
@@ -152,7 +161,15 @@ export default class ThemeJson extends Extension<
       typography: {
         ...(this.options.settings?.typography ?? {}),
         fontSizes: tailwindAdapter.fontSize.transform(
-          this.app.tailwind.resolveThemeValue(`fontSize`, extendOnly),
+          Object.assign(
+            {},
+            {
+              ...this.app.tailwind.resolveThemeValue(
+                `fontSize`,
+                extendOnly,
+              ),
+            },
+          ),
         ),
       },
     })

--- a/sources/@roots/sage/src/wp-theme-json/plugin.ts
+++ b/sources/@roots/sage/src/wp-theme-json/plugin.ts
@@ -11,12 +11,17 @@ import type {Compiler, WebpackPluginInstance} from 'webpack'
  */
 export interface Options {
   /**
-   * JSON contents
+   * WordPress `settings`
    *
    * @public
    */
   settings?: Partial<ThemeJSON.GlobalSettingsAndStyles['settings']>
 
+  /**
+   * WordPress `customTemplates`
+   *
+   * @public
+   */
   customTemplates?: ThemeJSON.GlobalSettingsAndStyles['customTemplates']
 
   /**

--- a/sources/@roots/sage/src/wp-theme-json/tailwind/fontFamily.test.ts
+++ b/sources/@roots/sage/src/wp-theme-json/tailwind/fontFamily.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {fontFamily} from './index'
+
+const mockFontFamily: fontFamily.TailwindFontFamily = {
+  sans: [`mOCK-SANS`, `SANS-MOCK`],
+  serif: `mock-serif`,
+}
+
+describe(`themeJson tailwind adapter`, () => {
+  it(`transforms fontFamily`, () => {
+    const mockfontFamilyRef = {...mockFontFamily}
+
+    expect(fontFamily.transform(mockFontFamily)).toStrictEqual([
+      {
+        name: `MOCK-SANS`,
+        slug: `sans`,
+        fontFamily: `mOCK-SANS,SANS-MOCK`,
+      },
+      {
+        name: `Mock-serif`,
+        slug: `serif`,
+        fontFamily: `mock-serif`,
+      },
+    ])
+
+    expect(mockFontFamily).toStrictEqual(mockfontFamilyRef)
+  })
+})

--- a/sources/@roots/sage/src/wp-theme-json/tailwind/fontFamily.ts
+++ b/sources/@roots/sage/src/wp-theme-json/tailwind/fontFamily.ts
@@ -1,7 +1,7 @@
 import type {GlobalSettingsAndStyles as WPThemeJson} from '@roots/bud-preset-wordpress/theme'
 
-export interface TailwindFonts {
-  [key: string]: Array<string>
+export interface TailwindFontFamily {
+  [key: string]: Array<string> | string
 }
 export type WordPressFonts =
   WPThemeJson['settings']['typography']['fontFamilies']
@@ -30,10 +30,11 @@ const name: name = label =>
 export interface transformEntry {
   ([slug, value]: [string, string]): WordPressFonts[any]
 }
-export const transformEntry: transformEntry = ([slug, fontFamily]: [
-  string,
-  string,
-]) => ({name: fontFamily.split(`,`).shift(), slug, fontFamily})
+export const transformEntry: transformEntry = ([slug, fontFamily]) => ({
+  name: name(fontFamily.split(`,`).shift()),
+  slug,
+  fontFamily,
+})
 
 /**
  * Transform tailwindcss fonts to wordpress theme.json fonts
@@ -43,9 +44,9 @@ export const transformEntry: transformEntry = ([slug, fontFamily]: [
  * @public
  */
 export interface transform {
-  (fonts: TailwindFonts): WordPressFonts
+  (fonts: TailwindFontFamily): WordPressFonts
 }
-export const transform: transform = (fonts: TailwindFonts) =>
-  Object.entries(fonts ?? {})
+export const transform: transform = fonts =>
+  Object.entries(fonts)
     .map(([k, v]) => [k, Array.isArray(v) ? v.join(`,`) : v])
     .map(transformEntry)

--- a/sources/@roots/sage/src/wp-theme-json/tailwind/fontSize.test.ts
+++ b/sources/@roots/sage/src/wp-theme-json/tailwind/fontSize.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {fontSize} from './index'
+
+const mockFontSize: fontSize.TailwindSize = {
+  lg: `1.25rem`,
+  xl: [`1.5rem`, `2rem`],
+}
+
+describe(`themeJson tailwind adapter`, () => {
+  it(`transforms fontSize`, () => {
+    const mockfontSizeRef = {...mockFontSize}
+
+    expect(fontSize.transform(mockFontSize)).toStrictEqual([
+      {
+        name: `lg`,
+        slug: `lg`,
+        size: `1.25rem`,
+      },
+      {
+        name: `xl`,
+        slug: `xl`,
+        size: `1.5rem`,
+      },
+    ])
+
+    expect(mockFontSize).toStrictEqual(mockfontSizeRef)
+  })
+})

--- a/sources/@roots/sage/src/wp-theme-json/tailwind/fontSize.ts
+++ b/sources/@roots/sage/src/wp-theme-json/tailwind/fontSize.ts
@@ -26,10 +26,11 @@ export type WordPressSizes =
 export interface transformEntry {
   ([slug, value]: [string, string]): WordPressSizes[any]
 }
-export const transformEntry: transformEntry = ([slug, fontSize]: [
-  string,
-  string,
-]) => ({name: slug, slug, size: fontSize})
+export const transformEntry: transformEntry = ([slug, fontSize]) => ({
+  name: slug,
+  slug,
+  size: fontSize,
+})
 
 /**
  * Transform tailwindcss fonts to wordpress theme.json fonts
@@ -41,10 +42,7 @@ export const transformEntry: transformEntry = ([slug, fontSize]: [
 export interface transform {
   (fonts: TailwindSize): WordPressSizes
 }
-
-export const transform: transform = (
-  fonts: TailwindSize,
-): WordPressSizes =>
-  Object.entries(fonts ?? {})
-    .map(([k, v]) => [k, Array.isArray(v) ? v.shift() : v])
+export const transform: transform = fonts =>
+  Object.entries(fonts)
+    .map(([k, v]) => [k, Array.isArray(v) ? v[0] : v])
     .map(transformEntry)

--- a/sources/@roots/sage/src/wp-theme-json/tailwind/palette.test.ts
+++ b/sources/@roots/sage/src/wp-theme-json/tailwind/palette.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {palette} from './index'
+
+const mockPalette: palette.TailwindColors = {
+  blue: {
+    shade: {
+      hue: {
+        '50': `#add8e6`,
+      },
+    },
+    group: {
+      sky: `#87ceeb`,
+    },
+  },
+  tomato: `#ff4500`,
+}
+
+describe(`themeJson tailwind adapter`, () => {
+  it(`transformsPalette`, () => {
+    const mockPaletteRef = {...mockPalette}
+
+    expect(palette.transform(mockPalette)).toStrictEqual([
+      {
+        name: `Blue Shade Hue 50`,
+        slug: `blue-shade-hue-50`,
+        color: `#add8e6`,
+      },
+      {
+        name: `Blue Group Sky`,
+        slug: `blue-group-sky`,
+        color: `#87ceeb`,
+      },
+      {
+        name: `Tomato`,
+        slug: `tomato`,
+        color: `#ff4500`,
+      },
+    ])
+
+    expect(mockPalette).toEqual(mockPaletteRef)
+  })
+})

--- a/sources/@roots/sage/src/wp-theme-json/tailwind/palette.ts
+++ b/sources/@roots/sage/src/wp-theme-json/tailwind/palette.ts
@@ -50,10 +50,7 @@ export interface toWordPressEntries {
     Array<string>,
   ]): WordPressColors
 }
-export const toWordPressEntries: toWordPressEntries = ([entry, path]: [
-  [string, string | TailwindColors],
-  Array<string>,
-]): WordPressColors => {
+export const toWordPressEntries: toWordPressEntries = ([entry, path]) => {
   const [name, value] = entry
 
   if (!isString(value)) {
@@ -77,7 +74,7 @@ export const toWordPressEntries: toWordPressEntries = ([entry, path]: [
 export interface transform {
   (palette: TailwindColors): WordPressColors
 }
-export const transform: transform = (palette: TailwindColors) =>
-  Object.entries(palette ?? {})
+export const transform: transform = palette =>
+  Object.entries(palette)
     .map(i => [i, []])
     .flatMap(toWordPressEntries)

--- a/sources/@roots/sage/tsconfig.json
+++ b/sources/@roots/sage/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": false,
   },
   "include": ["./src"],
-  "exclude": ["./lib", "./node_modules"],
+  "exclude": ["./lib", "./node_modules", "./**/*.test.ts"],
   "references": [
     {"path": "./../bud-framework/tsconfig.json"},
     {"path": "./../bud-api/tsconfig.json"},

--- a/tests/integration/sage.test.ts
+++ b/tests/integration/sage.test.ts
@@ -1,116 +1,272 @@
-import {beforeAll, describe, it} from '@jest/globals'
-import {Project} from '@repo/test-kit/project'
+import { beforeAll, describe, it } from "@jest/globals";
+import { Project } from "@repo/test-kit/project";
 
-const test = (pacman: 'yarn' | 'npm') => () => {
-  let project: Project
+const test = (pacman: "yarn" | "npm") => () => {
+  let project: Project;
 
   beforeAll(async () => {
     project = await new Project({
       label: `@examples/sage`,
       dist: `public`,
       with: pacman,
-    }).setup()
-  })
+    }).setup();
+  });
 
   describe(`entrypoints.json`, () => {
     it(`has expected app entries`, () => {
-      expect(project.entrypoints.app.css).toBeInstanceOf(Array)
-      expect(project.entrypoints.app.css).toHaveLength(1)
-      expect(project.entrypoints.app.dependencies).toEqual([])
-    })
+      expect(project.entrypoints.app.css).toBeInstanceOf(Array);
+      expect(project.entrypoints.app.css).toHaveLength(1);
+      expect(project.entrypoints.app.dependencies).toEqual([]);
+    });
 
     it(`has expected editor entries`, () => {
-      expect(project.entrypoints.editor.css).toBeInstanceOf(Array)
-      expect(project.entrypoints.editor.css).toHaveLength(1)
-    })
-  })
+      expect(project.entrypoints.editor.css).toBeInstanceOf(Array);
+      expect(project.entrypoints.editor.css).toHaveLength(1);
+    });
+  });
 
   describe(`runtime`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`runtime.js`].length).toBeGreaterThan(10)
-    })
+      expect(project.assets[`runtime.js`].length).toBeGreaterThan(10);
+    });
 
     it(`is transpiled`, () => {
-      expect(project.assets[`runtime.js`].includes(`import `)).toBeFalsy()
-    })
-  })
+      expect(project.assets[`runtime.js`].includes(`import `)).toBeFalsy();
+    });
+  });
 
   describe(`app.js`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`app.js`].length).toBeGreaterThan(10)
-    })
+      expect(project.assets[`app.js`].length).toBeGreaterThan(10);
+    });
 
     it(`is transpiled`, () => {
-      expect(project.assets[`app.js`].includes(`import `)).toBeFalsy()
-    })
-  })
+      expect(project.assets[`app.js`].includes(`import `)).toBeFalsy();
+    });
+  });
 
   describe(`app.css`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`app.css`].length).toBeGreaterThan(10)
-    })
+      expect(project.assets[`app.css`].length).toBeGreaterThan(10);
+    });
 
     it(`is transpiled`, () => {
-      expect(project.assets[`app.css`].includes(`@import`)).toBe(false)
-    })
+      expect(project.assets[`app.css`].includes(`@import`)).toBe(false);
+    });
 
     it(`@tailwind directive is transpiled`, () => {
-      expect(project.assets[`app.css`].includes(`@apply`)).toBe(false)
-    })
+      expect(project.assets[`app.css`].includes(`@apply`)).toBe(false);
+    });
 
     it(`has whitespace removed`, () => {
-      expect(project.assets[`app.css`].match(/    /)).toBeFalsy()
-    })
+      expect(project.assets[`app.css`].match(/    /)).toBeFalsy();
+    });
 
     it(`has breaks removed`, () => {
-      expect(project.assets[`app.css`].match(/\\n/)).toBeFalsy()
-    })
-  })
+      expect(project.assets[`app.css`].match(/\\n/)).toBeFalsy();
+    });
+
+    it(`has xl font-size`, () => {
+      expect(
+        project.assets[`app.css`].includes(`.text-xl{font-size:1.25rem`)
+      ).toBeTruthy();
+    });
+
+    it(`has custom font-size`, () => {
+      expect(
+        project.assets[`app.css`].includes(`.text-custom{font-size:.625rem`)
+      ).toBeTruthy();
+    });
+  });
+
+  if (pacman === `yarn`) {
+    describe(`theme.json`, () => {
+      it(`matches snapshot`, async () => {
+        const themeJson = await project.readJson(
+          project.projectPath(`theme.json`)
+        );
+        expect(themeJson).toMatchInlineSnapshot(`
+          {
+            "$schema": "https://schemas.wp.org/trunk/theme.json",
+            "__generated__": "⚠️ This file is generated. Do not edit.",
+            "settings": {
+              "color": {
+                "custom": false,
+                "customGradient": false,
+                "palette": [
+                  {
+                    "color": "#f7fafc",
+                    "name": "Gray",
+                    "slug": "gray",
+                  },
+                  {
+                    "color": "#f7fafc",
+                    "name": "Brand Gray",
+                    "slug": "brand-gray",
+                  },
+                ],
+              },
+              "custom": {
+                "spacing": {},
+                "typography": {
+                  "font-size": {},
+                  "line-height": {},
+                },
+              },
+              "spacing": {
+                "padding": true,
+                "units": [
+                  "px",
+                  "%",
+                  "em",
+                  "rem",
+                  "vw",
+                  "vh",
+                ],
+              },
+              "typography": {
+                "customFontSize": false,
+                "dropCap": false,
+                "fontFamilies": [
+                  {
+                    "fontFamily": "Inter,sans-serif",
+                    "name": "Inter",
+                    "slug": "sans",
+                  },
+                  {
+                    "fontFamily": "ui-serif,Georgia,Cambria,"Times New Roman",Times,serif",
+                    "name": "Ui-serif",
+                    "slug": "serif",
+                  },
+                  {
+                    "fontFamily": "ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace",
+                    "name": "Ui-monospace",
+                    "slug": "mono",
+                  },
+                ],
+                "fontSizes": [
+                  {
+                    "name": "xs",
+                    "size": "0.75rem",
+                    "slug": "xs",
+                  },
+                  {
+                    "name": "sm",
+                    "size": "0.875rem",
+                    "slug": "sm",
+                  },
+                  {
+                    "name": "base",
+                    "size": "1rem",
+                    "slug": "base",
+                  },
+                  {
+                    "name": "lg",
+                    "size": "1.125rem",
+                    "slug": "lg",
+                  },
+                  {
+                    "name": "xl",
+                    "size": "1.25rem",
+                    "slug": "xl",
+                  },
+                  {
+                    "name": "2xl",
+                    "size": "1.5rem",
+                    "slug": "2xl",
+                  },
+                  {
+                    "name": "3xl",
+                    "size": "1.875rem",
+                    "slug": "3xl",
+                  },
+                  {
+                    "name": "4xl",
+                    "size": "2.25rem",
+                    "slug": "4xl",
+                  },
+                  {
+                    "name": "5xl",
+                    "size": "3rem",
+                    "slug": "5xl",
+                  },
+                  {
+                    "name": "6xl",
+                    "size": "3.75rem",
+                    "slug": "6xl",
+                  },
+                  {
+                    "name": "7xl",
+                    "size": "4.5rem",
+                    "slug": "7xl",
+                  },
+                  {
+                    "name": "8xl",
+                    "size": "6rem",
+                    "slug": "8xl",
+                  },
+                  {
+                    "name": "9xl",
+                    "size": "8rem",
+                    "slug": "9xl",
+                  },
+                  {
+                    "name": "custom",
+                    "size": ".625rem",
+                    "slug": "custom",
+                  },
+                ],
+              },
+            },
+            "version": 2,
+          }
+        `);
+      });
+    });
+  }
 
   describe(`editor.js`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`editor.js`].length).toBeGreaterThan(10)
-    })
+      expect(project.assets[`editor.js`].length).toBeGreaterThan(10);
+    });
 
     it(`is transpiled`, () => {
-      expect(project.assets[`editor.js`].includes(`import `)).toBeFalsy()
-    })
-  })
+      expect(project.assets[`editor.js`].includes(`import `)).toBeFalsy();
+    });
+  });
 
   it(`[editor] css: has contents`, () => {
-    expect(project.assets[`editor.css`].length).toBeGreaterThan(10)
-  })
+    expect(project.assets[`editor.css`].length).toBeGreaterThan(10);
+  });
 
   it(`[editor] css: is transpiled`, () => {
-    expect(project.assets[`editor.css`].includes(`@import`)).toBe(false)
-  })
+    expect(project.assets[`editor.css`].includes(`@import`)).toBe(false);
+  });
 
   it(`[editor] css: @tailwind directive is transpiled`, () => {
-    expect(project.assets[`editor.css`].includes(`@apply`)).toBe(false)
-  })
+    expect(project.assets[`editor.css`].includes(`@apply`)).toBe(false);
+  });
 
   it(`[editor] css: has whitespace removed`, () => {
-    expect(project.assets[`editor.css`].match(/    /)).toBeFalsy()
-  })
+    expect(project.assets[`editor.css`].match(/    /)).toBeFalsy();
+  });
 
   it(`[editor] css: has breaks removed`, () => {
-    expect(project.assets[`editor.css`].match(/\\n/)).toBeFalsy()
-  })
+    expect(project.assets[`editor.css`].match(/\\n/)).toBeFalsy();
+  });
 
   it(`[snapshots] package.json is unchanged`, async () => {
-    expect(project.packageJson).toMatchSnapshot()
-  })
+    expect(project.packageJson).toMatchSnapshot();
+  });
 
   it(`[snapshots] public/manifest.json matches expectations`, async () => {
-    expect(project.manifest[`app.js`]).toMatch(/js\/app\.[\d|\w]*\.js/)
-    expect(project.manifest[`app.css`]).toMatch(/css\/app\.[\d|\w]*\.css/)
+    expect(project.manifest[`app.js`]).toMatch(/js\/app\.[\d|\w]*\.js/);
+    expect(project.manifest[`app.css`]).toMatch(/css\/app\.[\d|\w]*\.css/);
     expect(project.manifest[`editor.css`]).toMatch(
-      /css\/editor\.[\d|\w]*\.css/,
-    )
-    expect(project.manifest[`runtime.js`]).toMatch(
-      /js\/runtime\.[\d|\w]*\.js/,
-    )
-  })
+      /css\/editor\.[\d|\w]*\.css/
+    );
+    expect(project.manifest[`runtime.js`]).toMatch(/js\/runtime\.[\d|\w]*\.js/);
+  });
 
   it(`[snapshots] module named chunks matches snapshot`, async () => {
     expect(project.modules.chunks.byName).toEqual(
@@ -118,12 +274,12 @@ const test = (pacman: 'yarn' | 'npm') => () => {
         app: expect.any(Number),
         editor: expect.any(Number),
         runtime: expect.any(Number),
-      }),
-    )
-  })
-}
+      })
+    );
+  });
+};
 
 describe(`sage`, () => {
-  describe(`npm`, test(`npm`))
-  describe(`yarn`, test(`yarn`))
-})
+  describe(`npm`, test(`npm`));
+  describe(`yarn`, test(`yarn`));
+});

--- a/tests/util/project/bud.config.cjs
+++ b/tests/util/project/bud.config.cjs
@@ -3,8 +3,9 @@ module.exports = async app => {
     .setPath(`@src`, `src`)
     .entry({app: [`scripts/app`, `styles/app`]})
     .copy([[`images`, `images`]])
-    .template({replace: {APP_TITLE: `Bud`}})
+    .template({replace: {APP_TITLE: `Bud`}, template: `src/index.html`})
     .devtool(false)
     .watch([`index.html`, `images`])
     .serve(3015)
+    .minimize()
 }

--- a/tests/util/project/src/index.html
+++ b/tests/util/project/src/index.html
@@ -12,7 +12,7 @@
 <body>
   <noscript>You need to enable JavaScript to run this app</noscript>
   <div id="root">foobar</div>
-  <div class="test">%replaceTest%</div>
+  <div class="text-xl">%replaceTest%</div>
 </body>
 
 </html>

--- a/tests/util/project/src/styles/app.css
+++ b/tests/util/project/src/styles/app.css
@@ -1,1 +1,4 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
 @import './common/global';

--- a/tests/util/project/src/styles/common/global.css
+++ b/tests/util/project/src/styles/common/global.css
@@ -1,7 +1,3 @@
-body {
-  @apply font-sans;
-}
-
 #root {
-  @apply text-3xl font-medium text-indigo-500;
+  @apply text-indigo-500;
 }

--- a/tests/util/project/tailwind.config.js
+++ b/tests/util/project/tailwind.config.js
@@ -1,11 +1,6 @@
 module.exports = {
-  content: [`src/**/*.{js,css,html}`, `static/**/*.{js,css,html}`],
+  content: [`src/index.html`],
   theme: {
-    extend: {
-      colors: {},
-    },
-  },
-  variants: {
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
Prevents mutations to tailwind theme when using theme.json generators

- adds unit tests for transformers
- adds integration tests confirming `.text-${key}` css is generated for transformed values
- adds integration tests confirming that `extendOnly` filter limits generated values

refers:

- https://github.com/roots/sage/issues/3092

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
