### PR TITLE
🩹fix(patch): script inject in multi-compiler w/ default entry

### DIFF
--- a/sources/@roots/bud-server/src/inject.ts
+++ b/sources/@roots/bud-server/src/inject.ts
@@ -1,5 +1,4 @@
 import type {Bud} from '@roots/bud-framework'
-import {isNull, isUndefined} from '@roots/bud-support/lodash-es'
 
 /**
  * Inject webpack entrypoints with client scripts

--- a/sources/@roots/bud-server/src/inject.ts
+++ b/sources/@roots/bud-server/src/inject.ts
@@ -11,14 +11,9 @@ export const inject = (
   injection: Array<(app: Bud) => string>,
 ): void => {
   app.hooks.on(`build.entry`, entrypoints => {
-    if (!injection) return
+    if (!injection) return entrypoints
 
-    if (app.isRoot) {
-      const missing =
-        !entrypoints || isUndefined(entrypoints) || isNull(entrypoints)
-
-      entrypoints = missing ? {app: {import: [`index`]}} : entrypoints
-    }
+    entrypoints = !entrypoints ? {app: {import: [`index`]}} : entrypoints
 
     return Object.entries(entrypoints).reduce(
       (entrypoints, [name, entry]) => {


### PR DESCRIPTION
Pretty specific bug:

- Create a child instance of bud with `bud.make`. Do not call `bud.entry` in the child context (this will use the default `src/index` as the child entrypoint).
- Invoke `bud build development`
- Error

## Reproduction budfile

```ts
export default async bud => {
  await bud.make(`child`)
}
```

## Cause

TypeError. The client injection script attempts to reduce the output of the `build.entrypoints` filter, but `entrypoints` is `undefined`.

## Fix

Reduce complexity of fn.

- It doesn't matter whether this is called on the parent or a child.
  - Bud doesn't support entrypoints on the parent but it doesn't matter here
  - We can just add the entrypoints; they will be discarded by `@roots/bud-compiler` anyway.
- If `entrypoints` doesn't exist then we set it as `{main: "index.js"}` explicitly. This would have been the default, but now we have an injection target.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
