### PR TITLE
✨ feat(none): `bud upgrade` command

### DIFF
--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -122,6 +122,7 @@
     "@roots/bud-support": "workspace:sources/@roots/bud-support",
     "@roots/bud-terser": "workspace:sources/@roots/bud-terser",
     "@roots/container": "workspace:sources/@roots/container",
+    "@roots/dependencies": "workspace:sources/@roots/dependencies",
     "browserslist": "4.21.4",
     "caniuse-lite": "1.0.30001427",
     "conf": "10.2.0",

--- a/sources/@roots/bud/src/cli/commands/upgrade.tsx
+++ b/sources/@roots/bud/src/cli/commands/upgrade.tsx
@@ -1,0 +1,82 @@
+import {Command, Option} from '@roots/bud-support/clipanion'
+import {Dependencies, IDependencyManager} from '@roots/dependencies'
+
+import BaseCommand from './base.js'
+
+/**
+ * `bud upgrade` command
+ *
+ * @public
+ */
+export default class UpgradeCommand extends BaseCommand {
+  /**
+   * Command paths
+   * @public
+   */
+  public static paths = [[`upgrade`]]
+
+  /**
+   * Command usage
+   * @public
+   */
+  public static usage = Command.Usage({
+    description: `Upgrade @roots dependencies`,
+    category: `tools`,
+    examples: [[`Upgrade @roots dependencies`, `$0 upgrade`]],
+  })
+
+  public notify = false
+
+  public options = Option.Proxy({name: `package manager options`})
+
+  public manager: Dependencies
+
+  public client: IDependencyManager
+
+  public isYarn: boolean
+
+  /**
+   * Command execute
+   *
+   * @public
+   */
+  public async runCommand() {
+    this.manager = new Dependencies(this.app.context.basedir)
+    this.isYarn = await this.manager.isYarn()
+    this.client = await this.manager.getClient()
+
+    await this.upgradeAllRootsDependenciesOfType(`devDependencies`)
+    await this.upgradeAllRootsDependenciesOfType(`dependencies`)
+
+    await this.app.fs.write(
+      `package.json`,
+      this.app.fs.json.stringify(this.app.context.manifest, null, 2),
+    )
+
+    this.context.stdout.write(
+      `\nDependencies upgraded in \`package.json\`.\n\nInstall with: ${
+        this.isYarn ? `yarn install` : `npm install`
+      }\n\n`,
+    )
+  }
+
+  public async upgradeAllRootsDependenciesOfType(
+    type: `devDependencies` | `dependencies`,
+  ): Promise<void> {
+    const dependencies = Object.keys(
+      this.app.context.manifest[type] ?? {},
+    ).filter(
+      (signifier: string) =>
+        signifier.startsWith(`@roots/`) || signifier.includes(`bud-`),
+    )
+
+    if (!dependencies.length) return
+
+    await Promise.all(
+      dependencies.map(async signifier => {
+        this.app.context.manifest[type][signifier] =
+          await this.client.getLatestVersion(signifier)
+      }),
+    )
+  }
+}

--- a/sources/@roots/bud/src/cli/index.ts
+++ b/sources/@roots/bud/src/cli/index.ts
@@ -9,6 +9,7 @@ import BuildProductionCommand from './commands/build.production.js'
 import CleanCommand from './commands/clean.js'
 import DoctorCommand from './commands/doctor.js'
 import ReplCommand from './commands/repl.js'
+import UpgradeCommand from './commands/upgrade.js'
 import ViewCommand from './commands/view.js'
 import WebpackCommand from './commands/webpack.js'
 
@@ -43,6 +44,7 @@ const bud = async () => {
   application.register(CleanCommand)
   application.register(DoctorCommand)
   application.register(ReplCommand)
+  application.register(UpgradeCommand)
   application.register(ViewCommand)
   application.register(WebpackCommand)
 

--- a/sources/@roots/bud/tsconfig.json
+++ b/sources/@roots/bud/tsconfig.json
@@ -31,5 +31,6 @@
     {"path": "./../bud-server/tsconfig.json"},
     {"path": "./../bud-support/tsconfig.json"},
     {"path": "./../bud-terser/tsconfig.json"},
+    {"path": "./../dependencies/tsconfig.json"}
   ]
 }

