### PR TITLE
🩹 improve(none): intercept stdout/stderr

### DIFF
--- a/sources/@roots/bud-dashboard/src/render/renderer.tsx
+++ b/sources/@roots/bud-dashboard/src/render/renderer.tsx
@@ -1,5 +1,5 @@
 import type {Bud} from '@roots/bud-framework'
-import {render, Static} from '@roots/bud-support/ink'
+import {Box, render, Static} from '@roots/bud-support/ink'
 import React from '@roots/bud-support/react'
 import type {StatsCompilation} from 'webpack'
 
@@ -23,21 +23,23 @@ export const renderDashboard = ({
     : [stats]
 
   return render(
-    app.isProduction ? (
-      <Static items={[0]}>
-        {i => <App key={i} compilations={compilations} app={app} />}
-      </Static>
-    ) : process.stdout.isTTY ? (
-      <TTYApp App={App} app={app} compilations={compilations} />
-    ) : (
-      <App
-        app={app}
-        compilations={compilations}
-        isTTY={false}
-        displayAssets
-        displayEntrypoints
-        displayServerInfo
-      />
-    ),
+    <Box flexDirection="column">
+      {app.isProduction ? (
+        <Static items={[0]}>
+          {i => <App key={i} compilations={compilations} app={app} />}
+        </Static>
+      ) : process.stdout.isTTY ? (
+        <TTYApp App={App} app={app} compilations={compilations} />
+      ) : (
+        <App
+          app={app}
+          compilations={compilations}
+          isTTY={false}
+          displayAssets
+          displayEntrypoints
+          displayServerInfo
+        />
+      )}
+    </Box>,
   )
 }

--- a/sources/@roots/bud-framework/package.json
+++ b/sources/@roots/bud-framework/package.json
@@ -149,6 +149,7 @@
     "import-meta-resolve": "2.1.0",
     "js-yaml": "4.1.0",
     "json5": "2.2.1",
+    "patch-console": "2.0.0",
     "safe-json-stringify": "1.2.0",
     "signale": "1.4.0",
     "tslib": "2.4.0"

--- a/sources/@roots/bud-framework/package.json
+++ b/sources/@roots/bud-framework/package.json
@@ -100,15 +100,8 @@
       "services": [
         "./lib/types/services/index.d.ts"
       ],
-      "services/api": [
-        "./lib/services/api.d.ts"
-      ],
-      "services/extensions": [
-        "./lib/services/extensions.d.ts"
-      ],
       "services/*": [
-        "./lib/types/services/*.d.ts",
-        "./lib/types/services/*/index.d.ts"
+        "./lib/types/services/*.d.ts"
       ],
       "registry": [
         "./lib/types/registry/index.d.ts"
@@ -149,7 +142,6 @@
     "import-meta-resolve": "2.1.0",
     "js-yaml": "4.1.0",
     "json5": "2.2.1",
-    "patch-console": "2.0.0",
     "safe-json-stringify": "1.2.0",
     "signale": "1.4.0",
     "tslib": "2.4.0"

--- a/sources/@roots/bud-framework/package.json
+++ b/sources/@roots/bud-framework/package.json
@@ -100,8 +100,18 @@
       "services": [
         "./lib/types/services/index.d.ts"
       ],
+      "services/api": [
+        "./lib/services/api.d.ts"
+      ],
+      "services/extensions": [
+        "./lib/services/extensions.d.ts"
+      ],
+      "services/console": [
+        "./lib/services/console.d.ts"
+      ],
       "services/*": [
-        "./lib/types/services/*.d.ts"
+        "./lib/types/services/*.d.ts",
+        "./lib/types/services/*/index.d.ts"
       ],
       "registry": [
         "./lib/types/registry/index.d.ts"

--- a/sources/@roots/bud-framework/src/bud.ts
+++ b/sources/@roots/bud-framework/src/bud.ts
@@ -13,6 +13,7 @@ import type * as methods from './methods/index.js'
 import type {Module} from './module'
 import type * as Service from './service'
 import type * as Api from './services/api.js'
+import type ConsoleBuffer from './services/console'
 import type FS from './services/fs.js'
 import type * as Options from './types/options'
 import type * as Registry from './types/registry'
@@ -132,6 +133,14 @@ export class Bud {
     )
   }
 
+  public consoleBuffer: ConsoleBuffer
+
+  public fs: FS
+
+  public logger: Logger
+
+  public module: Module
+
   public services: Array<string> = []
 
   public api: Api.Service
@@ -148,15 +157,9 @@ export class Bud {
 
   public extensions: Services.Extensions.Service
 
-  public fs: FS
-
   public hooks: Services.Hooks.Service
 
   public project: Services.Project.Service
-
-  public logger: Logger
-
-  public module: Module
 
   public server: Services.Server.Service
 
@@ -212,6 +215,11 @@ export class Bud {
    */
   public yml: FS['yml']
 
+  /**
+   * Value helper
+   *
+   * @public
+   */
   public value = Value
 
   /**

--- a/sources/@roots/bud-framework/src/services/console.ts
+++ b/sources/@roots/bud-framework/src/services/console.ts
@@ -1,5 +1,5 @@
 import {bind} from '@roots/bud-support/decorators'
-import patchConsole from 'patch-console'
+import patchConsole from '@roots/bud-support/patch-console'
 
 import {Service} from '../service.js'
 

--- a/sources/@roots/bud-framework/src/services/console.ts
+++ b/sources/@roots/bud-framework/src/services/console.ts
@@ -1,0 +1,38 @@
+import {bind} from '@roots/bud-support/decorators'
+import patchConsole from 'patch-console'
+
+import {Service} from '../service.js'
+
+export default class ConsoleBuffer extends Service {
+  public static label = `consoleBuffer`
+
+  public messages: {stdout: string[]; stderr: string[]} = {
+    stdout: [],
+    stderr: [],
+  }
+
+  public restore: () => any
+
+  @bind
+  public async boot() {
+    if (this.app.context?.args?.ci) return
+
+    this.restore = patchConsole((stream, data) => {
+      const message = data.trim()
+
+      if (!message || message.length === 0) return
+      if (this.messages[stream].some(message => message === data)) return
+
+      this.app.logger
+        .makeInstance({
+          disabled: this.app.context.args?.log === false,
+          config: {displayLabel: false},
+          logLevel: `info`,
+        })
+        .scope(...this.app.logger.scope, stream)
+        [stream === `stdout` ? `log` : `error`](message)
+    })
+
+    this.app.hooks.action(`compiler.close`, this.restore)
+  }
+}

--- a/sources/@roots/bud-framework/src/types/services/dashboard.ts
+++ b/sources/@roots/bud-framework/src/types/services/dashboard.ts
@@ -10,8 +10,6 @@ import type {Service as Base} from '../../service'
 export interface Service extends Base {
   instance: any
 
-  log(...strings: Array<string>): unknown
-
   /**
    * Render the dashboard
    *

--- a/sources/@roots/bud-support/package.json
+++ b/sources/@roots/bud-support/package.json
@@ -134,7 +134,7 @@
     "lodash-es": "4.17.21",
     "parse5": "7.1.1",
     "parse5-htmlparser2-tree-adapter": "7.0.0",
-    "patch-console": "2.0.0",
+    "patch-console": "1.0.0",
     "pretty-format": "29.0.3",
     "react": "17.0.2",
     "typanion": "3.12.0",

--- a/sources/@roots/bud-support/package.json
+++ b/sources/@roots/bud-support/package.json
@@ -51,6 +51,7 @@
     "./ink-link": "./lib/dependencies/ink-link/index.js",
     "./ink-text-input": "./lib/dependencies/ink-text-input/index.js",
     "./lodash-es": "./lib/dependencies/lodash-es/index.js",
+    "./patch-console": "./lib/dependencies/patch-console/index.js",
     "./pretty-format": "./lib/dependencies/pretty-format/index.js",
     "./react": "./lib/dependencies/react/index.js",
     "./typanion": "./lib/dependencies/typanion/index.js"
@@ -99,6 +100,9 @@
       "lodash-es": [
         "./lib/dependencies/lodash-es/index.d.ts"
       ],
+      "patch-console": [
+        "./lib/dependencies/patch-console/index.d.ts"
+      ],
       "pretty-format": [
         "./lib/dependencies/pretty-format/index.d.ts"
       ],
@@ -130,6 +134,7 @@
     "lodash-es": "4.17.21",
     "parse5": "7.1.1",
     "parse5-htmlparser2-tree-adapter": "7.0.0",
+    "patch-console": "2.0.0",
     "pretty-format": "29.0.3",
     "react": "17.0.2",
     "typanion": "3.12.0",

--- a/sources/@roots/bud-support/src/dependencies/patch-console/index.ts
+++ b/sources/@roots/bud-support/src/dependencies/patch-console/index.ts
@@ -1,0 +1,3 @@
+import patchConsole from 'patch-console'
+
+export default patchConsole

--- a/sources/@roots/bud/src/context/services.ts
+++ b/sources/@roots/bud/src/context/services.ts
@@ -11,5 +11,6 @@ export default class Services {
     `@roots/bud-server`,
     `@roots/bud/services/project`,
     `@roots/bud-framework/services/fs`,
+    `@roots/bud-framework/services/console`,
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5801,7 +5801,6 @@ __metadata:
     import-meta-resolve: 2.1.0
     js-yaml: 4.1.0
     json5: 2.2.1
-    patch-console: 2.0.0
     safe-json-stringify: 1.2.0
     signale: 1.4.0
     tslib: 2.4.0
@@ -6235,6 +6234,7 @@ __metadata:
     lodash-es: 4.17.21
     parse5: 7.1.1
     parse5-htmlparser2-tree-adapter: 7.0.0
+    patch-console: 2.0.0
     pretty-format: 29.0.3
     react: 17.0.2
     typanion: 3.12.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7284,7 +7284,6 @@ __metadata:
     "@roots/bud-eslint": "workspace:sources/@roots/bud-eslint"
     "@roots/bud-preset-recommend": "workspace:sources/@roots/bud-preset-recommend"
     "@roots/bud-tailwindcss": "workspace:sources/@roots/bud-tailwindcss"
-    daisyui: 2.31.0
   languageName: unknown
   linkType: soft
 
@@ -12351,7 +12350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.6.0, color-string@npm:^1.9.0":
+"color-string@npm:^1.6.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
   dependencies:
@@ -12377,16 +12376,6 @@ __metadata:
     color-convert: ^1.9.3
     color-string: ^1.6.0
   checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
-  languageName: node
-  linkType: hard
-
-"color@npm:^4.2":
-  version: 4.2.3
-  resolution: "color@npm:4.2.3"
-  dependencies:
-    color-convert: ^2.0.1
-    color-string: ^1.9.0
-  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -13229,16 +13218,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-selector-tokenizer@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "css-selector-tokenizer@npm:0.8.0"
-  dependencies:
-    cssesc: ^3.0.0
-    fastparse: ^1.1.2
-  checksum: 1eb7ca7d2c21ede700a0fab7df4547198431c30ba62663d81a566a8abe6ab7524f627ce6c0bde63f34917e199b73be4081e449bd8faf107d155766204082aa0a
-  languageName: node
-  linkType: hard
-
 "css-tree@npm:1.0.0-alpha.28":
   version: 1.0.0-alpha.28
   resolution: "css-tree@npm:1.0.0-alpha.28"
@@ -13475,21 +13454,6 @@ __metadata:
     es5-ext: ^0.10.50
     type: ^1.0.1
   checksum: 49ca0639c7b822db670de93d4fbce44b4aa072cd848c76292c9978a8cd0fff1028763020ff4b0f147bd77bfe29b4c7f82e0f71ade76b2a06100543cdfd948d19
-  languageName: node
-  linkType: hard
-
-"daisyui@npm:2.31.0":
-  version: 2.31.0
-  resolution: "daisyui@npm:2.31.0"
-  dependencies:
-    color: ^4.2
-    css-selector-tokenizer: ^0.8.0
-    postcss-js: ^4.0.0
-    tailwindcss: ^3
-  peerDependencies:
-    autoprefixer: ^10.0.2
-    postcss: ^8.1.6
-  checksum: ad802f0f03ab0c0cdae745dda567f0415e475f66d933801a974ff5ba369fb9f302693dd14e306956d5b7653763badc738fed8eea201b182ecb13a3142c6b47e7
   languageName: node
   linkType: hard
 
@@ -16093,13 +16057,6 @@ __metadata:
   version: 1.0.12
   resolution: "fastest-levenshtein@npm:1.0.12"
   checksum: e1a013698dd1d302c7a78150130c7d50bb678c2c2f8839842a796d66cc7cdf50ea6b3d7ca930b0c8e7e8c2cd84fea8ab831023b382f7aab6922c318c1451beab
-  languageName: node
-  linkType: hard
-
-"fastparse@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "fastparse@npm:1.1.2"
-  checksum: c4d199809dc4e8acafeb786be49481cc9144de296e2d54df4540ccfd868d0df73afc649aba70a748925eb32bbc4208b723d6288adf92382275031a8c7e10c0aa
   languageName: node
   linkType: hard
 
@@ -29929,7 +29886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3, tailwindcss@npm:^3.1.8":
+"tailwindcss@npm:^3.1.8":
   version: 3.1.8
   resolution: "tailwindcss@npm:3.1.8"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6234,7 +6234,7 @@ __metadata:
     lodash-es: 4.17.21
     parse5: 7.1.1
     parse5-htmlparser2-tree-adapter: 7.0.0
-    patch-console: 2.0.0
+    patch-console: 1.0.0
     pretty-format: 29.0.3
     react: 17.0.2
     typanion: 3.12.0
@@ -24539,14 +24539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"patch-console@npm:2.0.0":
-  version: 2.0.0
-  resolution: "patch-console@npm:2.0.0"
-  checksum: 10e7d382cc1cf930a2114a822cdc816109a1147bcbc4881ca4fa2ad0228a60cf14d53f815fce3164f25851fea71db4026ae8271e4026b42b0a6e92ddc074d4c2
-  languageName: node
-  linkType: hard
-
-"patch-console@npm:^1.0.0":
+"patch-console@npm:1.0.0, patch-console@npm:^1.0.0":
   version: 1.0.0
   resolution: "patch-console@npm:1.0.0"
   checksum: 8cd738aa470f2e9463fca35da6a19403384ac555004f698ddd3dfdb69135ab60fe9bd2edd1dbdd8c09d92c0a2190fd0f7337fe48123013baf8ffec8532885a3a

--- a/yarn.lock
+++ b/yarn.lock
@@ -5801,6 +5801,7 @@ __metadata:
     import-meta-resolve: 2.1.0
     js-yaml: 4.1.0
     json5: 2.2.1
+    patch-console: 2.0.0
     safe-json-stringify: 1.2.0
     signale: 1.4.0
     tslib: 2.4.0
@@ -7283,6 +7284,7 @@ __metadata:
     "@roots/bud-eslint": "workspace:sources/@roots/bud-eslint"
     "@roots/bud-preset-recommend": "workspace:sources/@roots/bud-preset-recommend"
     "@roots/bud-tailwindcss": "workspace:sources/@roots/bud-tailwindcss"
+    daisyui: 2.31.0
   languageName: unknown
   linkType: soft
 
@@ -12349,7 +12351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-string@npm:^1.6.0":
+"color-string@npm:^1.6.0, color-string@npm:^1.9.0":
   version: 1.9.1
   resolution: "color-string@npm:1.9.1"
   dependencies:
@@ -12375,6 +12377,16 @@ __metadata:
     color-convert: ^1.9.3
     color-string: ^1.6.0
   checksum: f81220e8b774d35865c2561be921f5652117638dcda7ca4029262046e37fc2444ac7bbfdd110cf1fd9c074a4ee5eda8f85944ffbdda26186b602dd9bb05f6400
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -13217,6 +13229,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-selector-tokenizer@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "css-selector-tokenizer@npm:0.8.0"
+  dependencies:
+    cssesc: ^3.0.0
+    fastparse: ^1.1.2
+  checksum: 1eb7ca7d2c21ede700a0fab7df4547198431c30ba62663d81a566a8abe6ab7524f627ce6c0bde63f34917e199b73be4081e449bd8faf107d155766204082aa0a
+  languageName: node
+  linkType: hard
+
 "css-tree@npm:1.0.0-alpha.28":
   version: 1.0.0-alpha.28
   resolution: "css-tree@npm:1.0.0-alpha.28"
@@ -13453,6 +13475,21 @@ __metadata:
     es5-ext: ^0.10.50
     type: ^1.0.1
   checksum: 49ca0639c7b822db670de93d4fbce44b4aa072cd848c76292c9978a8cd0fff1028763020ff4b0f147bd77bfe29b4c7f82e0f71ade76b2a06100543cdfd948d19
+  languageName: node
+  linkType: hard
+
+"daisyui@npm:2.31.0":
+  version: 2.31.0
+  resolution: "daisyui@npm:2.31.0"
+  dependencies:
+    color: ^4.2
+    css-selector-tokenizer: ^0.8.0
+    postcss-js: ^4.0.0
+    tailwindcss: ^3
+  peerDependencies:
+    autoprefixer: ^10.0.2
+    postcss: ^8.1.6
+  checksum: ad802f0f03ab0c0cdae745dda567f0415e475f66d933801a974ff5ba369fb9f302693dd14e306956d5b7653763badc738fed8eea201b182ecb13a3142c6b47e7
   languageName: node
   linkType: hard
 
@@ -16056,6 +16093,13 @@ __metadata:
   version: 1.0.12
   resolution: "fastest-levenshtein@npm:1.0.12"
   checksum: e1a013698dd1d302c7a78150130c7d50bb678c2c2f8839842a796d66cc7cdf50ea6b3d7ca930b0c8e7e8c2cd84fea8ab831023b382f7aab6922c318c1451beab
+  languageName: node
+  linkType: hard
+
+"fastparse@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "fastparse@npm:1.1.2"
+  checksum: c4d199809dc4e8acafeb786be49481cc9144de296e2d54df4540ccfd868d0df73afc649aba70a748925eb32bbc4208b723d6288adf92382275031a8c7e10c0aa
   languageName: node
   linkType: hard
 
@@ -24538,6 +24582,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"patch-console@npm:2.0.0":
+  version: 2.0.0
+  resolution: "patch-console@npm:2.0.0"
+  checksum: 10e7d382cc1cf930a2114a822cdc816109a1147bcbc4881ca4fa2ad0228a60cf14d53f815fce3164f25851fea71db4026ae8271e4026b42b0a6e92ddc074d4c2
+  languageName: node
+  linkType: hard
+
 "patch-console@npm:^1.0.0":
   version: 1.0.0
   resolution: "patch-console@npm:1.0.0"
@@ -29878,7 +29929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.1.8":
+"tailwindcss@npm:^3, tailwindcss@npm:^3.1.8":
   version: 3.1.8
   resolution: "tailwindcss@npm:3.1.8"
   dependencies:


### PR DESCRIPTION
Prevent duplicative terminal logs by capturing console messages and sending them to bud logger.

- creates a new service: `@roots/bud-framework/services/consoleBuffer`
- restores console methods on `compiler.close`
- console can be restored early with `bud.consoleBuffer.restore()`
- adds a debounce to `bud.dashboard.stats` to prevent duplicative calls from webpack

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
