### PR TITLE
✨ feat(none): upload to s3

### DIFF
--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -106,6 +106,7 @@
     "@repo/test-kit": "workspace:sources/@repo/test-kit",
     "@skypack/package-check": "0.2.2",
     "@types/braces": "3.0.1",
+    "@types/mime-types": "^2",
     "@types/mini-css-extract-plugin": "2.5.0",
     "@types/node": "16.11.48",
     "@types/node-notifier": "8.0.2"
@@ -124,6 +125,7 @@
     "@roots/bud-support": "workspace:sources/@roots/bud-support",
     "@roots/bud-terser": "workspace:sources/@roots/bud-terser",
     "@roots/container": "workspace:sources/@roots/container",
+    "aws-sdk": "2.1228.0",
     "browserslist": "latest",
     "caniuse-lite": "latest",
     "clean-webpack-plugin": "^4.0.0",
@@ -132,6 +134,7 @@
     "dotenv": "16.0.3",
     "dotenv-expand": "9.0.0",
     "import-meta-resolve": "2.1.0",
+    "mime-types": "2.1.35",
     "mini-css-extract-plugin": "^2.4.5",
     "node-notifier": "10.0.1",
     "open": "8.4.0",

--- a/sources/@roots/bud/src/context/extensions.ts
+++ b/sources/@roots/bud/src/context/extensions.ts
@@ -29,6 +29,7 @@ export default class Extensions {
     `@roots/bud/extensions/webpack-define-plugin`,
     `@roots/bud/extensions/mini-css-extract-plugin`,
     `@roots/bud/extensions/copy-webpack-plugin`,
+    `@roots/bud/extensions/bud-s3`,
   ]
 
   public constructor(public manifest: Context['manifest']) {}

--- a/sources/@roots/bud/src/env.ts
+++ b/sources/@roots/bud/src/env.ts
@@ -14,6 +14,7 @@ import type {Build} from '@roots/bud-framework/services'
 import type CDN from './extensions/bud-cdn/index.js'
 import type ESM from './extensions/bud-esm/index.js'
 import type FixStyleOnlyEntrypoints from './extensions/bud-fix-style-only-entrypoints/index.js'
+import type BudS3 from './extensions/bud-s3/index.js'
 import type Clean from './extensions/clean-webpack-plugin/index.js'
 import type Copy from './extensions/copy-webpack-plugin/index.js'
 import type MiniCss from './extensions/mini-css-extract-plugin/index.js'
