### PR TITLE
🩹 fix(patch): bud.esm bindings

### DIFF
--- a/sources/@repo/docs/content/guides/extending/index.mdx
+++ b/sources/@repo/docs/content/guides/extending/index.mdx
@@ -208,7 +208,7 @@ export default class MyExtension extends Extension {
 }
 ```
 
-### afterConfig
+### configAfter
 
 Async callback. Called after user configuration has been processed.
 
@@ -219,13 +219,13 @@ import {Extension} from '@roots/bud-framework/extension'
 export default class MyExtension extends Extension {
   public label = 'bud-extension'
 
-  public async afterConfig(app, options) {
+  public async configAfter(app, options) {
     // do something
   }
 }
 ```
 
-### beforeBuild
+### buildBefore
 
 Async callback. Called directly before configuration is constructed and passed to the compiler).
 
@@ -236,7 +236,7 @@ import {Extension} from '@roots/bud-framework/extension'
 export default class MyExtension extends Extension {
   public label = 'bud-extension'
 
-  public async beforeBuild(app, options) {
+  public async buildBefore(app, options) {
     // do something
   }
 }
@@ -342,3 +342,57 @@ export default class MyExtension extends Extension {
 ```
 
 When present **bud.js** will pass the extension itself to the compiler's `plugin` array.
+
+### when
+
+A callback that returns a boolean. The extension will be registered regardless of the value returned by this function, but certain methods
+will not be called if this function returns `false`.
+
+This function is passed `bud` and the resolved extension `options`.
+
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async when(app, options) {
+    return app.isProduction && options.set.size > 0
+  }
+}
+```
+
+If `Extension.when` returns `false` the following methods will be discarded:
+
+- [buildBefore](#buildBefore)
+- [buildAfter](#buildafter)
+- [configAfter](#configAfter)
+- [make](#make)
+
+`Extension.enabled` (a simple `boolean`) will always take precedence over `Extension.when` if it is set.
+
+```ts title="extension.ts"
+import {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+export default class MyExtension extends Extension {
+  public label = 'bud-extension'
+
+  public async register(app, options) {
+    // this overrides `when`
+    this.enabled = true
+  }
+
+  /**
+   * This function will never be called because {@link Extension.enabled}
+   * was set to `true` in {@link Extension.register}.
+   */
+  public async when(app, options) {
+    return app.isProduction && options.set.size > 0
+  }
+}
+```
+
+This is by design; it makes it more straight-forward for the consuming developer to reason about enabling or disabling
+particular extensions should they wish to override your implementation.

--- a/sources/@repo/docs/content/guides/extending/lifecycle.mdx
+++ b/sources/@repo/docs/content/guides/extending/lifecycle.mdx
@@ -60,6 +60,8 @@ export default class MyExtension extends Extension {
 
 Async callback. Called after user configuration has been processed.
 
+This function is not called if either the value of `Extension.enabled` is `false` or `Extension.when` returns `false`.
+
 ```ts title="extension.ts"
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
@@ -77,6 +79,8 @@ export default class MyExtension extends Extension {
 
 Async callback. Called directly before configuration is constructed and passed to the compiler.
 
+This function is not called if either the value of `Extension.enabled` is `false` or `Extension.when` returns `false`.
+
 ```ts title="extension.ts"
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
@@ -93,6 +97,8 @@ export default class MyExtension extends Extension {
 ### buildAfter
 
 Async callback. Called directly after configuration is produced.
+
+This function is not called if either the value of `Extension.enabled` is `false` or `Extension.when` returns `false`.
 
 ```ts title="extension.ts"
 import {Bud} from '@roots/bud-framework'

--- a/sources/@repo/docs/content/releases/6.5.2.mdx
+++ b/sources/@repo/docs/content/releases/6.5.2.mdx
@@ -10,14 +10,18 @@ author_image_url: https://avatars.githubusercontent.com/u/397606?v=4
 tags: [release, 6.5]
 ---
 
-Bug fix for multi-compiler builds.
+Bug fix for multi-instance builds.
 
 <!--truncate-->
 
-## Fix: Client script injection in multi-compiler when no entrypoints are specified
+## Fix: Client script injection TypeError when no entrypoints are specified
 
 Specifying an entrypoint is optional and, accordingly, its value may very well return `undefined`.
 This possibility was not handled correctly by `@roots/bud-server/inject` for multi-instance configurations, and would throw a `TypeError` if a child didn't explicitly set an instance. This is now fixed.
+
+## Fix: Certain conditionally applied extensions enabled/disabled globally in multi-instance
+
+In multi-instance configurations the last call to `Extension.enable()` or `Extension.disable()` would be applied to all instances. This has been fixed.
 
 ## ℹ️ Release information
 

--- a/sources/@repo/test-kit/package.json
+++ b/sources/@repo/test-kit/package.json
@@ -23,6 +23,7 @@
     "@repo/constants": "workspace:sources/@repo/constants",
     "@repo/logger": "workspace:sources/@repo/logger",
     "@roots/bud": "workspace:sources/@roots/bud",
+    "@roots/bud-api": "workspace:sources/@roots/bud-api",
     "@roots/bud-compiler": "workspace:sources/@roots/bud-compiler",
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework",
     "@types/fs-extra": "9.0.13",

--- a/sources/@repo/test-kit/tsconfig.json
+++ b/sources/@repo/test-kit/tsconfig.json
@@ -5,6 +5,7 @@
     "types": [
       "node",
       "jest",
+      "@roots/bud-api",
       "@roots/bud",
       "@roots/bud-framework"
     ],
@@ -15,6 +16,7 @@
   "exclude": ["node_modules"],
   "references": [
     {"path": "./../../@roots/bud/tsconfig.json"},
+    {"path": "./../../@roots/bud-api/tsconfig.json"},
     {"path": "./../../@roots/bud-framework/tsconfig.json"},
     {"path": "./../../@roots/bud-compiler/tsconfig.json"},
   ]

--- a/sources/@roots/bud-api/src/methods/template/interpolate-html-plugin.extension.ts
+++ b/sources/@roots/bud-api/src/methods/template/interpolate-html-plugin.extension.ts
@@ -3,7 +3,6 @@ import {
   bind,
   label,
   options,
-  when,
 } from '@roots/bud-framework/extension/decorators'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 
@@ -16,7 +15,6 @@ import InterpolateHtmlPlugin from './interpolate-html-plugin.plugin.js'
  * @decorator `@label`
  */
 @label(`interpolate-html-plugin`)
-@when(async () => true)
 @options({})
 export default class BudInterpolateHtmlPlugin extends Extension<
   Record<string, RegExp>,

--- a/sources/@roots/bud-criticalcss/src/extension.ts
+++ b/sources/@roots/bud-criticalcss/src/extension.ts
@@ -1,11 +1,11 @@
 import type {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import {
+  disabled,
   expose,
   label,
   options,
   plugin,
-  when,
 } from '@roots/bud-framework/extension/decorators'
 import CriticalCssWebpackPlugin, {
   Options,
@@ -41,7 +41,7 @@ import CriticalCssWebpackPlugin, {
       : `/`,
   request: {https: {rejectUnauthorized: false}},
 })
-@when(async () => false)
+@disabled
 export default class BudCriticalCss extends Extension<
   Options,
   CriticalCssWebpackPlugin

--- a/sources/@roots/bud-framework/src/bud.ts
+++ b/sources/@roots/bud-framework/src/bud.ts
@@ -248,7 +248,7 @@ export class Bud {
       return this.get(context.label)
     }
 
-    this.log(`instantiating bud`, context)
+    this.log(`instantiating new bud instance`)
     const child = await new Bud().lifecycle(context)
 
     if (!this.children) this.children = {[context.label]: child}

--- a/sources/@roots/bud-framework/src/extension/decorators/disabled.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/disabled.ts
@@ -1,0 +1,27 @@
+/**
+ * Extension disabled by default
+ *
+ * @remarks
+ * Class decorator.
+ *
+ * Use for plugins and extensions which are chonky and not strictly
+ * required for the application to function (minimizers, etc.)
+ *
+ * @public
+ */
+export const disabled = <Extension extends {new (...args: any[]): any}>(
+  constructor: Extension,
+) =>
+  class extends constructor {
+    public declare enabled: boolean
+
+    /**
+     * Class constructor
+     *
+     * @public
+     */
+    public constructor(...args: any[]) {
+      super(...args)
+      this.enabled = false
+    }
+  }

--- a/sources/@roots/bud-framework/src/extension/decorators/index.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/index.ts
@@ -3,6 +3,7 @@ import {bind, once} from '@roots/bud-support/decorators'
 import {dependsOn} from './dependsOn.js'
 import {dependsOnOptional} from './dependsOnOptional.js'
 import {development} from './development.js'
+import {disabled} from './disabled.js'
 import {expose} from './expose.js'
 import {label} from './label.js'
 import {options} from './options.js'
@@ -16,6 +17,7 @@ export {
   dependsOnOptional,
   dependsOn,
   development,
+  disabled,
   expose,
   label,
   once,

--- a/sources/@roots/bud-framework/src/extension/decorators/when.test.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/when.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {when} from './when'
+
+@when(async () => true)
+// @ts-ignore
+class TestClass {}
+
+describe(`when`, () => {
+  it(`should return a decorator`, async () => {
+    expect(when(async () => true)).toBeInstanceOf(Function)
+  })
+
+  it(`should add a when property to the class`, async () => {
+    // @ts-ignore
+    expect(new TestClass().when).toBeInstanceOf(Function)
+    // @ts-ignore
+    expect(await new TestClass().when()).toBe(true)
+  })
+})

--- a/sources/@roots/bud-framework/src/extension/decorators/when.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/when.ts
@@ -4,5 +4,10 @@ export const when =
   (when: Extension['when']) =>
   <Type extends {new (...args: any[]): any}>(constructor: Type) =>
     class extends constructor {
-      public when = when
+      public when: Extension[`when`]
+
+      public constructor(...args: any[]) {
+        super(...args)
+        this.when = when.bind ? when.bind(this) : when
+      }
     }

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -223,16 +223,6 @@ export class Extension<
     options?: ExtensionOptions,
   ): Promise<unknown>
 
-  public async compilerBefore?(
-    app: Bud,
-    options?: ExtensionOptions,
-  ): Promise<unknown>
-
-  public async compilerAfter?(
-    app: Bud,
-    options?: ExtensionOptions,
-  ): Promise<unknown>
-
   /**
    * `make` callback
    *
@@ -276,14 +266,14 @@ export class Extension<
         ),
     })
 
-    const opts = this.options ?? {}
+    const options = this.options ?? {}
 
     Object.defineProperty(this, `options`, {
       get: this.getOptions,
       set: this.setOptions,
     })
 
-    this.setOptions(opts as any)
+    this.setOptions(options as any)
   }
 
   /**
@@ -356,10 +346,12 @@ export class Extension<
    */
   @bind
   public async _buildBefore() {
+    if (this.meta[`buildBefore`]) return
+    this.meta[`buildBefore`] = true
+
     const enabled = await this.isEnabled()
     if (isUndefined(this.buildBefore) || enabled === false) return
     this.logger.log(`buildBefore`)
-    this.meta[`buildBefore`] = true
 
     await this.buildBefore(this.app, this.options)
   }
@@ -371,10 +363,12 @@ export class Extension<
    */
   @bind
   public async _buildAfter() {
+    if (this.meta[`buildAfter`]) return
+    this.meta[`buildAfter`] = true
+
     const enabled = await this.isEnabled()
     if (isUndefined(this.buildAfter) || enabled === false) return
     this.logger.log(`buildAfter`)
-    this.meta[`buildAfter`] = true
 
     await this.buildAfter(this.app, this.options)
   }
@@ -386,10 +380,12 @@ export class Extension<
    */
   @bind
   public async _configAfter() {
+    if (this.meta[`configAfter`]) return
+    this.meta[`configAfter`] = true
+
     const enabled = await this.isEnabled()
     if (isUndefined(this.configAfter) || enabled === false) return
     this.logger.log(`configAfter`)
-    this.meta[`configAfter`] = true
 
     await this.configAfter(this.app, this.options)
   }

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -151,7 +151,7 @@ export class Extension<
     _app: Bud,
     _options?: ExtensionOptions,
   ): Promise<boolean> {
-    return this.enabled
+    return !isUndefined(this.enabled) ? this.enabled : true
   }
 
   /**

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -266,14 +266,14 @@ export class Extension<
         ),
     })
 
-    const options = this.options ?? {}
+    const opts = this.options ?? {}
 
     Object.defineProperty(this, `options`, {
       get: this.getOptions,
       set: this.setOptions,
     })
 
-    this.setOptions(options as any)
+    this.setOptions(opts as any)
   }
 
   /**
@@ -304,16 +304,17 @@ export class Extension<
   @bind
   public async _register() {
     if (isUndefined(this.register)) return
-    this.logger.log(`registered`)
 
-    if (this.init && !this.meta[`init`]) await this._init()
-    this.meta[`register`] = true
+    if (!this.meta[`init`]) await this._init()
 
     try {
       await this.register(this.app, this.options)
+      this.meta[`register`] = true
     } catch (error) {
       throw error
     }
+
+    this.logger.success(`registered`)
   }
 
   /**
@@ -326,10 +327,8 @@ export class Extension<
   public async _boot() {
     if (isUndefined(this.boot)) return
 
-    if (this.init && !this.meta[`init`]) await this._init()
-    if (this.register && !this.meta[`register`]) await this._register()
-
-    this.logger.log(`booted`)
+    if (!this.meta[`init`]) await this._init()
+    if (!this.meta[`register`]) await this._register()
 
     try {
       await this.boot(this.app, this.options)
@@ -337,6 +336,8 @@ export class Extension<
     } catch (error) {
       throw error
     }
+
+    this.logger.success(`booted`)
   }
 
   /**
@@ -346,12 +347,10 @@ export class Extension<
    */
   @bind
   public async _buildBefore() {
-    if (this.meta[`buildBefore`]) return
-    this.meta[`buildBefore`] = true
-
     const enabled = await this.isEnabled()
     if (isUndefined(this.buildBefore) || enabled === false) return
     this.logger.log(`buildBefore`)
+    this.meta[`buildBefore`] = true
 
     await this.buildBefore(this.app, this.options)
   }
@@ -363,12 +362,10 @@ export class Extension<
    */
   @bind
   public async _buildAfter() {
-    if (this.meta[`buildAfter`]) return
-    this.meta[`buildAfter`] = true
-
     const enabled = await this.isEnabled()
     if (isUndefined(this.buildAfter) || enabled === false) return
     this.logger.log(`buildAfter`)
+    this.meta[`buildAfter`] = true
 
     await this.buildAfter(this.app, this.options)
   }
@@ -380,12 +377,10 @@ export class Extension<
    */
   @bind
   public async _configAfter() {
-    if (this.meta[`configAfter`]) return
-    this.meta[`configAfter`] = true
-
     const enabled = await this.isEnabled()
     if (isUndefined(this.configAfter) || enabled === false) return
     this.logger.log(`configAfter`)
+    this.meta[`configAfter`] = true
 
     await this.configAfter(this.app, this.options)
   }

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -384,6 +384,8 @@ export class Extension<
   public async _configAfter() {
     const enabled = await this.isEnabled()
     if (isUndefined(this.configAfter) || enabled === false) return
+    this.logger.log(`configAfter`)
+    this.meta[`configAfter`] = true
 
     await this.configAfter(this.app, this.options)
   }
@@ -650,7 +652,9 @@ export class Extension<
    */
   @bind
   public disable() {
-    this.when = async () => false
+    this.when = function () {
+      return false
+    }.bind(this)
   }
 
   /**
@@ -661,7 +665,9 @@ export class Extension<
    */
   @bind
   public enable() {
-    this.when = async () => true
+    this.when = function () {
+      return true
+    }.bind(this)
   }
 
   /**
@@ -672,11 +678,10 @@ export class Extension<
    */
   @bind
   public async isEnabled(): Promise<boolean> {
-    if (isUndefined(this.when)) return true
-    if (isBoolean(this.when)) return this.when as unknown as boolean
     if (isFunction(this.when))
       return await this.when(this.app, this.options)
-
+    if (isUndefined(this.when)) return true
+    if (isBoolean(this.when)) return this.when as unknown as boolean
     return true
   }
 

--- a/sources/@roots/bud-framework/src/lifecycle/init.ts
+++ b/sources/@roots/bud-framework/src/lifecycle/init.ts
@@ -80,6 +80,7 @@ export const initialize = (app: Bud): Bud =>
         app.hooks.filter(`feature.hash`)
           ? `js/dynamic/[id].[contenthash:6].js`
           : `js/dynamic/[id].js`,
+      'build.output.clean': () => app.isProduction,
       'build.output.filename': () => join(`js`, filenameFormat(app)),
       'build.output.path': () => app.path(`@dist`),
       'build.output.publicPath': `auto`,

--- a/sources/@roots/bud-hooks/src/service.ts
+++ b/sources/@roots/bud-hooks/src/service.ts
@@ -91,6 +91,7 @@ export default class Hooks extends Service implements HooksInterface {
     super(app)
 
     this.syncStore = new SyncHooks(app)
+
     this.on = this.syncStore.set
     this.hasSyncHook = this.syncStore.has
     this.filter = this.syncStore.get

--- a/sources/@roots/bud-terser/src/css-minimizer/extension.ts
+++ b/sources/@roots/bud-terser/src/css-minimizer/extension.ts
@@ -1,10 +1,10 @@
 import {Extension} from '@roots/bud-framework/extension'
 import {
   bind,
+  disabled,
   expose,
   label,
   options,
-  when,
 } from '@roots/bud-framework/extension/decorators'
 import Plugin from 'css-minimizer-webpack-plugin'
 
@@ -15,6 +15,7 @@ import Plugin from 'css-minimizer-webpack-plugin'
  * @decorator `@label`
  * @decorator `@expose`
  * @decorator `@options`
+ * @decorator `@disabled`
  */
 @label(`@roots/bud-terser/css-minimizer`)
 @expose(`minimizeCss`)
@@ -30,7 +31,7 @@ import Plugin from 'css-minimizer-webpack-plugin'
     ],
   },
 })
-@when(async () => false)
+@disabled
 export default class BudMinimizeCSS extends Extension {
   /**
    * `buildBefore` callback

--- a/sources/@roots/bud-terser/src/extension.ts
+++ b/sources/@roots/bud-terser/src/extension.ts
@@ -3,10 +3,10 @@ import {
   bind,
   dependsOn,
   dependsOnOptional,
+  disabled,
   expose,
   label,
   options,
-  when,
 } from '@roots/bud-framework/extension/decorators'
 import TerserPlugin from 'terser-webpack-plugin'
 
@@ -31,6 +31,7 @@ export type Options = TerserPlugin.BasePluginOptions & {
  * @decorator `@label`
  * @decorator `@expose`
  * @decorator `@options`
+ * @decorator `@disabled`
  */
 @label(`@roots/bud-terser`)
 @dependsOn([`@roots/bud-terser/css-minimizer`])
@@ -55,7 +56,7 @@ export type Options = TerserPlugin.BasePluginOptions & {
     },
   },
 })
-@when(async () => false)
+@disabled
 export default class Terser extends Extension<Options> {
   /**
    * Terser options getter/setter

--- a/sources/@roots/bud-typescript/src/typecheck/index.ts
+++ b/sources/@roots/bud-typescript/src/typecheck/index.ts
@@ -1,10 +1,10 @@
 import {Extension} from '@roots/bud-framework'
 import {
   bind,
+  disabled,
   label,
   options,
   plugin,
-  when,
 } from '@roots/bud-framework/extension/decorators'
 import Plugin from 'fork-ts-checker-webpack-plugin'
 import type {ForkTsCheckerWebpackPluginOptions as Options} from 'fork-ts-checker-webpack-plugin/lib/plugin-options.js'
@@ -21,7 +21,7 @@ import type {ForkTsCheckerWebpackPluginOptions as Options} from 'fork-ts-checker
     mode: `readonly`,
   }),
 })
-@when(async () => false)
+@disabled
 export default class BudTypeCheckPlugin extends Extension<
   Options,
   Plugin

--- a/sources/@roots/bud/src/bud.ts
+++ b/sources/@roots/bud/src/bud.ts
@@ -1,6 +1,4 @@
-import type Api from '@roots/bud-api'
 import * as Framework from '@roots/bud-framework'
-import type Hooks from '@roots/bud-hooks'
 
 /**
  * ⚡️ Bud
@@ -8,7 +6,5 @@ import type Hooks from '@roots/bud-hooks'
  * @public
  */
 export default class Bud extends Framework.Bud {
-  public declare api: Api
-  public declare hooks: Hooks
   public implementation = Bud
 }

--- a/sources/@roots/bud/src/cli/commands/build.base.tsx
+++ b/sources/@roots/bud/src/cli/commands/build.base.tsx
@@ -484,12 +484,6 @@ export default class BuildCommand extends BaseCommand {
         [this.app.context.args.clean ? `enable` : `disable`]()
 
       this.app.hooks.on(`build.output.clean`, this.app.context.args.clean)
-    } else if (
-      this.app.isProduction &&
-      !isset(this.app.hooks.filter(`build.output.clean`))
-    ) {
-      this.app.extensions.get(`clean-webpack-plugin`).enable()
-      this.app.hooks.on(`build.output.clean`, true)
     }
 
     if (isset(this.app.context.args.devtool))

--- a/sources/@roots/bud/src/extensions/bud-esm/index.test.ts
+++ b/sources/@roots/bud/src/extensions/bud-esm/index.test.ts
@@ -1,12 +1,121 @@
-import {describe, test} from '@jest/globals'
-import {Extension} from '@roots/bud-framework'
+import {describe, expect, it, jest} from '@jest/globals'
+import {factory} from '@repo/test-kit/bud'
+import {Extension} from '@roots/bud-framework/extension'
 
 import extensionConstructor from './index'
 
 describe(`bud-esm`, () => {
-  it(`is an instance of Extension`, () => {
+  it(`is constructable`, () => {
     expect(extensionConstructor).toBeInstanceOf(Function)
   })
 
-  test.todo(`should be tested`)
+  it(`should be an instance of extension`, async () => {
+    let bud = await factory()
+    expect(new extensionConstructor(bud)).toBeInstanceOf(Extension)
+  })
+
+  it(`should be exposed via bud.esm`, async () => {
+    let bud = await factory()
+    new extensionConstructor(bud)
+    expect(bud.esm).toBeInstanceOf(Extension)
+  })
+
+  it(`should be labeled esm`, async () => {
+    let bud = await factory()
+    const instance = new extensionConstructor(
+      // @ts-ignore
+      bud,
+    )
+    expect(instance.label).toBe(`esm`)
+  })
+
+  it(`should have a when fn`, async () => {
+    let bud = await factory()
+    let instance = new extensionConstructor(bud)
+    expect(instance.when).toBeInstanceOf(Function)
+  })
+
+  it(`should be disabled by default`, async () => {
+    let bud = await factory()
+    let instance = new extensionConstructor(bud)
+    expect(await instance.isEnabled()).toBe(false)
+  })
+
+  it(`should be enable-able`, async () => {
+    let bud = await factory()
+    let instance = new extensionConstructor(bud)
+    instance.enable()
+    expect(await instance.isEnabled()).toBe(true)
+  })
+
+  it(`should be callable when enabled using extensions api`, async () => {
+    let bud = await factory()
+    bud.extensions.add(extensionConstructor)
+    expect(bud.extensions.get(`esm`).when).toBeInstanceOf(Function)
+
+    bud.extensions.get(`esm`).enable()
+    expect(await bud.extensions.get(`esm`).isEnabled()).toBe(true)
+  })
+
+  it(`should call hooks from buildBefore`, async () => {
+    let bud = await factory()
+
+    let instance = new extensionConstructor(bud)
+
+    instance.enable()
+    await instance.buildBefore(bud)
+
+    expect(bud.hooks.filter(`build.experiments`)).toEqual({
+      outputModule: true,
+    })
+    expect(bud.hooks.filter(`build.output.module`)).toEqual(true)
+  })
+
+  it(`should call externals when imports is defined in package.json`, async () => {
+    let bud = await factory()
+    bud.context.manifest = {
+      imports: {
+        react: `React`,
+      },
+    }
+
+    const externalsSpy = jest.spyOn(
+      bud,
+      // @ts-ignore
+      `externals`,
+    )
+
+    let instance = new extensionConstructor(bud)
+
+    instance.enable()
+    await instance.buildBefore(
+      //@ts-ignore
+      bud,
+    )
+
+    expect(externalsSpy).toHaveBeenCalled()
+  })
+
+  it(`should not call externals when imports is undefined in package.json`, async () => {
+    let bud = await factory()
+    bud.context.manifest = {
+      imports: undefined,
+    }
+
+    const externalsSpy = jest.spyOn(
+      bud,
+      // @ts-ignore
+      `externals`,
+    )
+
+    let instance = new extensionConstructor(bud)
+
+    instance.enable()
+    await instance.buildBefore(
+      //@ts-ignore
+      bud,
+    )
+
+    expect(externalsSpy).not.toHaveBeenCalled()
+  })
 })

--- a/sources/@roots/bud/src/extensions/bud-esm/index.test.ts
+++ b/sources/@roots/bud/src/extensions/bud-esm/index.test.ts
@@ -51,10 +51,12 @@ describe(`bud-esm`, () => {
   it(`should be callable when enabled using extensions api`, async () => {
     let bud = await factory()
     bud.extensions.add(extensionConstructor)
-    expect(bud.extensions.get(`esm`).when).toBeInstanceOf(Function)
+    const extensionInstance = bud.extensions.get(`esm`)
 
-    bud.extensions.get(`esm`).enable()
-    expect(await bud.extensions.get(`esm`).isEnabled()).toBe(true)
+    expect(extensionInstance.when).toBeInstanceOf(Function)
+
+    extensionInstance.enable()
+    expect(await extensionInstance.isEnabled()).toBe(true)
   })
 
   it(`should call hooks from buildBefore`, async () => {

--- a/sources/@roots/bud/src/extensions/bud-esm/index.test.ts
+++ b/sources/@roots/bud/src/extensions/bud-esm/index.test.ts
@@ -29,12 +29,6 @@ describe(`bud-esm`, () => {
     expect(instance.label).toBe(`esm`)
   })
 
-  it(`should have a when fn`, async () => {
-    let bud = await factory()
-    let instance = new extensionConstructor(bud)
-    expect(instance.when).toBeInstanceOf(Function)
-  })
-
   it(`should be disabled by default`, async () => {
     let bud = await factory()
     let instance = new extensionConstructor(bud)
@@ -52,8 +46,6 @@ describe(`bud-esm`, () => {
     let bud = await factory()
     bud.extensions.add(extensionConstructor)
     const extensionInstance = bud.extensions.get(`esm`)
-
-    expect(extensionInstance.when).toBeInstanceOf(Function)
 
     extensionInstance.enable()
     expect(await extensionInstance.isEnabled()).toBe(true)

--- a/sources/@roots/bud/src/extensions/bud-esm/index.ts
+++ b/sources/@roots/bud/src/extensions/bud-esm/index.ts
@@ -1,5 +1,9 @@
 import {Extension} from '@roots/bud-framework/extension'
-import {expose, label} from '@roots/bud-framework/extension/decorators'
+import {
+  disabled,
+  expose,
+  label,
+} from '@roots/bud-framework/extension/decorators'
 
 import type Bud from '../../bud.js'
 
@@ -9,9 +13,11 @@ import type Bud from '../../bud.js'
  * @public
  * @decorator `@label`
  * @decorator `@expose`
+ * @decorator `@disabled`
  */
 @label(`esm`)
 @expose(`esm`)
+@disabled
 export default class Esm extends Extension {
   /**
    * `buildBefore` callback
@@ -30,15 +36,5 @@ export default class Esm extends Extension {
 
     app.context.manifest?.imports &&
       app.externals(app.context.manifest.imports)
-  }
-
-  /**
-   * `when` callback
-   *
-   * @public
-   * @decorator `@bind`
-   */
-  public async when() {
-    return false
   }
 }

--- a/sources/@roots/bud/src/extensions/bud-esm/index.ts
+++ b/sources/@roots/bud/src/extensions/bud-esm/index.ts
@@ -1,9 +1,7 @@
 import {Extension} from '@roots/bud-framework/extension'
-import {
-  bind,
-  expose,
-  label,
-} from '@roots/bud-framework/extension/decorators'
+import {expose, label} from '@roots/bud-framework/extension/decorators'
+
+import type Bud from '../../bud.js'
 
 /**
  * Extension enabling ESM compilation output
@@ -21,9 +19,8 @@ export default class Esm extends Extension {
    * @public
    * @decorator `@bind`
    */
-  @bind
-  public async buildBefore() {
-    this.app.hooks.fromMap({
+  public async buildBefore(app: Bud) {
+    app.hooks.fromMap({
       'build.experiments': experiments => ({
         ...(experiments ?? {}),
         outputModule: true,
@@ -31,8 +28,8 @@ export default class Esm extends Extension {
       'build.output.module': true,
     })
 
-    this.app.context.manifest?.imports &&
-      this.app.externals(this.app.context.manifest.imports)
+    app.context.manifest?.imports &&
+      app.externals(app.context.manifest.imports)
   }
 
   /**
@@ -41,7 +38,6 @@ export default class Esm extends Extension {
    * @public
    * @decorator `@bind`
    */
-  @bind
   public async when() {
     return false
   }

--- a/sources/@roots/bud/src/extensions/clean-webpack-plugin/index.test.ts
+++ b/sources/@roots/bud/src/extensions/clean-webpack-plugin/index.test.ts
@@ -1,4 +1,5 @@
 import {describe, test} from '@jest/globals'
+import {factory} from '@repo/test-kit/bud'
 
 import extensionConstructor from './index'
 
@@ -7,5 +8,19 @@ describe(`clean-webpack-plugin`, () => {
     expect(extensionConstructor).toBeInstanceOf(Function)
   })
 
-  test.todo(`should be tested`)
+  it(`is enabled in production`, async () => {
+    let bud = await factory()
+    let instance = new extensionConstructor(bud)
+
+    expect(bud.isProduction).toBe(true)
+    expect(await instance.isEnabled()).toBe(true)
+  })
+
+  it(`is disable-able`, async () => {
+    let bud = await factory()
+    let instance = new extensionConstructor(bud)
+
+    instance.disable()
+    expect(await instance.isEnabled()).toBe(false)
+  })
 })

--- a/sources/@roots/bud/src/extensions/clean-webpack-plugin/index.ts
+++ b/sources/@roots/bud/src/extensions/clean-webpack-plugin/index.ts
@@ -3,7 +3,7 @@ import {
   label,
   options,
   plugin,
-  when,
+  production,
 } from '@roots/bud-framework/extension/decorators'
 import {
   CleanWebpackPlugin,
@@ -17,7 +17,7 @@ import {
  * @decorator `@label`
  * @decorator `@plugin`
  * @decorator `@options`
- * @decorator `@when`
+ * @decorator `@production`
  */
 @label(`clean-webpack-plugin`)
 @plugin(CleanWebpackPlugin)
@@ -43,10 +43,7 @@ import {
    */
   cleanOnceBeforeBuildPatterns: [`**/*`],
 })
-@when(
-  async ({hooks, isProduction}) =>
-    hooks.filter(`feature.clean`) && isProduction,
-)
+@production
 export default class BudClean extends Extension<
   PluginOptions,
   CleanWebpackPlugin

--- a/sources/@roots/bud/src/factory/index.ts
+++ b/sources/@roots/bud/src/factory/index.ts
@@ -20,7 +20,6 @@ const get = async (basedir?: string) => {
   )
 
   if (!cached) return await factory()
-
   return cached
 }
 

--- a/sources/@roots/bud/src/services/env/env.test.ts
+++ b/sources/@roots/bud/src/services/env/env.test.ts
@@ -17,10 +17,7 @@ describe(`@roots/bud/services/env`, () => {
   })
 
   it(`is a container service`, () => {
-    const instance = new Env(
-      // @ts-ignore
-      bud,
-    )
+    const instance = new Env(bud)
     expect(instance).toBeInstanceOf(ServiceContainer)
   })
 })

--- a/sources/@roots/bud/src/services/project/index.ts
+++ b/sources/@roots/bud/src/services/project/index.ts
@@ -1,7 +1,6 @@
 import {Service as BaseService} from '@roots/bud-framework/service'
 import type {Service} from '@roots/bud-framework/services/project'
 import {bind} from '@roots/bud-support/decorators'
-import {omit} from '@roots/bud-support/lodash-es'
 import format from '@roots/bud-support/pretty-format'
 
 /**
@@ -40,14 +39,15 @@ export default class Project extends BaseService implements Service {
         path,
         this.app.fs.json.stringify(
           {
-            context: omit(
-              this.app.context,
-              `env`,
-              `stdout`,
-              `stderr`,
-              `stdin`,
-              `stdio`,
-            ),
+            basedir: this.app.context.basedir,
+            children: this.app.children
+              ? Object.keys(this.app.children)
+              : [],
+            context: {
+              args: this.app.context?.args,
+              extensions: this.app.context?.extensions,
+              services: this.app.context?.services,
+            },
             extensions: this.app.extensions.repository,
             hooks: {
               sync: this.app.hooks.syncStore.store,

--- a/sources/@roots/bud/src/services/project/project.test.ts
+++ b/sources/@roots/bud/src/services/project/project.test.ts
@@ -17,10 +17,7 @@ describe(`@roots/bud/services/project`, () => {
   })
 
   it(`is a container service`, () => {
-    const instance = new Project(
-      // @ts-ignore
-      bud,
-    )
+    const instance = new Project(bud)
     expect(instance).toBeInstanceOf(Service)
   })
 })

--- a/sources/@roots/sage/src/wp-theme-json/extension.ts
+++ b/sources/@roots/sage/src/wp-theme-json/extension.ts
@@ -2,11 +2,11 @@ import {Extension} from '@roots/bud-framework'
 import {
   bind,
   dependsOnOptional,
+  disabled,
   expose,
   label,
   options,
   plugin,
-  when,
 } from '@roots/bud-framework/extension/decorators'
 import type {GlobalSettingsAndStyles as WPThemeJson} from '@roots/bud-preset-wordpress/theme'
 import {isBoolean, isFunction} from '@roots/bud-support/lodash-es'
@@ -49,6 +49,7 @@ export interface Mutator {
  * @decorator `@when`
  * @decorator `@plugin`
  * @decorator `@expose`
+ * @decorator `@disabled`
  */
 @label(`@roots/sage/wp-theme-json`)
 @dependsOnOptional([`@roots/bud-tailwindcss`])
@@ -73,9 +74,9 @@ export interface Mutator {
     },
   },
 })
-@when(async () => false)
 @plugin(ThemeJsonWebpackPlugin)
 @expose(`wpjson`)
+@disabled
 export default class ThemeJson extends Extension<
   Options,
   ThemeJsonWebpackPlugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -5408,6 +5408,7 @@ __metadata:
     "@repo/constants": "workspace:sources/@repo/constants"
     "@repo/logger": "workspace:sources/@repo/logger"
     "@roots/bud": "workspace:sources/@roots/bud"
+    "@roots/bud-api": "workspace:sources/@roots/bud-api"
     "@roots/bud-compiler": "workspace:sources/@roots/bud-compiler"
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework"
     "@types/fs-extra": 9.0.13


### PR DESCRIPTION
Not sure what is up with the bindings in this class but it doesn't work in multi-instance configs. Easiest fix is to just remove the need to bind.

Edit: This was bugging me. The problem has to do with the way `Extension.enable()` and `Extension.disable()` override `Extension.when()` (they end up overriding the prototype). So, this PR makes a couple additional changes:

- adds `Extension.enabled` (optional `boolean` value). If set, it overrides `Extension.when`.
- `Extension.disable` sets `Extension.enabled` to `false`
- `Extension.enable` sets `Extension.enabled` to `true`
- Adds `@disabled` decorator for extensions which are not enabled by default

The `@disabled` decorator is much better than the old way of handling this:

```ts
import {Extension} from '@roots/bud-framework/extension'
import {disabled, label} from '@roots/bud-framework/extension/decorators'

@label('my-extension')
@disabled
class MyExtension extends Extension {}
```

instead of:

```ts
import {Extension} from '@roots/bud-framework/extension'
import {when, label} from '@roots/bud-framework/extension/decorators'

@label('my-extension')
@when(async () => false)
class MyExtension extends Extension {}
```

Which would suffer from similar issues with bindings, even if expressed with a non-arrow fn:

```ts
import {Extension} from '@roots/bud-framework/extension'
import {when, label} from '@roots/bud-framework/extension/decorators'

@label('my-extension')
@when(async function () {
  return false
})
class MyExtension extends Extension {}
```

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
