### PR TITLE
📕 docs(none): build READMEs

### DIFF
--- a/sources/@repo/docs/content/docs/bud.assets.mdx
+++ b/sources/@repo/docs/content/docs/bud.assets.mdx
@@ -115,9 +115,9 @@ there is probably no real harm in doing so.
 **bud.assets** is just a simple interface wrapper for the `copy-webpack-plugin` extension. You can utilize the extension directly:
 
 ```js title="bud.config.js"
-app.extensions
+bud.extensions
   .get('copy-webpack-plugin')
-  .setOption('patterns', [{from: app.path('@src/images')}])
+  .setOption('patterns', [{from: bud.path('@src/images')}])
 ```
 
 It accepts any options that [copy-webpack-plugin](https://www.npmjs.com/package/copy-webpack-plugin) does.

--- a/sources/@repo/docs/content/extensions/bud-esbuild.mdx
+++ b/sources/@repo/docs/content/extensions/bud-esbuild.mdx
@@ -33,7 +33,7 @@ Typechecking can be added with [fork-ts-checker-webpack-plugin](https://www.npmj
 ```ts
 import Plugin from 'fork-ts-checker-webpack-plugin'
 
-export default app => {
-  await app.extensions.add(Plugin)
+export default bud => {
+  await bud.extensions.add(Plugin)
 }
 ```

--- a/sources/@repo/docs/content/extensions/bud-purgecss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-purgecss.mdx
@@ -21,8 +21,8 @@ By default, bud does not purge any styles on its own. [PurgeCSS](https://purgecs
 ```ts title="bud.config.js"
 import purgeCssWordPress from `purgecss-with-wordpress`
 
-app.purgecss({
-  content: [app.path(`resources/views/**`)],
+bud.purgecss({
+  content: [bud.path(`resources/views/**`)],
   safelist: [...purgeCssWordPress.safelist],
 })
 ```

--- a/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
@@ -33,13 +33,13 @@ export const main = () => {
 Generating the imports can be memory intensive and increase build times, so it is opt-in.
 
 ```ts
-app.tailwind.generateImports()
+bud.tailwind.generateImports()
 ```
 
 Better to generate imports only for specific keys (much less memory intensive):
 
 ```ts
-app.tailwind.generateImports([`colors`, `fontFamily`])
+bud.tailwind.generateImports([`colors`, `fontFamily`])
 ```
 
 This is a lot better than trying to import the actual `tailwind.config.js` file to read these values as the values are fully resolved (merged with `defaultTheme`, plugins applied, etc.)

--- a/sources/@repo/docs/content/guides/configure.mdx
+++ b/sources/@repo/docs/content/guides/configure.mdx
@@ -51,8 +51,8 @@ export default async bud => {
      * Copy static assets from `sources/static` to `dist/static`
      */
     .assets({
-      from: app.path(`@src/static`),
-      to: app.path(`@dist/static`),
+      from: bud.path(`@src/static`),
+      to: bud.path(`@dist/static`),
     })
 }
 ```
@@ -188,9 +188,9 @@ For complete control, you can pass an object:
 ```js title='bud.config.mjs'
 export default async bud => {
   bud.assets({
-    from: app.path(`@src`, 'images'),
-    to: app.path(`@dist`, 'images', `@name`), // `@name` is the filename (including hash if applicable)
-    context: app.path(`@src`),
+    from: bud.path(`@src`, 'images'),
+    to: bud.path(`@dist`, 'images', `@name`), // `@name` is the filename (including hash if applicable)
+    context: bud.path(`@src`),
     noErrorOnMissing: true,
     toType: `template`,
   })

--- a/sources/@repo/docs/content/guides/extending/index.mdx
+++ b/sources/@repo/docs/content/guides/extending/index.mdx
@@ -128,7 +128,7 @@ export default class MyExtension extends Extension {
   public label = 'bud-extension'
 
   public options = {
-    option: (app: Bud) => app.path('@src'),
+    option: (bud: Bud) => bud.path('@src'),
   }
 }
 ```
@@ -158,7 +158,7 @@ Also note, the extension options are **read only**. There are helpers in the bas
 #### setOption
 
 ```ts title="extension.js"
-extension.setOptions('foo', (app: Bud) => 'could have been a string')
+extension.setOptions('foo', (bud: Bud) => 'could have been a string')
 ```
 
 #### setOptions
@@ -166,7 +166,7 @@ extension.setOptions('foo', (app: Bud) => 'could have been a string')
 ```ts title="extension.js"
 extension.setOptions({
   foo: 'literal',
-  bar: (app: Bud) => 'a callback is fine, as well'.
+  bar: (bud: Bud) => 'a callback is fine, as well'.
 })
 ```
 
@@ -273,7 +273,7 @@ export default class MyExtension extends Extension {
   }
 
   public options = {
-    option: (app: Bud) => app.path('@src'),
+    option: (bud: Bud) => bud.path('@src'),
   }
 }
 ```
@@ -332,7 +332,7 @@ export default class MyExtension extends Extension {
   public plugin = Plugin
 
   public options = {
-    option: (app: Bud) => app.path('@src'),
+    option: (bud: Bud) => bud.path('@src'),
   }
 }
 ```

--- a/sources/@repo/docs/content/guides/general-use/customizing-loaders.mdx
+++ b/sources/@repo/docs/content/guides/general-use/customizing-loaders.mdx
@@ -218,6 +218,6 @@ bud.build.items.precss.setOptions({esModule: false})
 bud.build
   .makeRule()
   .setTest(({hooks}) => hooks.filter(`pattern.vue`))
-  .setInclude([app => app.path(`@src`)])
+  .setInclude([bud => bud.path(`@src`)])
   .setUse(items => [`vue`, ...items])
 ```

--- a/sources/@repo/docs/content/guides/general-use/esmodules.mdx
+++ b/sources/@repo/docs/content/guides/general-use/esmodules.mdx
@@ -21,7 +21,7 @@ a PR that implements the change you would like to see.
 To output `esm`, you may call:
 
 ```ts title="bud.config.mjs"
-app.esm.enable()
+bud.esm.enable()
 ```
 
 Or, set the `build` command's `--esm` flag:

--- a/sources/@repo/docs/content/guides/general-use/extensions.mdx
+++ b/sources/@repo/docs/content/guides/general-use/extensions.mdx
@@ -16,7 +16,7 @@ You can choose to use the bud extensions API directly in order to register an ex
 
 ```js title="bud.config.mjs"
 import BudMDX from '@roots/bud-mdx'
-export default async app => {
+export default async bud => {
   await bud.extensions.add(BudMDX)
 }
 ```
@@ -26,7 +26,7 @@ This means that you can add basically any Webpack plugin as demonstrated above.
 
 ```js title="bud.config.mjs"
 import BrowserSyncWebpackPlugin from 'browser-sync-webpack-plugin'
-export default async app => {
+export default async bud => {
   await bud.extensions.add(new BrowserSyncWebpackPlugin({...options}))
 }
 ```

--- a/sources/@repo/docs/content/guides/general-use/node-api.mdx
+++ b/sources/@repo/docs/content/guides/general-use/node-api.mdx
@@ -21,7 +21,7 @@ import type {Bud} from '@roots/bud'
 import {get} from '@roots/bud/factory'
 
 const basdir = process.cwd()
-const app: Bud = await get(basedir)
+const bud: Bud = await get(basedir)
 ```
 
 If `get` is called again with the same `basedir` it will return the same instance. This means that you can arbitrarily access `bud` from anywhere in your project
@@ -35,7 +35,7 @@ The fastest way to get going is calling the `factory` helper exported from **@ro
 import type {Bud} from '@roots/bud'
 import {factory} from '@roots/bud/factory'
 
-const app: Bud = await factory()
+const bud: Bud = await factory()
 ```
 
 ### Manually
@@ -50,11 +50,11 @@ const context = await applicationContext.get(process.cwd())
 
 // override context options here
 
-const app: Bud = await new Bud().lifecycle(context)
+const bud: Bud = await new Bud().lifecycle(context)
 
 // configure build here
 
-await app.run()
+await bud.run()
 ```
 
 ## Application context
@@ -110,7 +110,7 @@ const overrides: Overrides = {
   },
 }
 
-const app: Bud = await factory(overrides)
+const bud: Bud = await factory(overrides)
 ```
 
 ## Learning more

--- a/sources/@repo/docs/content/guides/general-use/remote-sources.mdx
+++ b/sources/@repo/docs/content/guides/general-use/remote-sources.mdx
@@ -65,13 +65,13 @@ import * as preact from 'unpkg:preact'
 You can add your own sources
 
 ```ts title="bud.config.mjs"
-app.cdn.setSource('localhost', 'https://localhost:8080/')
+bud.cdn.setSource('localhost', 'https://localhost:8080/')
 ```
 
 If you want to remove a source it's easy to access the mapping directly:
 
 ```ts title="bud.config.mjs"
-app.cdn.sources.delete('gist')
+bud.cdn.sources.delete('gist')
 ```
 
 ## Module caching

--- a/sources/@repo/docs/content/releases/5.0.0.mdx
+++ b/sources/@repo/docs/content/releases/5.0.0.mdx
@@ -36,8 +36,8 @@ interface make {
 The easiest and cleanest way to use this feature is with a callback. `bud.make` ultimately returns the parent compiler instance for fluent chaining.
 
 ```ts title='bud.config.ts'
-export default async (app: Bud) => {
-  app
+export default async (bud: Bud) => {
+  bud
     .make('my-wordpress-theme', async (theme: Bud) => {
       // theme is a fresh copy of Bud
     })
@@ -51,7 +51,7 @@ export default async (app: Bud) => {
 You can retrieve a compiler you have already made with `bud.get`.
 
 ```ts
-app.get('child')
+bud.get('child')
   .entry(...) // configuring the child
 ```
 
@@ -70,7 +70,7 @@ However, this is unnecessary for users who simply wish to use some Webpack plugi
 Previously, a small amount of boilerplate was required to wrap a plugin:
 
 ```ts
-app.use({
+bud.use({
   name: 'my-webpack-plugin',
   make: new MyWebpackPlugin(),
 })
@@ -79,7 +79,7 @@ app.use({
 But, now you can just use a plugin. A name will be automatically generated.
 
 ```ts
-app.use(new MyWebpackPlugin())
+bud.use(new MyWebpackPlugin())
 ```
 
 A side effect of this is that extension authors can now make a single package that works both with vanilla webpack and bud:

--- a/sources/@repo/docs/content/releases/5.4.0.mdx
+++ b/sources/@repo/docs/content/releases/5.4.0.mdx
@@ -54,7 +54,7 @@ bud.build.rules.js.setIncludes([
 ])
 ```
 
-You could just open up the entire project `setIncludes([app.path('project')])` but that will make compilation needlessly slow.
+You could just open up the entire project `setIncludes([bud.path('project')])` but that will make compilation needlessly slow.
 
 ## Improved: anchor tag `onClick` interceptor (for proxy dev)
 

--- a/sources/@repo/docs/content/releases/5.5.0.mdx
+++ b/sources/@repo/docs/content/releases/5.5.0.mdx
@@ -33,7 +33,7 @@ For more on how to set this up [check out the bud.serve documentation](/docs/bud
 You can generate a `theme.json` file for your theme using the `@roots/sage` package.
 
 ```ts title="bud.config.js"
-app.themeJson({
+bud.themeJson({
   typography: {
     customFontSize: false,
   },
@@ -43,7 +43,7 @@ app.themeJson({
 You can even sync your tailwind palette:
 
 ```ts title="bud.config.js"
-app.useTailwindColors()
+bud.useTailwindColors()
 ```
 
 Find out more in the updated docs for [@roots/sage](/extensions/sage).

--- a/sources/@repo/docs/content/releases/5.6.0.mdx
+++ b/sources/@repo/docs/content/releases/5.6.0.mdx
@@ -71,7 +71,7 @@ Want to add support to bud for some arcane syntax? Great news, the API for `load
 Here's typescript.
 
 ```ts
-app.build
+bud.build
   .setLoader('ts', 'ts-loader')
   .setItem('ts', {loader: 'ts', options: {}})
   .setRule('ts', {test: /\.tsx?/, use: [`babel`, `ts`]})
@@ -80,9 +80,9 @@ app.build
 If you just want to modify an existing rule, there is lots for you in this update:
 
 ```ts
-app.bulid.rule.ts.setUse([`babel`, `ts`])
-app.build.loaders.ts.setSrc(`alternate-ts-loader`)
-app.build.items.ts.setOptions({...options})
+bud.bulid.rule.ts.setUse([`babel`, `ts`])
+bud.build.loaders.ts.setSrc(`alternate-ts-loader`)
+bud.build.items.ts.setOptions({...options})
 ```
 
 Extension authors should take advantage of how all properties for loader, item, and rule definitions can be expressed with a callback. This means if someone changes their source path later your rule will still be pointed in the right direction.

--- a/sources/@repo/docs/content/releases/6.1.0.mdx
+++ b/sources/@repo/docs/content/releases/6.1.0.mdx
@@ -105,7 +105,7 @@ domReady(async () => {
 In addition to the theme color palette, you can now generate font sizes and font families from `tailwind.config.js` using `bud.wpjson.useTailwindFontSize` and `bud.wpjson.useTailwindFontFamily`.
 
 ```js title="bud.config.mjs"
-app.wpjson
+bud.wpjson
   .useTailwindColors()
   .useTailwindFontSize()
   .useTailwindFontFamily()
@@ -116,23 +116,23 @@ You can also modify fields which are not under the `settings` key using the stan
 
 ```js title="bud.config.mjs"
 // callback
-app.wpjson.setOptions(opts => ({
+bud.wpjson.setOptions(opts => ({
   ...options,
   customTemplates: [],
 }))
 
 // literal
-app.wpjson.setOptions({
+bud.wpjson.setOptions({
   // using without a callback
   // will fully override theme.json
-  ...app.wpjson.getOptions(),
+  ...bud.wpjson.getOptions(),
 })
 ```
 
-`app.wpjson.settings` can be used to change the `settings` prop granularly:
+`bud.wpjson.settings` can be used to change the `settings` prop granularly:
 
 ```js title="bud.config.mjs"
-app.wpjson.settings(theme => theme.set('custom', {}))
+bud.wpjson.settings(theme => theme.set('custom', {}))
 ```
 
 :::danger Breaking

--- a/sources/@repo/docs/content/releases/6.4.0.mdx
+++ b/sources/@repo/docs/content/releases/6.4.0.mdx
@@ -73,7 +73,7 @@ bud.assets(
     {from: 'images', to: 'images'},
     {from: 'fonts', to: 'fonts'},
   ],
-  {context: app.path('@assets')},
+  {context: bud.path('@assets')},
 )
 ```
 
@@ -84,12 +84,12 @@ bud.assets([
   {
     from: 'images',
     to: 'images',
-    context: app.path('@assets'),
+    context: bud.path('@assets'),
   },
   {
     from: 'fonts',
     to: 'fonts',
-    context: app.path(`assets`),
+    context: bud.path(`assets`),
   },
 ])
 ```
@@ -278,10 +278,10 @@ bud.hooks.fromMap({
 
 ```ts
 bud.hooks.fromAsyncMap({
-  'build.plugins': async () => await app.extensions.make(),
+  'build.plugins': async () => await bud.extensions.make(),
   'build.resolve.modules': async () => [
-    app.hooks.filter(`location.@src`),
-    app.hooks.filter(`location.@modules`),
+    bud.hooks.filter(`location.@src`),
+    bud.hooks.filter(`location.@modules`),
   ],
 })
 ```

--- a/sources/@repo/docs/content/releases/6.4.3.mdx
+++ b/sources/@repo/docs/content/releases/6.4.3.mdx
@@ -29,12 +29,12 @@ You can now easily use tailwind theme values in your app code by importing them 
 An example:
 
 ```ts
-import {black} from '@tailwind/colors'
-import {sans} from '@tailwind/fontFamily'
+import colors from '@tailwind/colors'
+import fontFamily from '@tailwind/fontFamily'
 
 export const main = () => {
-  document.body.style.backgroundColor = black
-  document.body.style.fontFamily = sans
+  document.body.style.backgroundColor = colors.black
+  document.body.style.fontFamily = fontFamily.sans
 }
 ```
 

--- a/sources/@repo/docs/content/releases/6.4.3.mdx
+++ b/sources/@repo/docs/content/releases/6.4.3.mdx
@@ -41,13 +41,13 @@ export const main = () => {
 Generating the imports can be memory intensive and increase build times, so it is opt-in.
 
 ```ts
-app.tailwind.generateImports()
+bud.tailwind.generateImports()
 ```
 
 Better to generate imports only for specific keys (much less memory intensive):
 
 ```ts
-app.tailwind.generateImports([`colors`, `fontFamily`])
+bud.tailwind.generateImports([`colors`, `fontFamily`])
 ```
 
 This is a lot better than trying to import the actual `tailwind.config.js` file to read these values as the values are fully resolved (merged with `defaultTheme`, plugins applied, etc.)

--- a/sources/@repo/docs/content/releases/6.4.5.mdx
+++ b/sources/@repo/docs/content/releases/6.4.5.mdx
@@ -2,7 +2,7 @@
 slug: 6.4.5
 title: 6.4.5
 description: Release notes for bud.js 6.4.5
-date: 2022-09-29
+date: 2022-10-03
 author: Kelly Mears
 author_title: Lead developer
 author_url: https://github.com/kellymears
@@ -19,6 +19,10 @@ A bugfix release for bud 6.4.
 `WP_HOME` is now automatically set as a _fallback_ proxy value. This means that if you don't call [bud.proxy](https://bud.js.org/docs/bud.proxy) value in your `bud.config.js` file, the extension will attempt to use `WP_HOME` (if it is available and is a string value).
 
 Previously, this value was set up front, which could cause errors if the value was malformed.
+
+## 🩹 [@roots/sage](https://bud.js.org/extensions/sage): `bud.wpjson.useTailwindFontSize` mutates config
+
+This function no longer mutates the tailwind config. This caused tailwind to not generate css for font sizes.
 
 ## ✨ [@roots/sage](https://bud.js.org/extensions/sage): filter theme.json values to those used in `theme.extend`
 

--- a/sources/@roots/sage/README.md
+++ b/sources/@roots/sage/README.md
@@ -63,8 +63,8 @@ Then, in your theme directory create a `eslint.config.cjs` file and include the 
 ```ts title="eslint.config.cjs"
 module.exports = {
   root: true,
-  extends: ["@roots/eslint-config/sage"],
-};
+  extends: ['@roots/eslint-config/sage'],
+}
 ```
 
 ### Using With Stylelint
@@ -79,11 +79,11 @@ Next, in your theme directory create a `.stylelintrc.js` file and include the Sa
 
 ```ts title="bud.config.mjs"
 module.exports = {
-  extends: ["@roots/sage/stylelint-config"],
+  extends: ['@roots/sage/stylelint-config'],
   rules: {
-    "color-no-invalid-hex": true,
+    'color-no-invalid-hex': true,
   },
-};
+}
 ```
 
 ### Managing Theme Json
@@ -95,7 +95,7 @@ You can manage [WordPress' `theme.json` config file](https://developer.wordpress
 In order to emit the file you will need to enable the feature:
 
 ```ts title="bud.config.mjs"
-bud.wpjson.enable();
+bud.wpjson.enable()
 ```
 
 ### Managing generic `theme.json` values
@@ -103,7 +103,7 @@ bud.wpjson.enable();
 You can use `setOption` from the bud.js extensions API to set `theme.json` values:
 
 ```ts title="bud.config.mjs"
-bud.wpjson.setOption("customTemplates", []).enable();
+bud.wpjson.setOption('customTemplates', []).enable()
 ```
 
 ### Managing the `settings` field
@@ -113,13 +113,13 @@ container interface exposed by `bud.wpjson.settings`.
 
 ```ts title="bud.config.mjs"
 bud.wptheme
-  .settings((theme) =>
+  .settings(theme =>
     theme
-      .set("typography.customFontSizes", true)
-      .set("typography.fontWeight", false)
-      .merge("spacing.units", ["px", "%", "em"])
+      .set('typography.customFontSizes', true)
+      .set('typography.fontWeight', false)
+      .merge('spacing.units', ['px', '%', 'em']),
   )
-  .enable();
+  .enable()
 ```
 
 ### Using tailwindcss config values
@@ -127,28 +127,36 @@ bud.wptheme
 If you use [@roots/bud-tailwindcss](https://bud.js.org/extensions/bud-tailwindcss) in your project there are several
 opt-in config functions that allow you to generate `theme.json` values directly from your tailwind config.
 
-#### wpjson.useTailwindColors
+#### wpjson.useTailwindColors()
 
-Convert `theme.extends.colors` to a `theme.json` palette.
+Convert `theme.colors` to a `theme.json` palette.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindColors().enable();
+bud.wpjson.useTailwindColors().enable()
 ```
 
 #### wpjson.useTailwindFontSize()
 
-Emits values from `theme.extends.fontSize` as the `typography.fontSizes` property of `theme.json`.
+Emits values from `theme.fontSize` as the `typography.fontSizes` property of `theme.json`.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindFontSize().enable();
+bud.wpjson.useTailwindFontSize().enable()
 ```
 
 #### wpjson.useTailwindFontFamily()
 
-Emits values from `theme.extends.fontFamily` as the `typography.fontFamilies` property of `theme.json`.
+Emits values from `theme.fontFamily` as the `typography.fontFamilies` property of `theme.json`.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindFontFamily().enable();
+bud.wpjson.useTailwindFontFamily().enable()
+```
+
+#### Limiting values to those defined in `theme.extend`
+
+You can pass `true` to any of the the above functions to limit the values emitted to those defined under tailwind's `theme.extend` key.
+
+```ts title="bud.config.mjs"
+bud.wpjson.useTailwindColors(true).enable()
 ```
 
 ### In combination
@@ -160,8 +168,8 @@ bud.wpjson
   .useTailwindColors()
   .useTailwindFontSize()
   .useTailwindFontFamily()
-  .setOption("typography.fontWeight", false)
-  .enable();
+  .setOption('typography.fontWeight', false)
+  .enable()
 ```
 
 ### Using With Sass
@@ -176,8 +184,11 @@ If using stylelint you will need to configure it for sass:
 
 ```ts file="stylelint.config.cjs"
 module.exports = {
-  extends: ["@roots/sage/stylelint-config", "@roots/bud-sass/stylelint-config"],
-};
+  extends: [
+    '@roots/sage/stylelint-config',
+    '@roots/bud-sass/stylelint-config',
+  ],
+}
 ```
 
 ## Contributing

--- a/sources/@roots/sage/README.md
+++ b/sources/@roots/sage/README.md
@@ -63,8 +63,8 @@ Then, in your theme directory create a `eslint.config.cjs` file and include the 
 ```ts title="eslint.config.cjs"
 module.exports = {
   root: true,
-  extends: ['@roots/eslint-config/sage'],
-}
+  extends: ["@roots/eslint-config/sage"],
+};
 ```
 
 ### Using With Stylelint
@@ -79,11 +79,11 @@ Next, in your theme directory create a `.stylelintrc.js` file and include the Sa
 
 ```ts title="bud.config.mjs"
 module.exports = {
-  extends: ['@roots/sage/stylelint-config'],
+  extends: ["@roots/sage/stylelint-config"],
   rules: {
-    'color-no-invalid-hex': true,
+    "color-no-invalid-hex": true,
   },
-}
+};
 ```
 
 ### Managing Theme Json
@@ -95,7 +95,7 @@ You can manage [WordPress' `theme.json` config file](https://developer.wordpress
 In order to emit the file you will need to enable the feature:
 
 ```ts title="bud.config.mjs"
-bud.wpjson.enable()
+bud.wpjson.enable();
 ```
 
 ### Managing generic `theme.json` values
@@ -103,7 +103,7 @@ bud.wpjson.enable()
 You can use `setOption` from the bud.js extensions API to set `theme.json` values:
 
 ```ts title="bud.config.mjs"
-bud.wpjson.setOption('customTemplates', []).enable()
+bud.wpjson.setOption("customTemplates", []).enable();
 ```
 
 ### Managing the `settings` field
@@ -113,13 +113,13 @@ container interface exposed by `bud.wpjson.settings`.
 
 ```ts title="bud.config.mjs"
 bud.wptheme
-  .settings(theme =>
+  .settings((theme) =>
     theme
-      .set('typography.customFontSizes', true)
-      .set('typography.fontWeight', false)
-      .merge('spacing.units', ['px', '%', 'em']),
+      .set("typography.customFontSizes", true)
+      .set("typography.fontWeight", false)
+      .merge("spacing.units", ["px", "%", "em"])
   )
-  .enable()
+  .enable();
 ```
 
 ### Using tailwindcss config values
@@ -132,7 +132,7 @@ opt-in config functions that allow you to generate `theme.json` values directly 
 Convert `theme.colors` to a `theme.json` palette.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindColors().enable()
+bud.wpjson.useTailwindColors().enable();
 ```
 
 #### wpjson.useTailwindFontSize()
@@ -140,7 +140,7 @@ bud.wpjson.useTailwindColors().enable()
 Emits values from `theme.fontSize` as the `typography.fontSizes` property of `theme.json`.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindFontSize().enable()
+bud.wpjson.useTailwindFontSize().enable();
 ```
 
 #### wpjson.useTailwindFontFamily()
@@ -148,7 +148,7 @@ bud.wpjson.useTailwindFontSize().enable()
 Emits values from `theme.fontFamily` as the `typography.fontFamilies` property of `theme.json`.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindFontFamily().enable()
+bud.wpjson.useTailwindFontFamily().enable();
 ```
 
 #### Limiting values to those defined in `theme.extend`
@@ -156,7 +156,7 @@ bud.wpjson.useTailwindFontFamily().enable()
 You can pass `true` to any of the the above functions to limit the values emitted to those defined under tailwind's `theme.extend` key.
 
 ```ts title="bud.config.mjs"
-bud.wpjson.useTailwindColors(true).enable()
+bud.wpjson.useTailwindColors(true).enable();
 ```
 
 ### In combination
@@ -168,8 +168,8 @@ bud.wpjson
   .useTailwindColors()
   .useTailwindFontSize()
   .useTailwindFontFamily()
-  .setOption('typography.fontWeight', false)
-  .enable()
+  .setOption("typography.fontWeight", false)
+  .enable();
 ```
 
 ### Using With Sass
@@ -184,11 +184,8 @@ If using stylelint you will need to configure it for sass:
 
 ```ts file="stylelint.config.cjs"
 module.exports = {
-  extends: [
-    '@roots/sage/stylelint-config',
-    '@roots/bud-sass/stylelint-config',
-  ],
-}
+  extends: ["@roots/sage/stylelint-config", "@roots/bud-sass/stylelint-config"],
+};
 ```
 
 ## Contributing


### PR DESCRIPTION
- some local corrections/changes and updated README build (already deployed)
- `app` => `bud`

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
