### PR TITLE
🩹 fix: unresolvable optional dependency causes error

### DIFF
--- a/sources/@roots/bud-framework/src/services/extensions.ts
+++ b/sources/@roots/bud-framework/src/services/extensions.ts
@@ -67,8 +67,6 @@ export abstract class Service extends BaseService implements Base.Service {
 
   public abstract isAllowed(signifier: string): boolean
 
-  public abstract isDirectDependency(signifier: string): boolean
-
   /**
    * @public
    */


### PR DESCRIPTION
Didn't catch this until doing e2e tests because deps are always resolved in the context of the repo. This stops optional dependencies which are not available from causing a TypeError.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
