### PR TITLE
📕 docs(none): @roots/bud-imagemin

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-imagemin/configure.mdx
+++ b/sources/@repo/docs/content/extensions/bud-imagemin/configure.mdx
@@ -1,0 +1,9 @@
+---
+title: 'bud.imagemin.configure'
+description: 'Configuring the image minimizer plugin'
+slug: 'configure'
+---
+
+import Configure from '@site/../../@roots/bud-imagemin/src/configure/configure.md'
+
+<Configure />

--- a/sources/@repo/docs/content/extensions/bud-imagemin/encode.mdx
+++ b/sources/@repo/docs/content/extensions/bud-imagemin/encode.mdx
@@ -1,0 +1,9 @@
+---
+title: 'bud.imagemin.encode'
+description: 'Setting encoder options'
+slug: 'encode'
+---
+
+import Encode from '@site/../../@roots/bud-imagemin/src/encode/encode.md'
+
+<Encode />

--- a/sources/@repo/docs/content/extensions/bud-imagemin/index.mdx
+++ b/sources/@repo/docs/content/extensions/bud-imagemin/index.mdx
@@ -8,15 +8,16 @@ import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 import {Install} from '@site/src/docs/Install'
 
-import SettingEncoderOptions from '@site/../../@roots/bud-imagemin/docs/01-setting-encoder-options.md'
-import UsingTheWebpPreset from '@site/../../@roots/bud-imagemin/docs/02-using-the-webp-preset.md'
+import Usage from '@site/../../@roots/bud-imagemin/docs/00-usage.md'
+import ConvertingToWebp from '@site/../../@roots/bud-imagemin/docs/01-converting-to-webp.md'
+import SettingEncoderOptions from '@site/../../@roots/bud-imagemin/docs/02-setting-encoder-options.md'
 import Minimizers from '@site/../../@roots/bud-imagemin/docs/03-generators.md'
 import Generators from '@site/../../@roots/bud-imagemin/docs/04-minimizers.md'
 
 [@roots/bud-imagemin](/extensions/bud-imagemin) optimizes image filesizes. It works with no configuration beyond installing it
 but also has a robust customization API.
 