@@ -26,11 +27,13 @@ declare module '@roots/bud-framework' {
   interface Bud {
     cdn: CDN
     esm: ESM
+    s3: BudS3
   }
 
   interface Modules {
     cdn: CDN
     esm: ESM
+    'bud-s3': BudS3
     'fix-style-only-entrypoints': FixStyleOnlyEntrypoints
     'webpack:define-plugin': Define
     'webpack:provide-plugin': Provide

--- a/sources/@roots/bud/src/extensions/bud-s3/index.ts
+++ b/sources/@roots/bud/src/extensions/bud-s3/index.ts
@@ -1,0 +1,222 @@
+import {Extension} from '@roots/bud-framework'
+import {
+  bind,
+  expose,
+  label,
+  options,
+  plugin,
+  when,
+} from '@roots/bud-framework/extension/decorators'
+
+import type {Options} from './options.interface'
+import S3Plugin from './plugin.js'
+
+/**
+ * Upload assets to an S3 compatible provider
+ *
+ * @example
+ * ```js
+ * bud.s3
+ *  .setKey(`key`)
+ *  .setSecret(`secret`)
+ *  .setBucket(`bucket`)
+ *  .setEndpoint(`https://sgp1.digitaloceanspaces.com`)
+ *  .setAcl(`public-read`)
+ *  .setCache(`max-age=602430`)
+ *  .enable()
+ * ```
+ *
+ * @public
+ * @decorator `@label`
+ * @decorator `@options`
+ * @decorator `@plugin`
+ * @decorator `@expose`
+ */
+@label(`bud-s3`)
+@options<Options>({
+  key: app =>
+    app.env.has(`S3_KEY`) && app.env.isString(`S3_KEY`)
+      ? app.env.get(`S3_KEY`)
+      : undefined,
+  secret: app =>
+    app.env.has(`S3_SECRET`) && app.env.isString(`S3_SECRET`)
+      ? app.env.get(`S3_SECRET`)
+      : undefined,
+  region: app =>
+    app.env.has(`S3_REGION`) && app.env.isString(`S3_REGION`)
+      ? app.env.get(`S3_REGION`)
+      : undefined,
+  endpoint: app =>
+    app.env.has(`S3_ENDPOINT`) && app.env.isString(`S3_ENDPOINT`)
+      ? app.env.get(`S3_ENDPOINT`)
+      : undefined,
+  bucket: app =>
+    app.env.has(`S3_BUCKET`) && app.env.isString(`S3_BUCKET`)
+      ? app.env.get(`S3_BUCKET`)
+      : undefined,
+  acl: `public-read`,
+  cache: `max-age=602430`,
+  prefix: app =>
+    app.env.has(`S3_PREFIX`) && app.env.isString(`S3_PREFIX`)
+      ? app.env.get(`S3_PREFIX`)
+      : undefined,
+  include: null,
+  exclude: null,
+  remove: [],
+})
+@plugin(S3Plugin)
+@expose(`s3`)
+@when(async app => false)
+export default class BudS3 extends Extension<Options, S3Plugin> {
+  /**
+   * Set S3 key
+   *
+   * @remarks
+   * Can also use the `S3_KEY` environment variable.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setKey(key: string) {
+    this.setOption(`key`, key)
+    return this
+  }
+
+  /**
+   * Set S3 secret
+   *
+   * @remarks
+   * Can also use the `S3_SECRET` environment variable.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setSecret(secret: string) {
+    this.setOption(`secret`, secret)
+    return this
+  }
+
+  /**
+   * Set S3 bucket
+   *
+   * @remarks
+   * Can also use the `S3_BUCKET` environment variable.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setBucket(bucket: string) {
+    this.setOption(`bucket`, bucket)
+    return this
+  }
+
+  /**
+   * If you are using Amazon S3 then only set region.
+   *
+   * @remarks
+   * Can also use the `S3_REGION` environment variable.
+   * `region` and `endpoint` shouldn't bet used together.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setRegion(region: string) {
+    this.setOption(`region`, region)
+    return this
+  }
+
+  /**
+   * Set S3 endpoint
+   *
+   * @remarks
+   * Can also use the `S3_ENDPOINT` environment variable.
+   * `region` and `endpoint` shouldn't bet used together.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setEndpoint(endpoint: string) {
+    this.setOption(`endpoint`, endpoint)
+    return this
+  }
+
+  /**
+   * Set ACL
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setAcl(acl: string) {
+    this.setOption(`acl`, acl)
+    return this
+  }
+
+  /**
+   * Set cache
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setCache(cache: string) {
+    this.setOption(`cache`, cache)
+    return this
+  }
+
+  /**
+   * Set prefix
+   *
+   * @remarks
+   * Can also use the `S3_PREFIX` environment variable.
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setPrefix(prefix: string) {
+    this.setOption(`prefix`, prefix)
+    return this
+  }
+
+  /**
+   * Set include
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setInclude(include: string) {
+    this.setOption(`include`, include)
+    return this
+  }
+
+  /**
+   * Set exclude
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setExclude(exclude: string) {
+    this.setOption(`exclude`, exclude)
+    return this
+  }
+
+  /**
+   * Set remove
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public setRemove(remove: Array<string>) {
+    this.setOption(`remove`, remove)
+    return this
+  }
+}

--- a/sources/@roots/bud/src/extensions/bud-s3/options.interface.ts
+++ b/sources/@roots/bud/src/extensions/bud-s3/options.interface.ts
@@ -1,0 +1,65 @@
+/**
+ * S3 options
+ *
+ * @public
+ */
+export interface Options {
+  /**
+   * AWS access key
+   * @public
+   */
+  key: string
+  /**
+   * AWS secret key
+   * @public
+   */
+  secret: string
+  /**
+   * AWS bucket name
+   * @public
+   */
+  bucket: string
+  /**
+   * If you are using Amazon S3 then only set region.
+   * `region` and `endpoint` both should not be set together.
+   * @public
+   */
+  region?: string
+  /**
+   * If you are using some other provider then set only endpoint.
+   * `region` and `endpoint` both should not be set together.
+   * @public
+   */
+  endpoint?: string
+  /**
+   * ACL for the uploaded files
+   * @public
+   */
+  acl: string
+  /**
+   * Cache-Control header for the uploaded files
+   * @public
+   */
+  cache: string
+  /**
+   * Prefix for the uploaded files
+   * @public
+   */
+  prefix: string
+  /**
+   * If you want to upload only specific files
+   * @public
+   */
+  include: string
+  /**
+   * If you want to exclude specific files
+   * from uploading
+   * @public
+   */
+  exclude: string
+  /**
+   * Remove files from the bucket before upload
+   * @public
+   */
+  remove: Array<string>
+}

--- a/sources/@roots/bud/src/extensions/bud-s3/plugin.ts
+++ b/sources/@roots/bud/src/extensions/bud-s3/plugin.ts
@@ -1,0 +1,138 @@
+/* eslint-disable no-console */
+import {join} from 'node:path'
+
+import {bind} from '@roots/bud-support/decorators'
+import {readFile} from '@roots/bud-support/fs'
+import {isUndefined} from '@roots/bud-support/lodash-es'
+import AWS from 'aws-sdk'
+import mime from 'mime-types'
+import type {Compiler} from 'webpack'
+
+import type {Options} from './options.interface'
+
+/**
+ * Upload assets to an S3 compatible provider
+ *
+ * @remarks
+ * Based on {@link https://github.com/olsgreen/webpack-s3-pusher/blob/master/webpack.s3.pusher.js}
+ *
+ * @public
+ */
+export default class S3Plugin {
+  /**
+   * Assets
+   *
+   * @public
+   */
+  public assets: Array<[string, string]> = []
+
+  public s3
+
+  /**
+   * Class constructor
+   *
+   * @public
+   */
+  public constructor(public options: Options) {
+    if (isUndefined(this.options.region)) this.options.region = `us-west-2`
+    if (
+      !isUndefined(this.options.key) &&
+      !isUndefined(this.options.secret)
+    ) {
+      const config = {
+        accessKeyId: this.options.key,
+        secretAccessKey: this.options.secret,
+        region: `us-west-2`,
+      }
+
+      if (!isUndefined(this.options.region)) {
+        Object.assign(config, {region: this.options.region})
+      }
+
+      if (!isUndefined(this.options.endpoint)) {
+        Object.assign(config, {endpoint: this.options.endpoint})
+      }
+
+      AWS.config.update(config)
+      this.s3 = new AWS.S3()
+    }
+  }
+
+  /**
+   * `apply` callback
+   *
+   *  @public
+   */
+  @bind
+  public apply(compiler: Compiler) {
+    compiler.hooks.emit.tapAsync(
+      `bud-s3-plugin`,
+      (compilation, callback) => {
+        this.assets = Array.from(Object.keys(compilation.assets))
+          .map((filename: string): [string, string | false] => [
+            filename,
+            mime.lookup(filename),
+          ])
+          .filter(([filename, mimeType]) => mimeType !== false) as Array<
+          [string, string]
+        >
+
+        callback()
+      },
+    )
+
+    compiler.hooks.afterEmit.tapAsync(
+      `bud-s3-plugin`,
+      (_compilation, callback) => {
+        ;(async () => {
+          await Promise.all(
+            this.assets.map(
+              async ([filename, mimeType]: [string, string]) => {
+                const local = join(compiler.outputPath, filename)
+                const remote = !isUndefined(this.options.prefix)
+                  ? join(this.options.prefix, filename)
+                  : filename
+
+                const contents = await readFile(local, `utf8`)
+
+                try {
+                  await this.upload(remote, contents, mimeType)
+                } catch (error) {
+                  console.error(`could not upload ${local} to ${remote}`)
+                  console.error(error.name, error.message)
+                  throw error
+                }
+              },
+            ),
+          ).then(() => callback())
+        })()
+      },
+    )
+  }
+
+  /**
+   * Upload asset to S3
+   *
+   * @public
+   */
+  @bind
+  public async upload(Key: string, Body: string, ContentType: string) {
+    return new Promise((resolve, reject) => {
+      this.s3.putObject(
+        {
+          Key,
+          Body,
+          ContentType,
+          Bucket: this.options.bucket ?? `us-west-2`,
+          ACL: this.options.acl ?? undefined,
+          CacheControl: this.options.cache ?? undefined,
+        },
+        (error: Error, data: any) => {
+          if (error) throw error
+          // @ts-ignore
+          resolve(data)
+        },
+      )
+    })
+  }
+}

--- a/tests/unit/bud-extensions/__snapshots__/service.development.test.ts.snap
+++ b/tests/unit/bud-extensions/__snapshots__/service.development.test.ts.snap
@@ -11,6 +11,7 @@ exports[`Extensions [development] bud.extensions.repository options matches snap
   "@roots/bud-tailwindcss",
   "@roots/bud-terser",
   "@roots/bud-terser/css-minimizer",
+  "bud-s3",
   "cdn",
   "clean-webpack-plugin",
   "copy-webpack-plugin",

--- a/tests/unit/bud-extensions/__snapshots__/service.production.test.ts.snap
+++ b/tests/unit/bud-extensions/__snapshots__/service.production.test.ts.snap
@@ -11,6 +11,7 @@ exports[`Extensions [production] bud.extensions.repository matches snapshot 1`] 
   "@roots/bud-tailwindcss",
   "@roots/bud-terser",
   "@roots/bud-terser/css-minimizer",
+  "bud-s3",
   "cdn",
   "clean-webpack-plugin",
   "copy-webpack-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5379,9 +5379,11 @@ __metadata:
     "@roots/container": "workspace:sources/@roots/container"
     "@skypack/package-check": 0.2.2
     "@types/braces": 3.0.1
+    "@types/mime-types": ^2
     "@types/mini-css-extract-plugin": 2.5.0
     "@types/node": 16.11.48
     "@types/node-notifier": 8.0.2
+    aws-sdk: 2.1228.0
     browserslist: latest
     caniuse-lite: latest
     clean-webpack-plugin: ^4.0.0
@@ -5390,6 +5392,7 @@ __metadata:
     dotenv: 16.0.3
     dotenv-expand: 9.0.0
     import-meta-resolve: 2.1.0
+    mime-types: 2.1.35
     mini-css-extract-plugin: ^2.4.5
     node-notifier: 10.0.1
     open: 8.4.0
@@ -6675,7 +6678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mime-types@npm:^2.1.0":
+"@types/mime-types@npm:^2, @types/mime-types@npm:^2.1.0":
   version: 2.1.1
   resolution: "@types/mime-types@npm:2.1.1"
   checksum: 106b5d556add46446a579ad25ff15d6b421851790d887edcad558c90c1e64b1defc72bfbaf4b08f208916e21d9cc45cdb951d77be51268b18221544cfe054a3c
@@ -9560,6 +9563,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"available-typed-arrays@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "available-typed-arrays@npm:1.0.5"
+  checksum: 20eb47b3cefd7db027b9bbb993c658abd36d4edd3fe1060e83699a03ee275b0c9b216cc076ff3f2db29073225fb70e7613987af14269ac1fe2a19803ccc97f1a
+  languageName: node
+  linkType: hard
+
+"aws-sdk@npm:2.1228.0":
+  version: 2.1228.0
+  resolution: "aws-sdk@npm:2.1228.0"
+  dependencies:
+    buffer: 4.9.2
+    events: 1.1.1
+    ieee754: 1.1.13
+    jmespath: 0.16.0
+    querystring: 0.2.0
+    sax: 1.2.1
+    url: 0.10.3
+    util: ^0.12.4
+    uuid: 8.0.0
+    xml2js: 0.4.19
+  checksum: e08bc4234c3a116d0186f347efd6d07d458d86d075ea3be803e7c928a4584db4639f94a068b4c103191c88d27059fb60c6032c756dadeecfcd4967ea10ac1a6b
+  languageName: node
+  linkType: hard
+
 "aws-sign2@npm:~0.7.0":
   version: 0.7.0
   resolution: "aws-sign2@npm:0.7.0"
@@ -9853,7 +9881,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.0.2, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -10242,6 +10270,17 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"buffer@npm:4.9.2":
+  version: 4.9.2
+  resolution: "buffer@npm:4.9.2"
+  dependencies:
+    base64-js: ^1.0.2
+    ieee754: ^1.1.4
+    isarray: ^1.0.0
+  checksum: 8801bc1ba08539f3be70eee307a8b9db3d40f6afbfd3cf623ab7ef41dffff1d0a31de0addbe1e66e0ca5f7193eeb667bfb1ecad3647f8f1b0750de07c13295c3
   languageName: node
   linkType: hard
 
@@ -13636,6 +13675,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-abstract@npm:^1.20.0":
+  version: 1.20.3
+  resolution: "es-abstract@npm:1.20.3"
+  dependencies:
+    call-bind: ^1.0.2
+    es-to-primitive: ^1.2.1
+    function-bind: ^1.1.1
+    function.prototype.name: ^1.1.5
+    get-intrinsic: ^1.1.3
+    get-symbol-description: ^1.0.0
+    has: ^1.0.3
+    has-property-descriptors: ^1.0.0
+    has-symbols: ^1.0.3
+    internal-slot: ^1.0.3
+    is-callable: ^1.2.6
+    is-negative-zero: ^2.0.2
+    is-regex: ^1.1.4
+    is-shared-array-buffer: ^1.0.2
+    is-string: ^1.0.7
+    is-weakref: ^1.0.2
+    object-inspect: ^1.12.2
+    object-keys: ^1.1.1
+    object.assign: ^4.1.4
+    regexp.prototype.flags: ^1.4.3
+    safe-regex-test: ^1.0.0
+    string.prototype.trimend: ^1.0.5
+    string.prototype.trimstart: ^1.0.5
+    unbox-primitive: ^1.0.2
+  checksum: 225f24966ed960868bcfa7b39b38c9f4b68d1e0351e4e052a199e3e2fd93838a28b050687a0edf1021c20173d0831d076ff33ec581de77ca8aded67e2e138a80
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^0.9.0":
   version: 0.9.3
   resolution: "es-module-lexer@npm:0.9.3"
@@ -14529,6 +14600,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"events@npm:1.1.1":
+  version: 1.1.1
+  resolution: "events@npm:1.1.1"
+  checksum: 40431eb005cc4c57861b93d44c2981a49e7feb99df84cf551baed299ceea4444edf7744733f6a6667e942af687359b1f4a87ec1ec4f21d5127dac48a782039b9
+  languageName: node
+  linkType: hard
+
 "events@npm:^3.2.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
@@ -15386,6 +15464,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"for-each@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "for-each@npm:0.3.3"
+  dependencies:
+    is-callable: ^1.1.3
+  checksum: 6c48ff2bc63362319c65e2edca4a8e1e3483a2fabc72fbe7feaf8c73db94fc7861bd53bc02c8a66a0c1dd709da6b04eec42e0abdd6b40ce47305ae92a25e5d28
+  languageName: node
+  linkType: hard
+
 "for-in@npm:^1.0.2":
   version: 1.0.2
   resolution: "for-in@npm:1.0.2"
@@ -15780,6 +15867,17 @@ __metadata:
     has: ^1.0.3
     has-symbols: ^1.0.1
   checksum: a9fe2ca8fa3f07f9b0d30fb202bcd01f3d9b9b6b732452e79c48e79f7d6d8d003af3f9e38514250e3553fdc83c61650851cb6870832ac89deaaceb08e3721a17
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "get-intrinsic@npm:1.1.3"
+  dependencies:
+    function-bind: ^1.1.1
+    has: ^1.0.3
+    has-symbols: ^1.0.3
+  checksum: 152d79e87251d536cf880ba75cfc3d6c6c50e12b3a64e1ea960e73a3752b47c69f46034456eae1b0894359ce3bc64c55c186f2811f8a788b75b638b06fab228a
   languageName: node
   linkType: hard
 
@@ -17356,7 +17454,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:1.1.13":
+  version: 1.1.13
+  resolution: "ieee754@npm:1.1.13"
+  checksum: 102df1ba662e316e6160f7ce29c7c7fa3e04f2014c288336c5a9ff40bbcc2a27d209fa2a81ebfb33f28b1941021343d30e9ad8ee85a2d61f79f5936c35edc33d
+  languageName: node
+  linkType: hard
+
+"ieee754@npm:^1.1.13, ieee754@npm:^1.1.4":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -17829,6 +17934,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-arguments@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: ^1.0.2
+    has-tostringtag: ^1.0.0
+  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
+  languageName: node
+  linkType: hard
+
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
@@ -17891,6 +18006,13 @@ __metadata:
   dependencies:
     builtin-modules: ^3.0.0
   checksum: f1e5dd2cd5f252d4d799b20a0c8c4f7e9c399c4d141749af76ca0121058d4062c3015d026f1b1409dd3d2a4ddfb9b15cf6eb9c370fed53fea8652ce35b5e95cb
+  languageName: node
+  linkType: hard
+
+"is-callable@npm:^1.1.3, is-callable@npm:^1.2.6":
+  version: 1.2.7
+  resolution: "is-callable@npm:1.2.7"
+  checksum: 61fd57d03b0d984e2ed3720fb1c7a897827ea174bd44402878e059542ea8c4aeedee0ea0985998aa5cc2736b2fa6e271c08587addb5b3959ac52cf665173d1ac
   languageName: node
   linkType: hard
 
@@ -18057,6 +18179,15 @@ __metadata:
   version: 2.1.0
   resolution: "is-generator-fn@npm:2.1.0"
   checksum: a6ad5492cf9d1746f73b6744e0c43c0020510b59d56ddcb78a91cbc173f09b5e6beff53d75c9c5a29feb618bfef2bf458e025ecf3a57ad2268e2fb2569f56215
+  languageName: node
+  linkType: hard
+
+"is-generator-function@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "is-generator-function@npm:1.0.10"
+  dependencies:
+    has-tostringtag: ^1.0.0
+  checksum: d54644e7dbaccef15ceb1e5d91d680eb5068c9ee9f9eb0a9e04173eb5542c9b51b5ab52c5537f5703e48d5fddfd376817c1ca07a84a407b7115b769d4bdde72b
   languageName: node
   linkType: hard
 
@@ -18407,6 +18538,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-typed-array@npm:^1.1.3, is-typed-array@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "is-typed-array@npm:1.1.9"
+  dependencies:
+    available-typed-arrays: ^1.0.5
+    call-bind: ^1.0.2
+    es-abstract: ^1.20.0
+    for-each: ^0.3.3
+    has-tostringtag: ^1.0.0
+  checksum: 11910f1e58755fef43bf0074e52fa5b932bf101ec65d613e0a83d40e8e4c6e3f2ee142d624ebc7624c091d3bbe921131f8db7d36ecbbb71909f2fe310c1faa65
+  languageName: node
+  linkType: hard
+
 "is-typedarray@npm:^1.0.0, is-typedarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "is-typedarray@npm:1.0.0"
@@ -18509,7 +18653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:1.0.0, isarray@npm:~1.0.0":
+"isarray@npm:1.0.0, isarray@npm:^1.0.0, isarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
   checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
@@ -19123,6 +19267,13 @@ __metadata:
   version: 1.4.0
   resolution: "jju@npm:1.4.0"
   checksum: 3790481bd2b7827dd6336e6e3dc2dcc6d425679ba7ebde7b679f61dceb4457ea0cda330972494de608571f4973c6dfb5f70fab6f3c5037dbab19ac449a60424f
+  languageName: node
+  linkType: hard
+
+"jmespath@npm:0.16.0":
+  version: 0.16.0
+  resolution: "jmespath@npm:0.16.0"
+  checksum: 2d602493a1e4addfd1350ac8c9d54b1b03ed09e305fd863bab84a4ee1f52868cf939dd1a08c5cdea29ce9ba8f86875ebb458b6ed45dab3e1c3f2694503fb2fd9
   languageName: node
   linkType: hard
 
@@ -21285,7 +21436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.25, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:2.1.35, mime-types@npm:^2.1.12, mime-types@npm:^2.1.25, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -22470,7 +22621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.12.0, object-inspect@npm:^1.9.0":
+"object-inspect@npm:^1.12.0, object-inspect@npm:^1.12.2, object-inspect@npm:^1.9.0":
   version: 1.12.2
   resolution: "object-inspect@npm:1.12.2"
   checksum: a534fc1b8534284ed71f25ce3a496013b7ea030f3d1b77118f6b7b1713829262be9e6243acbcb3ef8c626e2b64186112cb7f6db74e37b2789b9c789ca23048b2
@@ -22502,6 +22653,18 @@ __metadata:
     has-symbols: ^1.0.1
     object-keys: ^1.1.1
   checksum: d621d832ed7b16ac74027adb87196804a500d80d9aca536fccb7ba48d33a7e9306a75f94c1d29cbfa324bc091bfc530bc24789568efdaee6a47fcfa298993814
+  languageName: node
+  linkType: hard
+
+"object.assign@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "object.assign@npm:4.1.4"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    has-symbols: ^1.0.3
+    object-keys: ^1.1.1
+  checksum: 76cab513a5999acbfe0ff355f15a6a125e71805fcf53de4e9d4e082e1989bdb81d1e329291e1e4e0ae7719f0e4ef80e88fb2d367ae60500d79d25a6224ac8864
   languageName: node
   linkType: hard
 
@@ -25163,6 +25326,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"punycode@npm:1.3.2":
+  version: 1.3.2
+  resolution: "punycode@npm:1.3.2"
+  checksum: b8807fd594b1db33335692d1f03e8beeddde6fda7fbb4a2e32925d88d20a3aa4cd8dcc0c109ccaccbd2ba761c208dfaaada83007087ea8bfb0129c9ef1b99ed6
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^1.3.2, punycode@npm:^1.4.1":
   version: 1.4.1
   resolution: "punycode@npm:1.4.1"
@@ -25270,6 +25440,13 @@ __metadata:
     split-on-first: ^1.0.0
     strict-uri-encode: ^2.0.0
   checksum: f2c7347578fa0f3fd4eaace506470cb4e9dc52d409a7ddbd613f614b9a594d750877e193b5d5e843c7477b3b295b857ec328903c943957adc41a3efb6c929449
+  languageName: node
+  linkType: hard
+
+"querystring@npm:0.2.0":
+  version: 0.2.0
+  resolution: "querystring@npm:0.2.0"
+  checksum: 8258d6734f19be27e93f601758858c299bdebe71147909e367101ba459b95446fbe5b975bf9beb76390156a592b6f4ac3a68b6087cea165c259705b8b4e56a69
   languageName: node
   linkType: hard
 
@@ -26831,6 +27008,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-regex-test@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "safe-regex-test@npm:1.0.0"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    is-regex: ^1.1.4
+  checksum: bc566d8beb8b43c01b94e67de3f070fd2781685e835959bbbaaec91cc53381145ca91f69bd837ce6ec244817afa0a5e974fc4e40a2957f0aca68ac3add1ddd34
+  languageName: node
+  linkType: hard
+
 "safe-regex@npm:^1.1.0":
   version: 1.1.0
   resolution: "safe-regex@npm:1.1.0"
@@ -26889,6 +27077,13 @@ __metadata:
   bin:
     sass: sass.js
   checksum: d5efcbad4bc2efe638cd12665f8aeedc20f4e6b1cd2454624334f9189e9ab8a73708241232f102f6f873ee56fb64d993a67ff23bf669da5c2cf7495412007739
+  languageName: node
+  linkType: hard
+
+"sax@npm:1.2.1":
+  version: 1.2.1
+  resolution: "sax@npm:1.2.1"
+  checksum: 8dca7d5e1cd7d612f98ac50bdf0b9f63fbc964b85f0c4e2eb271f8b9b47fd3bf344c4d6a592e69ecf726d1485ca62cd8a52e603bbc332d18a66af25a9a1045ad
   languageName: node
   linkType: hard
 
@@ -30187,6 +30382,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"url@npm:0.10.3":
+  version: 0.10.3
+  resolution: "url@npm:0.10.3"
+  dependencies:
+    punycode: 1.3.2
+    querystring: 0.2.0
+  checksum: 7b83ddb106c27bf9bde8629ccbe8d26e9db789c8cda5aa7db72ca2c6f9b8a88a5adf206f3e10db78e6e2d042b327c45db34c7010c1bf0d9908936a17a2b57d05
+  languageName: node
+  linkType: hard
+
 "use-composed-ref@npm:^1.0.0":
   version: 1.2.1
   resolution: "use-composed-ref@npm:1.2.1"
@@ -30245,6 +30450,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util@npm:^0.12.4":
+  version: 0.12.4
+  resolution: "util@npm:0.12.4"
+  dependencies:
+    inherits: ^2.0.3
+    is-arguments: ^1.0.4
+    is-generator-function: ^1.0.7
+    is-typed-array: ^1.1.3
+    safe-buffer: ^5.1.2
+    which-typed-array: ^1.1.2
+  checksum: 8eac7a6e6b341c0f1b3eb73bbe5dfcae31a7e9699c8fc3266789f3e95f7637946a7700dcf1904dbd3749a58a36760ebf7acf4bb5b717f7468532a8a79f44eff0
+  languageName: node
+  linkType: hard
+
 "utila@npm:~0.4":
   version: 0.4.0
   resolution: "utila@npm:0.4.0"
@@ -30263,6 +30482,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: c81095493225ecfc28add49c106ca4f09cdf56bc66731aa8dabc2edbbccb1e1bfe2de6a115e5c6a380d3ea166d1636410b62ef216bb07b3feb1cfde1d95d5080
+  languageName: node
+  linkType: hard
+
+"uuid@npm:8.0.0":
+  version: 8.0.0
+  resolution: "uuid@npm:8.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 56d4e23aa7ac26fa2db6bd1778db34cb8c9f5a10df1770a27167874bf6705fc8f14a4ac414af58a0d96c7653b2bd4848510b29d1c2ef8c91ccb17429c1872b5e
   languageName: node
   linkType: hard
 
@@ -31138,6 +31366,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-typed-array@npm:^1.1.2":
+  version: 1.1.8
+  resolution: "which-typed-array@npm:1.1.8"
+  dependencies:
+    available-typed-arrays: ^1.0.5
+    call-bind: ^1.0.2
+    es-abstract: ^1.20.0
+    for-each: ^0.3.3
+    has-tostringtag: ^1.0.0
+    is-typed-array: ^1.1.9
+  checksum: bedf4d30a738e848404fe67fe0ace33433a7298cf3f5a4d4b2c624ba99c4d25f06a7fd6f3566c3d16af5f8a54f0c6293cbfded5b1208ce11812753990223b45a
+  languageName: node
+  linkType: hard
+
 "which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
@@ -31418,6 +31660,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml2js@npm:0.4.19":
+  version: 0.4.19
+  resolution: "xml2js@npm:0.4.19"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~9.0.1
+  checksum: ca8b2fee430d450a18947786bfd7cd1a353ee00fc6fd550acbc8a8e65f1b4df5e9786fcb2990c1a5514ecd554d445fb74e1d716b3a4fcfffc10554aeb5db482b
+  languageName: node
+  linkType: hard
+
 "xml2js@npm:^0.4.16":
   version: 0.4.23
   resolution: "xml2js@npm:0.4.23"
@@ -31432,6 +31684,13 @@ __metadata:
   version: 11.0.1
   resolution: "xmlbuilder@npm:11.0.1"
   checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~9.0.1":
+  version: 9.0.7
+  resolution: "xmlbuilder@npm:9.0.7"
+  checksum: 8193bb323806a002764f013bea0c6e9ff2dc26fd29109408761b16b59a8ad2214c2abe8e691755fd8b525586e3a0e1efeb92335947d7b0899032b779f1705a53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upload assets on `afterEmit` to an s3 compatible service.

Example usage:

```ts
  app.s3
    .setKey(`ABCDEFGHIJKLMNOPQRSTUVWXYZ`)
    .setSecret(`***********************`)
    .setBucket(`bud-test`)
    .setEndpoint(`https://sfo2.digitaloceanspaces.com`)
    .setCache(`max-age=31536000`)
    .enable()
```

Works with `env`:

```ts
S3_KEY=
S3_SECRET=
S3_REGION=
S3_ENDPOINT=
S3_BUCKET=
S3_PREFIX=
```

todo:

- [ ] unit test
- [ ] i think `merged-manifest-webpack-plugin` (used by @roots/sage) merges the manifests _after_ webpack is done
- [ ] it would be cool if this tied into `publicPath` somehow?

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