--- a/sources/@roots/dependencies/package.json
+++ b/sources/@roots/dependencies/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "helpful-decorators": "2.1.0",
-    "tslib": "2.4.1"
+    "tslib": "2.4.0"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/sources/@roots/dependencies/package.json
+++ b/sources/@roots/dependencies/package.json
@@ -38,7 +38,7 @@
   ],
   "type": "module",
   "module": "./lib/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./lib/index.d.ts",
   "exports": {
     ".": "./lib/index.js"
   },
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "helpful-decorators": "2.1.0",
-    "tslib": "2.4.0"
+    "tslib": "2.4.1"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/sources/@roots/dependencies/src/command/npm.command.ts
+++ b/sources/@roots/dependencies/src/command/npm.command.ts
@@ -15,17 +15,20 @@ export class Npm extends Command implements IDependencyManager {
   @bind
   public install(
     dependencies: Array<string | [string, string]>,
-    dev: boolean = false,
+    args: Array<string> = [],
     onMessage?: (message: string) => void,
+    onError?: (message: string) => void,
   ): Promise<any> {
     return Npm.execute(
-      onMessage ?? this.onMessage,
-      `npm`,
-      `install`,
-      ...Npm.normalizeDependencies(dependencies),
-      dev ? `--dev` : null,
-      `--cwd`,
-      this.path,
+      [
+        `npm`,
+        `install`,
+        ...Npm.normalizeDependencies(dependencies),
+        `--prefix`,
+        this.path,
+      ],
+      onMessage,
+      onError,
     )
   }
 
@@ -36,14 +39,29 @@ export class Npm extends Command implements IDependencyManager {
   public uninstall(
     dependencies: Array<string | [string, string]>,
     onMessage?: (message: string) => void,
+    onError?: (message: string) => void,
   ): Promise<any> {
     return Npm.execute(
-      onMessage ?? this.onMessage,
-      `npm`,
-      `uninstall`,
-      ...Npm.normalizeDependencies(dependencies),
-      `--prefix`,
-      this.path,
+      [
+        `npm`,
+        `uninstall`,
+        ...Npm.normalizeDependencies(dependencies),
+        `--prefix`,
+        this.path,
+      ],
+      onMessage,
+      onError,
     )
+  }
+
+  /**
+   * Get the latest version of a package from the npm registry
+   *
+   * @public
+   */
+  @bind
+  public async getLatestVersion(signifier: string): Promise<string> {
+    const result = await Npm.execute([`npm`, `view`, signifier, `version`])
+    if (result?.shift) return result.shift().trim()
   }
 }

--- a/sources/@roots/dependencies/src/command/yarn.command.ts
+++ b/sources/@roots/dependencies/src/command/yarn.command.ts
@@ -13,37 +13,55 @@ export class Yarn extends Command implements IDependencyManager {
    * @public
    */
   @bind
-  public install(
-    dependencies: Array<string | [string, string]>,
-    dev: boolean = false,
+  public async install(
+    dependencies: Array<[string, string]>,
+    args: Array<string> = [],
     onMessage?: (message: string) => void,
+    onError?: (message: string) => void,
   ): Promise<any> {
-    return Yarn.execute(
-      onMessage ?? this.onMessage,
-      `yarn`,
-      `add`,
-      ...Yarn.normalizeDependencies(dependencies),
-      dev ? `--dev` : null,
-      `--cwd`,
-      this.path,
+    await Yarn.execute(
+      [
+        `yarn`,
+        `add`,
+        ...Yarn.normalizeDependencies(dependencies),
+        ...args,
+      ],
+      onMessage,
+      onError,
     )
+    await Yarn.execute([`yarn`, `install`])
   }
 
   /**
    * @public
    */
   @bind
-  public uninstall(
-    dependencies: Array<string | [string, string]>,
+  public async uninstall(
+    dependencies: Array<[string, string]>,
     onMessage?: (message: string) => void,
+    onError?: (message: string) => void,
   ): Promise<any> {
-    return Yarn.execute(
-      onMessage ?? this.onMessage,
-      `yarn`,
-      `remove`,
-      ...Yarn.normalizeDependencies(dependencies),
-      `--cwd`,
-      this.path,
+    return await Yarn.execute(
+      [`yarn`, `remove`, ...Yarn.normalizeDependencies(dependencies)],
+      onMessage,
+      onError,
     )
+  }
+
+  /**
+   * Get the latest version of a package from the npm registry
+   *
+   * @public
+   */
+  @bind
+  public async getLatestVersion(signifier: string): Promise<string> {
+    const result = await Yarn.execute([
+      `yarn`,
+      `info`,
+      signifier,
+      `version`,
+    ])
+
+    if (result?.shift) return result.shift().trim()
   }
 }

--- a/sources/@roots/dependencies/src/index.ts
+++ b/sources/@roots/dependencies/src/index.ts
@@ -15,21 +15,23 @@ export {Dependencies} from './dependencies.js'
 
 interface Install {
   (
-    dependencies: Array<string | [string, string]>,
-    dev?: boolean,
+    dependencies: Array<[string, string]>,
+    args?: Array<string>,
     onMessage?: (message: string) => void,
+    onError?: (message: string) => void,
   ): Promise<any>
 }
 
 interface Uninstall {
   (
-    dependencies: Array<string | [string, string]>,
+    dependencies: Array<[string, string]>,
     onMessage?: (message: string) => void,
   ): Promise<any>
 }
 
 export interface IDependencyManager {
   onMessage?: (message: string) => void
+  getLatestVersion(signifier: string): Promise<string>
   path: string
   install: Install
   uninstall: Uninstall

--- a/sources/@roots/dependencies/tsconfig.json
+++ b/sources/@roots/dependencies/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "lib",
   },
   "include": ["src"],
-  "exclude": ["lib", "node_modules"]
+  "exclude": ["**/*.test.ts", "*.test.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6292,6 +6292,7 @@ __metadata:
     "@roots/bud-support": "workspace:sources/@roots/bud-support"
     "@roots/bud-terser": "workspace:sources/@roots/bud-terser"
     "@roots/container": "workspace:sources/@roots/container"
+    "@roots/dependencies": "workspace:sources/@roots/dependencies"
     "@skypack/package-check": 0.2.2
     "@types/node": 16.18.2
     "@types/node-notifier": 8.0.2
@@ -6366,7 +6367,7 @@ __metadata:
     "@types/lodash": 4.14.186
     "@types/node": 16.18.2
     helpful-decorators: 2.1.0
-    tslib: 2.4.0
+    tslib: 2.4.1
     vitest: 0.24.4
   languageName: unknown
   linkType: soft
@@ -29977,6 +29978,13 @@ __metadata:
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
+"tslib@npm:2.4.1":
+  version: 2.4.1
+  resolution: "tslib@npm:2.4.1"
+  checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6367,7 +6367,7 @@ __metadata:
     "@types/lodash": 4.14.186
     "@types/node": 16.18.2
     helpful-decorators: 2.1.0
-    tslib: 2.4.1
+    tslib: 2.4.0
     vitest: 0.24.4
   languageName: unknown
   linkType: soft
@@ -29978,13 +29978,6 @@ __metadata:
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
-  languageName: node
-  linkType: hard
-
-"tslib@npm:2.4.1":
-  version: 2.4.1
-  resolution: "tslib@npm:2.4.1"
-  checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- doesn't install anything
- does bump all `@roots/*` and `*?bud-*` packages to latest
- supports yarn and npm

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