-The extension uses [GoogleChromeLabs/squoosh](https://github.com/GoogleChromeLabs/squoosh).
+The extension uses [googlechromelabs/squoosh](https://github.com/googlechromelabs/squoosh).
 
 ## Installation
 
@@ -26,13 +27,15 @@ The extension uses [GoogleChromeLabs/squoosh](https://github.com/GoogleChromeLab
 
 Once installed, all compatible assets will be run through the image minimizer. No further configuration is required.
 
-## Setting encoder options
-
-<SettingEncoderOptions />
+<Usage />
 
 ## Using the webp preset
 
-<UsingTheWebpPreset />
+<ConvertingToWebp />
+
+## Setting encoder options
+
+<SettingEncoderOptions />
 
 ## Minimizers
 

--- a/sources/@roots/bud-imagemin/README.md
+++ b/sources/@roots/bud-imagemin/README.md
@@ -32,37 +32,18 @@ npm install @roots/bud-imagemin --save-dev
 
 ## Usage
 
-### Setting Encoder Options
+### Usage
 
-**@roots/bud-imagemin** works out of the box with no configuration. However, you may wish to customize the encoder settings.
+**@roots/bud-imagemin** works out of the box with no configuration. It uses the [squoosh](https://squoosh.app/) library to optimize images, and sticks to the default options provided by the library.
 
-This is done with the **bud.imagemin.encode** method.
+Ultimately, this extension is a relatively thin wrapper around the [webpack-contrib/image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin). Refer to the [plugin documentation](https://github.com/webpack-contrib/image-minimizer-webpack-plugin) for a better understanding of how it all works.
 
-```typescript title="bud.config.mjs"
-export default async (bud) => {
-  bud.imagemin.encode(`jpg`, { quality: 50 });
-};
-```
+### Functions
 
-Some of the squoosh encoders have a name that does not match the filetype. For example, the `mozjpeg` encoder is used to encode `jpg` files.
+- [bud.imagemin.encode](https://bud.js.org/extensions/bud-imagemin/encode)
+- [bud.imagemin.configure](https://bud.js.org/extensions/bud-imagemin/configure)
 
-When setting the encoder options the function will automatically map filetypes to the encoder name for you.
-
-### Mapping new encoders
-
-If you are adding [support for a new minimizer](#minimizers), you may want to add to the encoder map or modify existing map entries.
-
-You can do that with the **bud.imagemin.encoders** map object:
-
-```typescript title="bud.config.mjs"
-export default async (bud) => {
-  bud.imagemin.encoders.set(`png`, [`squoosh`, `oxipng`]);
-};
-```
-
-This allows the [bud.imagemin.encode](#setting-encoder-options) method to work with the new minimizer.
-
-### Using The Webp Preset
+### Converting To Webp
 
 You may convert an asset to `webp` format using the `?as=webp` url parameter.
 
@@ -78,7 +59,35 @@ body {
 import image from "./images/image.jpg?as=webp";
 ```
 
-This is an example of a generator, and you're able [to add additional ones if you'd like](#generators).
+You're able [to add additional generators](#generators) if you want to do the same thing with another filetype.
+
+### Setting Encoder Options
+
+You may wish to customize the encoder settings. This is done with [bud.imagemin.encode](https://bud.js.org/extensions/bud-imagemin/encode).
+
+```typescript title="bud.config.mjs"
+export default async (bud) => {
+  bud.imagemin.encode(`jpg`, { quality: 50 });
+};
+```
+
+Some of the default squoosh encoders have a name that does not match the filetype. For example, the `mozjpeg` encoder is used to encode `jpg` files.
+
+When setting the encoder options the function will automatically map filetypes to the encoder name for you.
+
+### Mapping new encoders
+
+If you are adding [support for a new minimizer](#minimizers), you may want to add to the encoder map or modify existing map entries.
+
+You can do that with the **bud.imagemin.encoders** map object:
+
+```typescript title="bud.config.mjs"
+export default async (bud) => {
+  bud.imagemin.encoders.set(`png`, [`squoosh`, `oxipng`]);
+};
+```
+
+This allows [bud.imagemin.encode](https://bud.js.org/extensions/bud-imagemin/encode) to work with the new minimizer.
 
 ### Generators
 
@@ -94,11 +103,8 @@ For example, this custom generator will convert an asset to `png` at 80% quality
 
 ```typescript title="bud.config.mjs"
 export default async (bud) => {
-  const encodeOptions = { oxipng: { quality: 80 } };
-
-  bud.imagemin.setGenerator(`png`, {
-    options: { encodeOptions },
-  });
+  const options = { oxipng: { quality: 80 } };
+  bud.imagemin.setGenerator(`png`, options);
 };
 ```
 
@@ -122,7 +128,9 @@ export default async (bud) => {
 
 ### Minimizers
 
-**@roots/bud-imagemin** is a simple wrapper around the [webpack-contrib/image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin). Refer to their [documentation](https://github.com/webpack-contrib/image-minimizer-webpack-plugin) for more information on how these features are used.
+### Modifying minimizers
+
+Use [bud.imagemin.configure](https://bud.js.org/extensions/bud-imagemin/configure) to customize minimizer options.
 
 ### Adding minimizers
 
@@ -136,59 +144,16 @@ export default async (bud) => {
     minimizer: {
       implementation: MinimizerFunction,
       options: {
-        encodeOptions: {},
+        encodeOptions: bud.imagemin.encoders,
       },
     },
   });
 };
 ```
-
-### Modifying minimizers
-
-You can use **bud.imagemin.configure** to customize the options for a minimizer that already exists.
-
-```typescript title="bud.config.mjs"
-export default async (bud) => {
-  bud.imagemin.configure(`squoosh`, {
-    options: {
-      encodeOptions: {},
-    },
-  });
-};
-```
-
-It also accepts a callback function.
-
-```typescript title="bud.config.mjs"
-export default async bud => {
-  bud.imagemin.configure(`squoosh`, config => ({
-    ...config,
-    options: {...config.options,
-      encodeOptions: {
-        mozjpeg: {quality: 50},
-      },
-    },
-  })
-}
-```
-
-If needed, you may call **bud.imagemin.configure** with three parameters to modify other options.
-
-```typescript title="bud.config.mjs"
-export default async (bud) => {
-  const minimizer = `squoosh`;
-  const optionKey = `include`;
-  const value = /\/includes/;
-
-  bud.imagemin.configure(minimizer, optionKey, value);
-};
-```
-
-In this case, a callback is also supported in the third parameter.
 
 ### Operating on minimizers directly
 
-You may access the minimizer map directly using **bud.imagemin.minimizers**
+You may access the minimizer map directly using **bud.imagemin.minimizers**.
 
 ```typescript title="bud.config.mjs"
 export default async (bud) => {

--- a/sources/@roots/bud-imagemin/docs/00-usage.md
+++ b/sources/@roots/bud-imagemin/docs/00-usage.md
@@ -1,0 +1,8 @@
+**@roots/bud-imagemin** works out of the box with no configuration. It uses the [squoosh](https://squoosh.app/) library to optimize images, and sticks to the default options provided by the library.
+
+Ultimately, this extension is a relatively thin wrapper around the [webpack-contrib/image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin). Refer to the [plugin documentation](https://github.com/webpack-contrib/image-minimizer-webpack-plugin) for a better understanding of how it all works.
+
+### Functions
+
+- [bud.imagemin.encode](https://bud.js.org/extensions/bud-imagemin/encode)
+- [bud.imagemin.configure](https://bud.js.org/extensions/bud-imagemin/configure)

--- a/sources/@roots/bud-imagemin/docs/01-converting-to-webp.md
+++ b/sources/@roots/bud-imagemin/docs/01-converting-to-webp.md
@@ -12,4 +12,4 @@ body {
 import image from './images/image.jpg?as=webp'
 ```
 
-This is an example of a generator, and you're able [to add additional ones if you'd like](#generators).
+You're able [to add additional generators](#generators) if you want to do the same thing with another filetype.

--- a/sources/@roots/bud-imagemin/docs/02-setting-encoder-options.md
+++ b/sources/@roots/bud-imagemin/docs/02-setting-encoder-options.md
@@ -1,6 +1,4 @@
-**@roots/bud-imagemin** works out of the box with no configuration. However, you may wish to customize the encoder settings.
-
-This is done with the **bud.imagemin.encode** method.
+You may wish to customize the encoder settings. This is done with [bud.imagemin.encode](https://bud.js.org/extensions/bud-imagemin/encode).
 
 ```typescript title="bud.config.mjs"
 export default async bud => {
@@ -8,7 +6,7 @@ export default async bud => {
 }
 ```
 
-Some of the squoosh encoders have a name that does not match the filetype. For example, the `mozjpeg` encoder is used to encode `jpg` files.
+Some of the default squoosh encoders have a name that does not match the filetype. For example, the `mozjpeg` encoder is used to encode `jpg` files.
 
 When setting the encoder options the function will automatically map filetypes to the encoder name for you.
 
@@ -24,4 +22,4 @@ export default async bud => {
 }
 ```
 
-This allows the [bud.imagemin.encode](#setting-encoder-options) method to work with the new minimizer.
+This allows [bud.imagemin.encode](https://bud.js.org/extensions/bud-imagemin/encode) to work with the new minimizer.

--- a/sources/@roots/bud-imagemin/docs/03-generators.md
+++ b/sources/@roots/bud-imagemin/docs/03-generators.md
@@ -10,11 +10,8 @@ For example, this custom generator will convert an asset to `png` at 80% quality
 
 ```typescript title="bud.config.mjs"
 export default async bud => {
-  const encodeOptions = {oxipng: {quality: 80}}
-
-  bud.imagemin.setGenerator(`png`, {
-    options: {encodeOptions},
-  })
+  const options = {oxipng: {quality: 80}}
+  bud.imagemin.setGenerator(`png`, options)
 }
 ```
 

--- a/sources/@roots/bud-imagemin/docs/04-minimizers.md
+++ b/sources/@roots/bud-imagemin/docs/04-minimizers.md
@@ -1,4 +1,6 @@
-**@roots/bud-imagemin** is a simple wrapper around the [webpack-contrib/image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin). Refer to their [documentation](https://github.com/webpack-contrib/image-minimizer-webpack-plugin) for more information on how these features are used.
+### Modifying minimizers
+
+Use [bud.imagemin.configure](https://bud.js.org/extensions/bud-imagemin/configure) to customize minimizer options.
 
 ### Adding minimizers
 
@@ -12,59 +14,16 @@ export default async bud => {
     minimizer: {
       implementation: MinimizerFunction,
       options: {
-        encodeOptions: {},
+        encodeOptions: bud.imagemin.encoders,
       },
     },
   })
 }
 ```
-
-### Modifying minimizers
-
-You can use **bud.imagemin.configure** to customize the options for a minimizer that already exists.
-
-```typescript title="bud.config.mjs"
-export default async bud => {
-  bud.imagemin.configure(`squoosh`, {
-    options: {
-      encodeOptions: {},
-    },
-  })
-}
-```
-
-It also accepts a callback function.
-
-```typescript title="bud.config.mjs"
-export default async bud => {
-  bud.imagemin.configure(`squoosh`, config => ({
-    ...config,
-    options: {...config.options,
-      encodeOptions: {
-        mozjpeg: {quality: 50},
-      },
-    },
-  })
-}
-```
-
-If needed, you may call **bud.imagemin.configure** with three parameters to modify other options.
-
-```typescript title="bud.config.mjs"
-export default async bud => {
-  const minimizer = `squoosh`
-  const optionKey = `include`
-  const value = /\/includes/
-
-  bud.imagemin.configure(minimizer, optionKey, value)
-}
-```
-
-In this case, a callback is also supported in the third parameter.
 
 ### Operating on minimizers directly
 
-You may access the minimizer map directly using **bud.imagemin.minimizers**
+You may access the minimizer map directly using **bud.imagemin.minimizers**.
 
 ```typescript title="bud.config.mjs"
 export default async bud => {

--- a/sources/@roots/bud-imagemin/src/configure/configure.md
+++ b/sources/@roots/bud-imagemin/src/configure/configure.md
@@ -1,0 +1,51 @@
+Use **bud.imagemin.configure** to customize [image-minimizer-webpack-plugin](https://github.com/webpack-contrib/image-minimizer-webpack-plugin) options:
+
+### Usage
+
+When using two parameters, you are implicitly operating on the `minimizer` property.
+
+**Using a simple object**
+
+```typescript title="bud.config.mjs"
+export default async bud => {
+  const minimizer = {options: {encodeOptions: {}}}
+
+  bud.imagemin.configure(`squoosh`, minimizer)
+}
+```
+
+**Using a callback function**
+
+```typescript title="bud.config.mjs"
+export default async bud => {
+  const callback = minimizer => ({
+    ...minimizer,
+    /* overload */
+  })
+
+  bud.imagemin.configure(`squoosh`, callback)
+}
+```
+
+You may use three parameters to modify other options beyond `minimizer`:
+
+```typescript title="bud.config.mjs"
+export default async bud => {
+  const key = `include`
+  const value = /\/includes/
+
+  bud.imagemin.configure(`squoosh`, key, value)
+}
+```
+
+You can use dot syntax when specifying the `key` parameter:
+
+```typescript title="bud.config.mjs"
+export default async bud => {
+  bud.imagemin.configure(
+    `squoosh`,
+    `minimizer.options.encodeOptions.mozjpeg`,
+    {quality: 50},
+  )
+}
+```

--- a/sources/@roots/bud-imagemin/src/configure/configure.test.ts
+++ b/sources/@roots/bud-imagemin/src/configure/configure.test.ts
@@ -1,0 +1,53 @@
+import '../types.js'
+
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {Bud, factory} from '@repo/test-kit/bud'
+
+import {BudImageminExtension} from '../extension.js'
+
+describe(`@roots/bud-imagemin`, () => {
+  let bud: Bud
+
+  beforeEach(async () => {
+    bud = await factory()
+    await bud.extensions.add(BudImageminExtension)
+  })
+
+  it(`should have a configure method which accepts updated options`, async () => {
+    bud.imagemin.configure(`squoosh`, {options: {test: true}})
+
+    expect(bud.imagemin.getMinimizer(`squoosh`)).toEqual(
+      expect.objectContaining({
+        minimizer: {
+          implementation: expect.any(Function),
+          options: {test: true},
+        },
+      }),
+    )
+  })
+
+  it(`should have a configure method which accepts a callback`, async () => {
+    const callback = vi.fn()
+    bud.imagemin.configure(`squoosh`, callback)
+
+    expect(callback).toHaveBeenCalledWith({
+      implementation: expect.any(Function),
+      options: {
+        encodeOptions: {
+          mozjpeg: {},
+          webp: {},
+          avif: {},
+          oxipng: {},
+          wp2: {},
+          jxl: {},
+        },
+      },
+    })
+  })
+
+  it(`should have a configure method which accepts a minimizer key and an associated callback`, async () => {
+    const callback = vi.fn()
+    bud.imagemin.configure(`squoosh`, `include`, callback)
+    expect(callback).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/sources/@roots/bud-imagemin/src/configure/configure.ts
+++ b/sources/@roots/bud-imagemin/src/configure/configure.ts
@@ -1,0 +1,42 @@
+import {get, set} from '@roots/bud-support/lodash-es'
+
+import type {BudImageminExtension} from '../extension.js'
+import type {Minimizer} from '../index.js'
+
+export type MutateMinimizerOptions<
+  K extends `${keyof Minimizer & string}`,
+> = (minimizer: Minimizer[K]) => Minimizer[K]
+
+export type ConfigureMinimizerArgs = [
+  string,
+  Minimizer[`minimizer`] | MutateMinimizerOptions<`minimizer`>,
+]
+
+export type ConfigureMinimizerByKeyArgs<
+  K extends `${keyof Minimizer & string}`,
+> = [string, K, Minimizer[K] | MutateMinimizerOptions<K>]
+
+export interface configure {
+  <K extends `${keyof Minimizer & string}`>(
+    this: BudImageminExtension,
+    ...args: ConfigureMinimizerArgs | ConfigureMinimizerByKeyArgs<K>
+  ): BudImageminExtension
+}
+
+/**
+ * Configure
+ *
+ * @see {@link https://bud.js.org/extensions/bud-imagemin/configure}
+ *
+ * @public
+ */
+export const configure: configure = function (...args) {
+  const [id, key, input] =
+    args.length === 3 ? args : [args[0], `minimizer`, args[1]]
+
+  const minimizer = this.getMinimizer(id)
+  const option = get(minimizer, key)
+  const value = typeof input === `function` ? input(option) : input
+
+  return this.setMinimizer(id, set(minimizer, key, value))
+}

--- a/sources/@roots/bud-imagemin/src/encode/encode.md
+++ b/sources/@roots/bud-imagemin/src/encode/encode.md
@@ -1,0 +1,15 @@
+Use **bud.imagemin.encode** to set the encoder options for a given filetype.
+
+### Usage
+
+```typescript title="bud.config.mjs"
+export default async bud => {
+  bud.imagemin.encode(`jpg`, {quality: 50})
+}
+```
+
+### Encoder keys
+
+Some of the squoosh encoders have a name that does not match the filetype. For example, the `mozjpeg` encoder is used to encode `jpg` files.
+
+You can use either `jpg`, `mozjpeg`, or `jpeg` as the key. The extension will handle the mapping for you.

--- a/sources/@roots/bud-imagemin/src/encode/encode.test.ts
+++ b/sources/@roots/bud-imagemin/src/encode/encode.test.ts
@@ -1,0 +1,25 @@
+import '../types.js'
+
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {Bud, factory} from '@repo/test-kit/bud'
+
+import {BudImageminExtension} from '../extension.js'
+
+describe(`@roots/bud-imagemin`, () => {
+  let bud: Bud
+
+  beforeEach(async () => {
+    bud = await factory()
+  })
+
+  it(`should set minimizer encodeOptions when encode fn is called`, async () => {
+    await bud.extensions.add(BudImageminExtension)
+
+    bud.imagemin.encode(`jpg`, {test: `case`})
+
+    expect(
+      bud.imagemin.minimizers.get(`squoosh`).minimizer.options
+        .encodeOptions.mozjpeg,
+    ).toEqual(expect.objectContaining({test: `case`}))
+  })
+})

--- a/sources/@roots/bud-imagemin/src/encode/encode.ts
+++ b/sources/@roots/bud-imagemin/src/encode/encode.ts
@@ -1,0 +1,40 @@
+import type {BudImageminExtension} from '../extension.js'
+import type {Minimizer} from '../index.js'
+
+export interface encode {
+  (
+    this: BudImageminExtension,
+    key: string,
+    options: {},
+  ): BudImageminExtension
+}
+
+/**
+ * ## bud.imagemin.encode
+ *
+ * Allows you to set the encoder options for a given filetype.
+ *
+ * @see {@link https://bud.js.org/extensions/bud-imagemin/encode}
+ *
+ * @public
+ */
+export function encode(
+  this: BudImageminExtension,
+  key: string,
+  options: Record<string, any>,
+): BudImageminExtension {
+  const [minimizer, encoder] = this.encoders.get(key)
+
+  const transformer = (minimizer: Minimizer): Minimizer => ({
+    ...minimizer,
+    options: {
+      ...minimizer?.options,
+      encodeOptions: {
+        ...minimizer?.options?.encodeOptions,
+        [encoder]: options,
+      },
+    },
+  })
+
+  return this.configure(minimizer, transformer)
+}

--- a/sources/@roots/bud-imagemin/src/extension.test.ts
+++ b/sources/@roots/bud-imagemin/src/extension.test.ts
@@ -58,49 +58,6 @@ describe(`@roots/bud-imagemin`, () => {
     )
   })
 
-  it(`should have a configure method which accepts updated options`, async () => {
-    await bud.extensions.add(BudImageminExtension)
-    bud.imagemin.configure(`squoosh`, {
-      options: {test: true},
-    })
-
-    expect(bud.imagemin.getMinimizer(`squoosh`)).toEqual(
-      expect.objectContaining({
-        minimizer: {
-          implementation: expect.any(Function),
-          options: {test: true},
-        },
-      }),
-    )
-  })
-
-  it(`should have a configure method which accepts a callback`, async () => {
-    const callback = vi.fn()
-    await bud.extensions.add(BudImageminExtension)
-    bud.imagemin.configure(`squoosh`, callback)
-
-    expect(callback).toHaveBeenCalledWith({
-      implementation: expect.any(Function),
-      options: {
-        encodeOptions: {
-          mozjpeg: {},
-          webp: {},
-          avif: {},
-          oxipng: {},
-          wp2: {},
-          jxl: {},
-        },
-      },
-    })
-  })
-
-  it(`should have a configure method which accepts a minimizer key and an associated callback`, async () => {
-    const callback = vi.fn()
-    await bud.extensions.add(BudImageminExtension)
-    bud.imagemin.configure(`squoosh`, `include`, callback)
-    expect(callback).toHaveBeenCalledWith(undefined)
-  })
-
   it(`should return a generator from getGenerator`, async () => {
     await bud.extensions.add(BudImageminExtension)
     bud.imagemin.generators.clear()
@@ -150,16 +107,5 @@ describe(`@roots/bud-imagemin`, () => {
       `build.optimization.minimizer`,
       expect.any(Function),
     )
-  })
-
-  it(`should set minimizer encodeOptions when encode fn is called`, async () => {
-    await bud.extensions.add(BudImageminExtension)
-
-    bud.imagemin.encode(`jpg`, {test: `case`})
-
-    expect(
-      bud.imagemin.minimizers.get(`squoosh`).minimizer.options
-        .encodeOptions.mozjpeg,
-    ).toEqual(expect.objectContaining({test: `case`}))
   })
 })

--- a/sources/@roots/bud-imagemin/src/index.ts
+++ b/sources/@roots/bud-imagemin/src/index.ts
@@ -12,5 +12,20 @@
 
 import './types.js'
 
+import type {Generator as ImageminGenerator} from 'image-minimizer-webpack-plugin'
+
 import {BudImageminExtension} from './extension.js'
+
+export type Generator = ImageminGenerator<any>
+
+export type Minimizer = {[key: string]: any}
+
+export type MinimizerMap = Map<string, Minimizer>
+
+export type GeneratorMap = Map<string, Generator>
+
+export type MutateMinimizerOptions<
+  K extends `${keyof Minimizer & string}`,
+> = (minimizer: Minimizer[K]) => Minimizer[K]
+
 export default BudImageminExtension


### PR DESCRIPTION
- Improve: `@roots/bud-imagemin` docs and README.md

refers:

- #1886 

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
