### PR TITLE
typo in docs

### DIFF
--- a/sources/@repo/docs/content/guides/index.mdx
+++ b/sources/@repo/docs/content/guides/index.mdx
@@ -29,7 +29,7 @@ bud.js is written in TypeScript but fully supports projects written in vanilla J
 
 ## Installation
 
-Add **@roots/bud** as a development dependency using your choice of pacakge manager.
+Add **@roots/bud** as a development dependency using your choice of package manager.
 
 ```bash npm2yarn
 npm install @roots/bud --save-dev


### PR DESCRIPTION
Fixes misspelled word in Bud docs.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

- none

### Adds

- none

### Removes

- none
