### PR TITLE
🩹 fix(none): fix webpack plugin direct usage

### DIFF
--- a/sources/@roots/bud-api/src/methods/use/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/use/index.test.ts
@@ -53,7 +53,12 @@ describe(`use`, () => {
       options: {},
     })
     await use(`@roots/bud-babel`)
-    expect(bud.extensions.has(`@roots/bud-babel`))
+    expect(
+      bud.extensions.has(
+        // @ts-ignore
+        `@roots/bud-babel`,
+      ),
+    ).toBe(true)
   })
 
   it(`registers an inline extension`, async () => {
@@ -68,10 +73,12 @@ describe(`use`, () => {
       label: `css-minimizer-webpack-plugin`,
       options: {},
     })
+
     await use(
       // @ts-ignore
       {label: `inline-extension`},
     )
+
     expect(
       bud.extensions.has(
         // @ts-ignore

--- a/sources/@roots/bud-extensions/package.json
+++ b/sources/@roots/bud-extensions/package.json
@@ -107,7 +107,8 @@
   },
   "devDependencies": {
     "@skypack/package-check": "0.2.2",
-    "@types/node": "16.18.3"
+    "@types/node": "16.18.3",
+    "palette-webpack-plugin": "1.0.5"
   },
   "dependencies": {
     "@roots/bud-framework": "workspace:sources/@roots/bud-framework",

--- a/sources/@roots/bud-extensions/src/service.test.ts
+++ b/sources/@roots/bud-extensions/src/service.test.ts
@@ -39,6 +39,9 @@ describe(`@roots/bud-extensions`, () => {
 
     await extensions.add(mockModule)
 
+    const instance = extensions.get(`mock_extension`)
+    expect(instance.label).toBe(`mock_extension`)
+
     expect(extensions.get(mockModule.label)?.options?.test).toEqual(
       mockModule.options.test,
     )
@@ -61,6 +64,30 @@ describe(`@roots/bud-extensions`, () => {
     )
   })
 
+  it(`should accept a plugin definition`, async () => {
+    extensions.repository = {} as any
+
+    const plugin = await import('palette-webpack-plugin')
+    await extensions.add(plugin.default)
+
+    expect(
+      Object.values(extensions.repository).sort().pop().constructor.name,
+    ).toBe(`PaletteWebpackPlugin`)
+  })
+
+  it(`should accept a plugin instance`, async () => {
+    extensions.repository = {} as any
+
+    const plugin = await import('palette-webpack-plugin')
+    // @ts-ignore
+    const instance = new plugin.default()
+    await extensions.add(instance)
+
+    expect(Object.values(extensions.repository).sort().pop()).toBe(
+      instance,
+    )
+  })
+
   it(`should assign a uuid to label for extensions without name`, async () => {
     extensions.repository = {} as Extensions[`repository`]
 
@@ -75,7 +102,7 @@ describe(`@roots/bud-extensions`, () => {
 
     expect(
       // @ts-ignore
-      Object.values(extensions.repository).sort().pop().label,
+      Object.keys(extensions.repository).sort().pop(),
     ).toMatch(
       /[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/,
     )

--- a/sources/@roots/bud-extensions/src/service.ts
+++ b/sources/@roots/bud-extensions/src/service.ts
@@ -279,7 +279,7 @@ export default class Extensions
       return source as ApplyPlugin
     }
 
-    if (source instanceof Object && !isConstructor(source)) {
+    if (!isConstructor(source)) {
       return new Extension(this.app).fromObject(source)
     }
 

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -1,7 +1,6 @@
 import {bind} from '@roots/bud-support/decorators'
 import {has, isFunction, isUndefined} from '@roots/bud-support/lodash-es'
 import type {Instance as Signale} from '@roots/bud-support/signale'
-import type {Compiler} from '@roots/bud-support/webpack'
 
 import type {Bud} from '../bud.js'
 import type {Modules} from '../index.js'
@@ -123,7 +122,7 @@ export class Extension<
    *
    * @public
    */
-  public label?: keyof Modules & string
+  public label: keyof Modules & string
 
   /**
    * @public
@@ -244,13 +243,6 @@ export class Extension<
    * @public
    */
   public plugin?: ApplyPluginConstructor
-
-  /**
-   * Compiler plugin `apply` method
-   *
-   * @public
-   */
-  public apply?(compiler: Compiler): unknown
 
   /**
    * Class constructor
@@ -400,11 +392,7 @@ export class Extension<
   public async _make() {
     this.logger.info(`trying to make`, this.label)
 
-    if (
-      isUndefined(this.make) &&
-      isUndefined(this.apply) &&
-      isUndefined(this.plugin)
-    ) {
+    if (isUndefined(this.make) && isUndefined(this.plugin)) {
       this.logger.info(`no make, apply or plugin prop found. skipping.`)
       return false
     }
@@ -415,7 +403,6 @@ export class Extension<
       this.logger.info(`${this.label} is disabled. skipping.`)
       return false
     }
-
     try {
       if (!isUndefined(this.apply)) {
         this.logger.info(`apply prop found. return extension instance`)

--- a/sources/@roots/bud-framework/src/types/services/extensions.ts
+++ b/sources/@roots/bud-framework/src/types/services/extensions.ts
@@ -55,8 +55,8 @@ export interface Service extends BaseService {
 
   instantiate<K extends `${keyof Modules & string}`>(
     extension: (new (...args: any[]) => Modules[K]) | ExtensionLiteral,
-    signifier?: K,
-  ): Extension<any, any>
+    options?: Record<string, any>,
+  ): Promise<Extension | ApplyPlugin>
 
   has<K extends keyof Modules & string>(key: K): boolean
 
@@ -64,7 +64,7 @@ export interface Service extends BaseService {
 
   remove<K extends keyof Modules & string>(key: K): this
 
-  set<K extends keyof Modules & string>(key: K, value: Modules[K]): this
+  set<K extends keyof Modules & string>(value: Modules[K]): this
 
   /**
    * Add an extension
@@ -83,17 +83,18 @@ export interface Service extends BaseService {
           | Extension
           | `${keyof Modules & string}`
         >,
+    options?: Record<string, any>,
   ): Promise<void>
 
   import<K extends `${keyof Modules}`>(
     signifier: K,
     fatalOnError?: boolean,
-  ): Promise<Extension<any, any>>
+  ): Promise<Extension | ApplyPlugin>
 
   runAll(methodName: LifecycleMethods): Promise<Array<void>>
 
   run<K extends `${keyof Modules & string}`>(
-    extension: Modules[K],
+    extension: Extension | ApplyPlugin | K,
     methodName: LifecycleMethods,
   ): Promise<this>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6083,6 +6083,7 @@ __metadata:
     copy-webpack-plugin: 11.0.0
     html-webpack-plugin: 5.5.0
     mini-css-extract-plugin: 2.6.1
+    palette-webpack-plugin: 1.0.5
     webpack-manifest-plugin: 5.0.0
   peerDependencies:
     clean-webpack-plugin: "*"
@@ -13555,6 +13556,29 @@ __metadata:
   version: 1.0.1
   resolution: "cyclist@npm:1.0.1"
   checksum: 3cc2fdeb358599ca0ea96f5ecf2fc530ccab7ed1f8aa1a894aebfacd2009281bd7380cb9b30db02a18cdd00b3ed1d7ce81a3b11fe56e33a6a0fe4424dc592fbe
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1":
+  version: 1.4.1
+  resolution: "d3-color@npm:1.4.1"
+  checksum: a214b61458b5fcb7ad1a84faed0e02918037bab6be37f2d437bf0e2915cbd854d89fbf93754f17b0781c89e39d46704633d05a2bfae77e6209f0f4b140f9894b
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "d3-color@npm:2.0.0"
+  checksum: b887354aa383937abd04fbffed3e26e5d6a788472cd3737fb10735930e427763e69fe93398663bccf88c0b53ee3e638ac6fcf0c02226b00ed9e4327c2dfbf3dc
+  languageName: node
+  linkType: hard
+
+"d3-hsv@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "d3-hsv@npm:0.1.0"
+  dependencies:
+    d3-color: 1
+  checksum: ad7cdb9ae9cb6724506055f741bcf7e3dbe534d41a1cd4a8398e8b85b59ea865113456d4003f2aac06ff625e2ddc2626b086742e7141f5721dcc2a33d7c774e7
   languageName: node
   linkType: hard
 
@@ -24170,6 +24194,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"palette-webpack-plugin@npm:1.0.5":
+  version: 1.0.5
+  resolution: "palette-webpack-plugin@npm:1.0.5"
+  dependencies:
+    d3-color: ^2.0.0
+    d3-hsv: ^0.1.0
+    lodash: ^4.17.20
+    sass-export: ^2.1.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: 85d6b4628fcf30506122c135003b6b29e76b981138f68e782c7fc879defedde5a0344ef0d39cc76355e75169cf940034f53d4bb91abfa00af580be4225c8f9ef
+  languageName: node
+  linkType: hard
+
 "papaparse@npm:^5.2.0":
   version: 5.3.1
   resolution: "papaparse@npm:5.3.1"
@@ -27902,6 +27940,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sass-export@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "sass-export@npm:2.1.2"
+  dependencies:
+    glob: ^7.1.6
+    minimist: ^1.2.5
+    sass: ^1.32.8
+  bin:
+    sass-export: bin/sass-export
+  checksum: cff2356a756eba19679a08c80cf69de613555d1a5e5b572b517f0197f340f67c3dce1dcdd89e6818d12246eff4d4f22098b19533a5334bcaa2bbf329e12ebdfe
+  languageName: node
+  linkType: hard
+
 "sass-loader@npm:^13.2.0":
   version: 13.2.0
   resolution: "sass-loader@npm:13.2.0"
@@ -27927,7 +27978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.56.1":
+"sass@npm:^1.32.8, sass@npm:^1.56.1":
   version: 1.56.1
   resolution: "sass@npm:1.56.1"
   dependencies:


### PR DESCRIPTION
- fixes ducktyping on `bud.extensions.instantiate` so that webpack plugins are respected

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
