### PR TITLE
✨ improve: @roots/bud-server proxy middleware

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,6 @@
 cacheFolder: storage/yarn/cache
 
-defaultSemverRangePrefix: ""
+defaultSemverRangePrefix: ''
 
 enableMessageNames: false
 
@@ -12,37 +12,29 @@ installStatePath: storage/yarn/install-state.gz
 
 nodeLinker: node-modules
 
-npmAuthToken: "${NPM_AUTH_TOKEN:-fallback}"
+npmAuthToken: '${NPM_AUTH_TOKEN:-fallback}'
 
 npmPublishAccess: public
 
-npmPublishRegistry: "http://0.0.0.0:4873"
+npmPublishRegistry: 'https://registry.npmjs.org'
 
-npmRegistryServer: "http://0.0.0.0:4873"
+npmRegistryServer: 'https://registry.npmjs.org'
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
+    spec: '@yarnpkg/plugin-typescript'
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
-    spec: "@yarnpkg/plugin-interactive-tools"
+    spec: '@yarnpkg/plugin-interactive-tools'
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
-  - path: .yarn/plugins/@yarnpkg/plugin-tsconfig-references.cjs
-    spec: "https://github.com/Dcard/yarn-plugins/releases/latest/download/plugin-tsconfig-references.js"
+    spec: '@yarnpkg/plugin-workspace-tools'
   - sources/@repo/yarn-plugin-bud/bundles/@yarnpkg/plugin-bud.js
   - sources/@repo/yarn-plugin-package/bundles/@yarnpkg/plugin-package.js
-  - path: .yarn/plugins/@yarnpkg/plugin-stage.cjs
-    spec: "@yarnpkg/plugin-stage"
 
 pnpDataPath: .yarn/pnp.data.json
 
 pnpUnpluggedFolder: .yarn/unplugged
 
 progressBarStyle: default
-
-unsafeHttpWhitelist:
-  - 0.0.0.0
-  - localhost
 
 virtualFolder: .yarn/__virtual__
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "execa": "6.1.0",
     "fs-extra": "10.1.0",
     "import-meta-resolve": "2.1.0",
+    "lodash": "4.17.21",
     "playwright": "1.28.0",
     "prettier": "2.7.1",
     "syncpack": "8.3.9",
@@ -57,6 +58,7 @@
     "webpack": "5.75.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4",
     "eslint-plugin-n": "15.5.1"
   }
 }

--- a/sources/@roots/bud-api/src/methods/proxy/index.ts
+++ b/sources/@roots/bud-api/src/methods/proxy/index.ts
@@ -1,10 +1,6 @@
 import type {Bud} from '@roots/bud-framework/bud'
 import type * as Server from '@roots/bud-framework/services/server'
-import {
-  isNumber,
-  isString,
-  isUndefined,
-} from '@roots/bud-support/lodash-es'
+import {isNumber, isString} from '@roots/bud-support/lodash-es'
 
 type ReplacementTuples = Array<[string, string]>
 type ReplacementCallback = (
@@ -26,15 +22,9 @@ export type Parameters = [
  * @public
  */
 export const enableMiddlewareHookCallback = (
-  middleware: Array<keyof Server.Middleware.Available> | undefined,
+  middleware: Array<keyof Server.Middleware.Available> | undefined = [],
 ): Array<keyof Server.Middleware.Available> => {
-  if (middleware === undefined) middleware = []
-
-  return [
-    ...(disableMiddlewareHookCallback(middleware) ?? []),
-    `cookie`,
-    `proxy`,
-  ]
+  return [...disableMiddlewareHookCallback(middleware), `cookie`, `proxy`]
 }
 
 /**
@@ -47,9 +37,8 @@ export const enableMiddlewareHookCallback = (
  * @public
  */
 export const disableMiddlewareHookCallback = (
-  middleware: Array<keyof Server.Middleware.Available> | undefined,
+  middleware: Array<keyof Server.Middleware.Available> | undefined = [],
 ): Array<keyof Server.Middleware.Available> => {
-  if (middleware === undefined) middleware = []
   return middleware?.filter(
     middleware => middleware !== `proxy` && middleware !== `cookie`,
   )
@@ -82,29 +71,33 @@ export const proxy: proxy = async function (
   /**
    * User proxy request from a port #
    */
-  isNumber(input) &&
-    this.hooks.on(`dev.middleware.proxy.target`, url => {
-      if (isUndefined(url)) url = new URL(`http://0.0.0.0`)
-      url.port = `${input}`
-      return url
-    })
+  if (isNumber(input)) {
+    this.hooks.on(
+      `dev.middleware.proxy.target`,
+      (url = new URL(`http://0.0.0.0`)) => {
+        url.port = `${input}`
+        return url
+      },
+    )
+  }
 
   /**
    * User proxy request from a string
    */
-  isString(input) &&
+  if (isString(input)) {
     this.hooks.on(`dev.middleware.proxy.target`, new URL(input))
+  }
 
   /**
    * User proxy request from a URL
    */
-  input instanceof URL &&
+  if (input instanceof URL) {
     this.hooks.on(`dev.middleware.proxy.target`, input)
+  }
 
   /**
-   * User proxy request as a boolean
+   * Enable or disable middleware (implicitly enabled unless supplied value is `false`)
    */
-
   this.hooks.on(
     `dev.middleware.enabled`,
     input === false
@@ -116,7 +109,6 @@ export const proxy: proxy = async function (
    * Handle URL replacements
    */
   if (replacements === undefined) return this
-
   this.hooks.on(`dev.middleware.proxy.replacements`, replacements)
 
   return this

--- a/sources/@roots/bud-api/src/methods/proxy/proxy.test.ts
+++ b/sources/@roots/bud-api/src/methods/proxy/proxy.test.ts
@@ -100,7 +100,7 @@ describe(`bud.proxy`, () => {
 
     expect(onSpy).toHaveBeenLastCalledWith(
       `dev.middleware.proxy.replacements`,
-      expect.any(Function),
+      [[/foo/, `bar`]],
     )
   })
 

--- a/sources/@roots/bud-framework/package.json
+++ b/sources/@roots/bud-framework/package.json
@@ -144,7 +144,7 @@
     "@types/js-yaml": "4.0.5",
     "@types/node": "16.18.3",
     "chokidar": "3.5.3",
-    "http-proxy-middleware": "2.0.6"
+    "http-proxy-middleware": "3.0.0-beta.0"
   },
   "dependencies": {
     "@roots/bud-support": "workspace:sources/@roots/bud-support",

--- a/sources/@roots/bud-framework/src/types/registry/dev.ts
+++ b/sources/@roots/bud-framework/src/types/registry/dev.ts
@@ -60,7 +60,8 @@ export interface Sync {
   'middleware.proxy.options.changeOrigin': Server.Middleware.Available['proxy']['options']['changeOrigin']
   'middleware.proxy.options.cookieDomainRewrite': Server.Middleware.Available['proxy']['options']['cookieDomainRewrite']
   'middleware.proxy.options.followRedirects': Server.Middleware.Available['proxy']['options']['followRedirects']
-  'middleware.proxy.options.headers': Server.Middleware.Available['proxy']['options']['headers']
+  'middleware.proxy.options.forward': Server.Middleware.Available['proxy']['options']['forward']
+  'middleware.proxy.options.headers': Record<string, string>
   'middleware.proxy.options.hostRewrite': Server.Middleware.Available['proxy']['options']['hostRewrite']
   'middleware.proxy.options.logLevel': Server.Middleware.Available['proxy']['options']['logLevel']
   'middleware.proxy.options.onProxyReq': Server.Middleware.Available['proxy']['options']['onProxyReq']
@@ -79,7 +80,7 @@ export interface Sync {
    * Proxy middleware replacements
    * @public
    */
-  'middleware.proxy.replacements': Array<[RegExp | string, string]>
+  'middleware.proxy.replacements': Array<[string, string]>
 }
 
 export type SyncRegistry = {

--- a/sources/@roots/bud-framework/src/types/registry/dev.ts
+++ b/sources/@roots/bud-framework/src/types/registry/dev.ts
@@ -63,9 +63,8 @@ export interface Sync {
   'middleware.proxy.options.forward': Server.Middleware.Available['proxy']['options']['forward']
   'middleware.proxy.options.headers': Record<string, string>
   'middleware.proxy.options.hostRewrite': Server.Middleware.Available['proxy']['options']['hostRewrite']
-  'middleware.proxy.options.logLevel': Server.Middleware.Available['proxy']['options']['logLevel']
-  'middleware.proxy.options.onProxyReq': Server.Middleware.Available['proxy']['options']['onProxyReq']
-  'middleware.proxy.options.onProxyRes': Server.Middleware.Available['proxy']['options']['onProxyRes']
+  'middleware.proxy.options.onProxyReq': Server.Middleware.Available['proxy']['options']['on']['proxyReq']
+  'middleware.proxy.options.onProxyRes': Server.Middleware.Available['proxy']['options']['on']['proxyRes']
   'middleware.proxy.options.protocolRewrite': Server.Middleware.Available['proxy']['options']['protocolRewrite']
   'middleware.proxy.options.secure': Server.Middleware.Available['proxy']['options']['secure']
   'middleware.proxy.options.selfHandleResponse': Server.Middleware.Available['proxy']['options']['selfHandleResponse']

--- a/sources/@roots/bud-server/package.json
+++ b/sources/@roots/bud-server/package.json
@@ -69,8 +69,8 @@
     "chokidar": "3.5.3",
     "cookie-parser": "1.4.6",
     "express": "4.18.2",
-    "http-proxy-middleware": "2.0.6",
-    "webpack-dev-middleware": "5.3.3"
+    "http-proxy-middleware": "3.0.0-beta.0",
+    "webpack-dev-middleware": "6.0.1"
   },
   "peerDependencies": {
     "@roots/bud-client": "*"

--- a/sources/@roots/bud-server/src/middleware/proxy/index.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/index.ts
@@ -20,97 +20,53 @@ export const proxy = (app: Bud) => {
       `dev.middleware.proxy.options.autoRewrite`,
       true,
     ),
-
-    /**
-     * Change origin
-     */
     changeOrigin: app.hooks.filter(
       `dev.middleware.proxy.options.changeOrigin`,
       true,
     ),
-
-    /**
-     * Cookie domain rewrite
-     */
     cookieDomainRewrite: app.hooks.filter(
       `dev.middleware.proxy.options.cookieDomainRewrite`,
       url.dev.host,
     ),
-
-    /**
-     * Follow redirects
-     */
     followRedirects: app.hooks.filter(
       `dev.middleware.proxy.options.followRedirects`,
       false,
     ),
-
-    /**
-     * Host rewrite
-     */
     hostRewrite: app.hooks.filter(
       `dev.middleware.proxy.options.hostRewrite`,
       url.dev.host,
     ),
-
-    /**
-     * Log level
-     */
-    logLevel: app.hooks.filter(
-      `dev.middleware.proxy.options.logLevel`,
-      `info`,
+    forward: app.hooks.filter(
+      `dev.middleware.proxy.options.forward`,
+      undefined,
     ),
-
-    /**
-     * Log provider
-     */
-    logProvider: () => app.logger.instance.scope(`proxy`),
-
-    /**
-     * Proxy request handler
-     */
-    onProxyReq: app.hooks.filter(
-      `dev.middleware.proxy.options.onProxyReq`,
-      request.make,
+    headers: app.hooks.filter(
+      `dev.middleware.proxy.options.headers`,
+      undefined,
     ),
-
-    /**
-     * Proxy response handler
-     */
-    onProxyRes: app.hooks.filter(
-      `dev.middleware.proxy.options.onProxyRes`,
-      response.make,
-    ),
-
-    /**
-     * Protocol rewrite
-     */
+    on: {
+      proxyReq: app.hooks.filter(
+        `dev.middleware.proxy.options.onProxyReq`,
+        request.make,
+      ),
+      proxyRes: app.hooks.filter(
+        `dev.middleware.proxy.options.onProxyRes`,
+        response.make,
+      ),
+    },
     protocolRewrite: app.hooks.filter(
       `dev.middleware.proxy.options.protocolRewrite`,
       url.dev.protocol === `https:` ? `https` : null,
     ),
-
-    /**
-     * Secure
-     */
     secure: app.hooks.filter(`dev.middleware.proxy.options.secure`, false),
-
-    /**
-     * Self handle response
-     */
     selfHandleResponse: app.hooks.filter(
       `dev.middleware.proxy.options.selfHandleResponse`,
       true,
     ),
-
-    /**
-     * Target
-     */
     target: app.hooks.filter(`dev.middleware.proxy.target`, url.proxy),
   }
 
   return createProxyMiddleware(
-    app.hooks.filter(`dev.middleware.proxy.paths`, [`**`, `!/bud/**`]),
     app.hooks.filter(`dev.middleware.proxy.options`, options),
   )
 }

--- a/sources/@roots/bud-server/src/middleware/proxy/req.interceptor.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/req.interceptor.ts
@@ -29,46 +29,37 @@ export class RequestInterceptorFactory {
   /**
    * Callback for `http-proxy-middleware` `onProxyReq`
    *
-   * @param proxyRequest - proxy client request
+   * @param proxy - proxy client request
    * @param request - incoming message
-   * @param _response - server response
+   * @param response - server response
    * @returns void
    *
    * @public
    * @decorator `@bind`
    */
   @bind
-  public async _interceptor(
-    proxyRequest: ClientRequest,
+  public interceptor(
+    proxy: ClientRequest,
     request: IncomingMessage,
     _response: ServerResponse,
   ) {
     try {
-      /**
-       * Acorn compat
-       * Ideally, we use the headers included after this
-       */
-      proxyRequest.setHeader(
-        `x-bud-dev-pathname`,
-        new URL(request.url, `http://${request.headers.host}`).pathname,
-      )
-
-      /**
-       * Headers
-       */
-      proxyRequest.setHeader(`x-bud-dev-origin`, this.url.dev.origin)
-      proxyRequest.setHeader(`x-bud-dev-protocol`, this.url.dev.protocol)
-      proxyRequest.setHeader(`x-bud-dev-hostname`, this.url.dev.hostname)
-      proxyRequest.setHeader(
-        `x-bud-request`,
-        new URL(
-          request.url,
-          `${this.url.dev.protocol ?? `http:`}//${request.headers.host}`,
-        ).toJSON(),
-      )
-    } catch (err) {
-      this.app.error(`${err}\n`)
-    }
+      proxy
+        .setHeader(
+          `x-bud-request`,
+          new URL(
+            request.url,
+            `${this.url.dev.protocol}//${request.headers.host}`,
+          ).toJSON(),
+        )
+        .setHeader(
+          `x-bud-dev-pathname`,
+          new URL(request.url, `http://${request.headers.host}`).pathname,
+        )
+        .setHeader(`x-bud-origin`, this.url.dev.origin)
+        .setHeader(`x-bud-protocol`, this.url.dev.protocol)
+        .setHeader(`x-bud-hostname`, this.url.dev.hostname)
+    } catch (error) {}
   }
 
   /**
@@ -76,6 +67,6 @@ export class RequestInterceptorFactory {
    */
   @bind
   public make() {
-    return this._interceptor
+    return this.interceptor
   }
 }

--- a/sources/@roots/bud-server/src/middleware/proxy/req.interceptor.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/req.interceptor.ts
@@ -59,6 +59,16 @@ export class RequestInterceptorFactory {
         .setHeader(`x-bud-origin`, this.url.dev.origin)
         .setHeader(`x-bud-protocol`, this.url.dev.protocol)
         .setHeader(`x-bud-hostname`, this.url.dev.hostname)
+
+      if (proxy.hasHeader(`location`)) {
+        proxy.setHeader(
+          `location`,
+          (proxy.getHeader(`location`) as string).replace(
+            this.url.proxy.origin,
+            this.url.dev.origin,
+          ),
+        )
+      }
     } catch (error) {}
   }
 

--- a/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/res.interceptor.ts
@@ -1,7 +1,7 @@
+import type * as http from 'node:http'
+
 import type {Bud} from '@roots/bud-framework'
 import {bind} from '@roots/bud-support/decorators'
-import {isString, isUndefined} from '@roots/bud-support/lodash-es'
-import type * as http from 'http'
 import {responseInterceptor} from 'http-proxy-middleware'
 
 import type {ApplicationURL} from './url.js'
@@ -14,10 +14,10 @@ interface ServerResponse extends http.ServerResponse {
   cookie: any
 }
 
-export interface ResponseInterceptorFactory {
+export interface InterceptorFactory {
   interceptor(
     buffer: Buffer,
-    proxyResponse: IncomingMessage,
+    proxy: IncomingMessage,
     request: IncomingMessage,
     response: ServerResponse,
   ): Promise<Buffer | string>
@@ -28,7 +28,7 @@ export interface ResponseInterceptorFactory {
  *
  * @public
  */
-export class ResponseInterceptorFactory {
+export class ResponseInterceptorFactory implements InterceptorFactory {
   /**
    * The bud instance
    *
@@ -46,6 +46,17 @@ export class ResponseInterceptorFactory {
   public constructor(public _app: () => Bud, public url: ApplicationURL) {}
 
   /**
+   * Returns the `onProxyRes` callback for `http-proxy-middleware`
+   *
+   * @public
+   * @decorator `@bind`
+   */
+  @bind
+  public make() {
+    return responseInterceptor(this.interceptor)
+  }
+
+  /**
    * Response interceptor
    *
    * @remarks
@@ -55,7 +66,7 @@ export class ResponseInterceptorFactory {
    * It can be used to modify the response body or the response object.
    *
    * @param buffer - Buffered response
-   * @param proxyResponse - Response from the proxy
+   * @param proxy - Response from the proxy
    * @param request - Request from the client
    * @param response - Response from the server
    *
@@ -65,66 +76,85 @@ export class ResponseInterceptorFactory {
   @bind
   public async interceptor(
     buffer: Buffer,
-    _proxyResponse: IncomingMessage,
+    proxy: IncomingMessage,
     request: IncomingMessage,
     response: ServerResponse,
-  ): Promise<Buffer | String> {
-    this.app.info(
-      request.url,
-      request.statusCode,
-      response.getHeader(`content-type`),
-    )
-    if (!`${response.getHeader(`content-type`)}`.startsWith(`text/`))
-      return buffer
-
-    Object.entries(
-      this.app.hooks.filter(`dev.middleware.proxy.options.headers`, {
-        ...response.getHeaders(),
-
-        'x-proxy-by': `@roots/bud`,
-        'x-bud-dev-origin': this.url.dev.origin,
-        'x-bud-dev-protocol': this.url.dev.protocol,
-        'x-bud-dev-hostname': this.url.dev.hostname,
-        'x-bud-proxy-origin': this.url.proxy.origin,
-
-        'content-security-policy': undefined,
-        'x-http-method-override': undefined,
-      }),
-    ).map(([k, v]: [string, string | number | ReadonlyArray<string>]) => {
-      if (isString(k) && isUndefined(v)) {
-        this.app.log(`removing header`, k)
-        response.removeHeader(k)
-      } else if (isString(k) && !isUndefined(v)) {
-        this.app.log(`setting header`, k, `=>`, v)
-        response.setHeader(k, v)
-      }
-    })
-
-    Object.entries(request.cookies).map(([k, v]) => {
-      this.app.info(`setting cookie`, k, `=>`, v)
-      response.cookie(k, v, {domain: undefined})
-    })
-
-    return this.app.hooks
-      .filter(`dev.middleware.proxy.replacements`, [])
-      .reduce(
-        (buffer: string, [search, replace]: [string | RegExp, string]) =>
-          buffer
-            .split(`\n`)
-            .map((ln: string) => ln.replaceAll(search, replace))
-            .join(`\n`),
-        buffer.toString(),
-      )
+  ): Promise<Buffer | string> {
+    this.mapProxyCookies(request, response)
+    response.setHeader(`x-bud-origin`, this.url.dev.origin)
+    return this.isTransformable(proxy) ? this.transform(buffer) : buffer
   }
 
   /**
-   * Returns the `onProxyRes` callback for `http-proxy-middleware`
+   * Modify a target string with search/replace tuples
    *
    * @public
    * @decorator `@bind`
    */
   @bind
-  public make() {
-    return responseInterceptor(this.interceptor)
+  public transform(buffer: Buffer): string {
+    return this.app.hooks
+      .filter(`dev.middleware.proxy.replacements`, [
+        [this.url.proxy.toString(), `/`],
+        [this.url.proxy.origin, this.url.dev.origin],
+      ])
+      .reduce(
+        (value, [search, replace]) =>
+          value.replaceAll(new RegExp(search, `g`), replace),
+        buffer.toString(),
+      )
+  }
+
+  /**
+   * Is body transformable?
+   *
+   * @public
+   */
+  public isTransformable(message?: IncomingMessage) {
+    if (typeof message?.headers?.[`content-type`] !== `string`)
+      return false
+
+    const type = message.headers[`content-type`]
+
+    return (
+      type.startsWith(`text/css`) ||
+      type.startsWith(`text/html`) ||
+      type.startsWith(`application/javascript`) ||
+      type.startsWith(`application/json`)
+    )
+  }
+
+  /**
+   * Map proxy cookies
+   *
+   * Unset the domain attached to cookies and remove the `secure` flag.
+   *
+   * @remarks
+   * For the cookie domain:
+   * - `null` domain will work for any domain, but will not be sent for IPs.
+   * - `undefined` will be sent for IPs.
+   */
+  @bind
+  public mapProxyCookies(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ) {
+    if (request.cookies) {
+      Object.entries(request.cookies).map(([k, v]) => {
+        response.cookie(k, v, {domain: undefined})
+      })
+    }
+
+    const raw = response?.getHeaders()?.[`set-cookie`]
+    if (!raw) return
+
+    const cookies = Array.isArray(raw) ? raw : [raw]
+
+    response.setHeader(
+      `set-cookie`,
+      cookies
+        .map(String)
+        .map(value => value.replace(`; secure`, ``).trim()),
+    )
   }
 }

--- a/storage/package.json
+++ b/storage/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "pm2": "^5.2.2",
-    "verdaccio": "^5.17.0"
+    "verdaccio": "^5.18.0"
   }
 }

--- a/storage/yarn.lock
+++ b/storage/yarn.lock
@@ -189,9 +189,9 @@
     "color-convert" "^2.0.1"
 
 "anymatch@~3.1.2":
-  "integrity" "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg=="
-  "resolved" "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz"
-  "version" "3.1.2"
+  "integrity" "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="
+  "resolved" "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
+  "version" "3.1.3"
   dependencies:
     "normalize-path" "^3.0.0"
     "picomatch" "^2.0.4"
@@ -848,7 +848,12 @@
   "resolved" "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   "version" "3.0.2"
 
-"extsprintf@^1.2.0", "extsprintf@1.3.0":
+"extsprintf@^1.2.0":
+  "integrity" "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
+  "resolved" "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz"
+  "version" "1.4.1"
+
+"extsprintf@1.3.0":
   "integrity" "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
   "resolved" "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   "version" "1.3.0"
@@ -1509,14 +1514,7 @@
   "resolved" "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz"
   "version" "3.0.0"
 
-"minimatch@^3.1.1":
-  "integrity" "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="
-  "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  "version" "3.1.2"
-  dependencies:
-    "brace-expansion" "^1.1.7"
-
-"minimatch@2 || 3":
+"minimatch@^3.1.1", "minimatch@2 || 3":
   "integrity" "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="
   "resolved" "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   "version" "3.1.2"
@@ -1552,20 +1550,20 @@
   "resolved" "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz"
   "version" "1.0.3"
 
-"ms@^2.1.1", "ms@2.1.2":
-  "integrity" "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-  "resolved" "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  "version" "2.1.2"
+"ms@^2.1.1", "ms@2.1.3":
+  "integrity" "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+  "resolved" "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  "version" "2.1.3"
 
 "ms@2.0.0":
   "integrity" "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
   "resolved" "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   "version" "2.0.0"
 
-"ms@2.1.3":
-  "integrity" "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-  "resolved" "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  "version" "2.1.3"
+"ms@2.1.2":
+  "integrity" "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+  "resolved" "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  "version" "2.1.2"
 
 "mute-stream@~0.0.4":
   "integrity" "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
@@ -2070,17 +2068,7 @@
   "resolved" "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
   "version" "1.2.4"
 
-"semver@^5.3.0":
-  "integrity" "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-  "resolved" "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
-  "version" "5.7.1"
-
-"semver@^5.5.0":
-  "integrity" "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-  "resolved" "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
-  "version" "5.7.1"
-
-"semver@^5.6.0":
+"semver@^5.3.0", "semver@^5.5.0", "semver@^5.6.0":
   "integrity" "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
   "resolved" "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   "version" "5.7.1"
@@ -2260,9 +2248,9 @@
   "version" "1.0.0"
 
 "systeminformation@^5.7":
-  "integrity" "sha512-2z1Ul+PDkO50yGmEGKWOPk3+TeAtTkbn6PmxqzH9D3BAN53QXgbYy6+PPJmBrszXy+X7g8uwZd1WdThKZtICcg=="
-  "resolved" "https://registry.npmjs.org/systeminformation/-/systeminformation-5.12.13.tgz"
-  "version" "5.12.13"
+  "integrity" "sha512-SpFIc6AkGL4RCtwmhCoECFdvnVVk/heA+pxdgjXvxW75oLQsJVXz0epNRNnnMucrk/+rvKFnMqC4LorDE5xzmQ=="
+  "resolved" "https://registry.npmjs.org/systeminformation/-/systeminformation-5.14.4.tgz"
+  "version" "5.14.4"
 
 "through@>=2.2.7 <3":
   "integrity" "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
@@ -2439,10 +2427,10 @@
     "http-errors" "2.0.0"
     "unix-crypt-td-js" "1.1.4"
 
-"verdaccio@^5.17.0":
-  "integrity" "sha512-is5ivFhZ8RUmafkIXWvOh/lDzu9Ooa9njP/sgfOVBKDgajOYEzn58YO6aOgmhw6WrYhGsBs8ocaEht48yjcTwA=="
-  "resolved" "https://registry.npmjs.org/verdaccio/-/verdaccio-5.17.0.tgz"
-  "version" "5.17.0"
+"verdaccio@^5.18.0":
+  "integrity" "sha512-z6akeVQS08iXXz0yqi6gMMOoSI2SHocQI+NMMtaVo2MFJaYvhoPSLf66MyXIS3vyCIOu108R6Ncknt0oTIUk1A=="
+  "resolved" "https://registry.npmjs.org/verdaccio/-/verdaccio-5.18.0.tgz"
+  "version" "5.18.0"
   dependencies:
     "@verdaccio/commons-api" "10.2.0"
     "@verdaccio/local-storage" "10.3.1"
@@ -2541,7 +2529,12 @@
   "resolved" "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   "version" "1.0.2"
 
-"ws@^7.0.0", "ws@~7.4.0":
+"ws@^7.0.0":
+  "integrity" "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+  "resolved" "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
+  "version" "7.5.9"
+
+"ws@~7.4.0":
   "integrity" "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
   "resolved" "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz"
   "version" "7.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6574,8 +6574,8 @@ __metadata:
     chokidar: 3.5.3
     cookie-parser: 1.4.6
     express: 4.18.2
-    http-proxy-middleware: 2.0.6
-    webpack-dev-middleware: 5.3.3
+    http-proxy-middleware: 3.0.0-beta.0
+    webpack-dev-middleware: 6.0.1
   peerDependencies:
     "@roots/bud-client": "*"
   peerDependenciesMeta:
@@ -8121,6 +8121,13 @@ __metadata:
   version: 4.14.186
   resolution: "@types/lodash@npm:4.14.186"
   checksum: ee0c1368a8100bb6efb88335107473a41928fc307ff1ef4ff1278868ccddba9c04c68c36d1ffe3a0392ef4a956e1955f7de3203ec09df4f1655dd1b88485c549
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:^4":
+  version: 4.14.190
+  resolution: "@types/lodash@npm:4.14.190::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40types%252flodash%2F-%2Flodash-4.14.190.tgz"
+  checksum: 353a55a1222a57224ead8bd3379fabb2e3e3f6685f599c48b1b66f099d8e9e015e6c6352c6e2275954004c3bb510377804c63117233c6f187700b6ab78adfa02
   languageName: node
   linkType: hard
 
@@ -11757,6 +11764,7 @@ __metadata:
     "@skypack/package-check": 0.2.2
     "@types/express": 4.17.14
     "@types/fs-extra": 9.0.13
+    "@types/lodash": ^4
     "@types/node": 16.18.3
     "@typescript-eslint/eslint-plugin": 5.42.1
     "@typescript-eslint/parser": 5.42.1
@@ -11771,6 +11779,7 @@ __metadata:
     execa: 6.1.0
     fs-extra: 10.1.0
     import-meta-resolve: 2.1.0
+    lodash: 4.17.21
     playwright: 1.28.0
     prettier: 2.7.1
     syncpack: 8.3.9
@@ -17488,6 +17497,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-monkey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "fs-monkey@npm:1.0.3::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Ffs-monkey%2F-%2Ffs-monkey-1.0.3.tgz"
+  checksum: cf50804833f9b88a476911ae911fe50f61a98d986df52f890bd97e7262796d023698cb2309fa9b74fdd8974f04315b648748a0a8ee059e7d5257b293bfc409c0
+  languageName: node
+  linkType: hard
+
 "fs.realpath@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
@@ -19097,6 +19113,25 @@ __metadata:
     "@types/express":
       optional: true
   checksum: 2ee85bc878afa6cbf34491e972ece0f5be0a3e5c98a60850cf40d2a9a5356e1fc57aab6cff33c1fc37691b0121c3a42602d2b1956c52577e87a5b77b62ae1c3a
+  languageName: node
+  linkType: hard
+
+"http-proxy-middleware@npm:3.0.0-beta.0":
+  version: 3.0.0-beta.0
+  resolution: "http-proxy-middleware@npm:3.0.0-beta.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fhttp-proxy-middleware%2F-%2Fhttp-proxy-middleware-3.0.0-beta.0.tgz"
+  dependencies:
+    "@types/http-proxy": ^1.17.8
+    debug: ^4.3.4
+    http-proxy: ^1.18.1
+    is-glob: ^4.0.1
+    is-plain-obj: ^3.0.0
+    micromatch: ^4.0.5
+  peerDependencies:
+    "@types/express": ^4.17.13
+  peerDependenciesMeta:
+    "@types/express":
+      optional: true
+  checksum: f681ba7d798f723df2bf6bf1b47dbe82192f2708cdffd2c570f72f9ccc4f280f91af0fded3993734cc25c2f7e1b5ae6f0f3ba5cf0f3225750b4b6c9707dfd5e4
   languageName: node
   linkType: hard
 
@@ -22197,6 +22232,15 @@ __metadata:
   dependencies:
     fs-monkey: 1.0.3
   checksum: c947ef46e2036524ba120cb42fa502fd75dae8d49d0c53e818d3d3780b9a3a47845705cd1cf51eec04c70f1db590ca7b6c7f78dd5a65883bb253fcedf86f412c
+  languageName: node
+  linkType: hard
+
+"memfs@npm:^3.4.12":
+  version: 3.4.12
+  resolution: "memfs@npm:3.4.12::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fmemfs%2F-%2Fmemfs-3.4.12.tgz"
+  dependencies:
+    fs-monkey: ^1.0.3
+  checksum: dab8dec1ae0b2a92e4d563ac86846047cd7aeb17cde4ad51da85cff6e580c32d12b886354527788e36eb75f733dd8edbaf174476b7cea73fed9c5a0e45a6b428
   languageName: node
   linkType: hard
 
@@ -32566,7 +32610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-middleware@npm:*, webpack-dev-middleware@npm:5.3.3, webpack-dev-middleware@npm:^5.3.1":
+"webpack-dev-middleware@npm:*, webpack-dev-middleware@npm:^5.3.1":
   version: 5.3.3
   resolution: "webpack-dev-middleware@npm:5.3.3"
   dependencies:
@@ -32578,6 +32622,21 @@ __metadata:
   peerDependencies:
     webpack: ^4.0.0 || ^5.0.0
   checksum: dd332cc6da61222c43d25e5a2155e23147b777ff32fdf1f1a0a8777020c072fbcef7756360ce2a13939c3f534c06b4992a4d659318c4a7fe2c0530b52a8a6621
+  languageName: node
+  linkType: hard
+
+"webpack-dev-middleware@npm:6.0.1":
+  version: 6.0.1
+  resolution: "webpack-dev-middleware@npm:6.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fwebpack-dev-middleware%2F-%2Fwebpack-dev-middleware-6.0.1.tgz"
+  dependencies:
+    colorette: ^2.0.10
+    memfs: ^3.4.12
+    mime-types: ^2.1.31
+    range-parser: ^1.2.1
+    schema-utils: ^4.0.0
+  peerDependencies:
+    webpack: ^5.0.0
+  checksum: eeda09cf4a1fdb09ee95f96ab657b0fb8d32c56f4d20c7f4499457a015c703f243711fda0b5bc0d103ff9e7c7b9b60568210a4c0fbd6d02361d09d2387cd723a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6254,7 +6254,7 @@ __metadata:
     "@types/js-yaml": 4.0.5
     "@types/node": 16.18.3
     chokidar: 3.5.3
-    http-proxy-middleware: 2.0.6
+    http-proxy-middleware: 3.0.0-beta.0
     tslib: 2.4.1
   languageName: unknown
   linkType: soft
@@ -19091,24 +19091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:2.0.6, http-proxy-middleware@npm:^2.0.0, http-proxy-middleware@npm:^2.0.3":
-  version: 2.0.6
-  resolution: "http-proxy-middleware@npm:2.0.6"
-  dependencies:
-    "@types/http-proxy": ^1.17.8
-    http-proxy: ^1.18.1
-    is-glob: ^4.0.1
-    is-plain-obj: ^3.0.0
-    micromatch: ^4.0.2
-  peerDependencies:
-    "@types/express": ^4.17.13
-  peerDependenciesMeta:
-    "@types/express":
-      optional: true
-  checksum: 2ee85bc878afa6cbf34491e972ece0f5be0a3e5c98a60850cf40d2a9a5356e1fc57aab6cff33c1fc37691b0121c3a42602d2b1956c52577e87a5b77b62ae1c3a
-  languageName: node
-  linkType: hard
-
 "http-proxy-middleware@npm:3.0.0-beta.0":
   version: 3.0.0-beta.0
   resolution: "http-proxy-middleware@npm:3.0.0-beta.0"
@@ -19125,6 +19107,24 @@ __metadata:
     "@types/express":
       optional: true
   checksum: f681ba7d798f723df2bf6bf1b47dbe82192f2708cdffd2c570f72f9ccc4f280f91af0fded3993734cc25c2f7e1b5ae6f0f3ba5cf0f3225750b4b6c9707dfd5e4
+  languageName: node
+  linkType: hard
+
+"http-proxy-middleware@npm:^2.0.0, http-proxy-middleware@npm:^2.0.3":
+  version: 2.0.6
+  resolution: "http-proxy-middleware@npm:2.0.6"
+  dependencies:
+    "@types/http-proxy": ^1.17.8
+    http-proxy: ^1.18.1
+    is-glob: ^4.0.1
+    is-plain-obj: ^3.0.0
+    micromatch: ^4.0.2
+  peerDependencies:
+    "@types/express": ^4.17.13
+  peerDependenciesMeta:
+    "@types/express":
+      optional: true
+  checksum: 2ee85bc878afa6cbf34491e972ece0f5be0a3e5c98a60850cf40d2a9a5356e1fc57aab6cff33c1fc37691b0121c3a42602d2b1956c52577e87a5b77b62ae1c3a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8126,7 +8126,7 @@ __metadata:
 
 "@types/lodash@npm:^4":
   version: 4.14.190
-  resolution: "@types/lodash@npm:4.14.190::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2F%40types%252flodash%2F-%2Flodash-4.14.190.tgz"
+  resolution: "@types/lodash@npm:4.14.190"
   checksum: 353a55a1222a57224ead8bd3379fabb2e3e3f6685f599c48b1b66f099d8e9e015e6c6352c6e2275954004c3bb510377804c63117233c6f187700b6ab78adfa02
   languageName: node
   linkType: hard
@@ -17490,16 +17490,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-monkey@npm:1.0.3":
+"fs-monkey@npm:1.0.3, fs-monkey@npm:^1.0.3":
   version: 1.0.3
   resolution: "fs-monkey@npm:1.0.3"
-  checksum: cf50804833f9b88a476911ae911fe50f61a98d986df52f890bd97e7262796d023698cb2309fa9b74fdd8974f04315b648748a0a8ee059e7d5257b293bfc409c0
-  languageName: node
-  linkType: hard
-
-"fs-monkey@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "fs-monkey@npm:1.0.3::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Ffs-monkey%2F-%2Ffs-monkey-1.0.3.tgz"
   checksum: cf50804833f9b88a476911ae911fe50f61a98d986df52f890bd97e7262796d023698cb2309fa9b74fdd8974f04315b648748a0a8ee059e7d5257b293bfc409c0
   languageName: node
   linkType: hard
@@ -19118,7 +19111,7 @@ __metadata:
 
 "http-proxy-middleware@npm:3.0.0-beta.0":
   version: 3.0.0-beta.0
-  resolution: "http-proxy-middleware@npm:3.0.0-beta.0::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fhttp-proxy-middleware%2F-%2Fhttp-proxy-middleware-3.0.0-beta.0.tgz"
+  resolution: "http-proxy-middleware@npm:3.0.0-beta.0"
   dependencies:
     "@types/http-proxy": ^1.17.8
     debug: ^4.3.4
@@ -22237,7 +22230,7 @@ __metadata:
 
 "memfs@npm:^3.4.12":
   version: 3.4.12
-  resolution: "memfs@npm:3.4.12::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fmemfs%2F-%2Fmemfs-3.4.12.tgz"
+  resolution: "memfs@npm:3.4.12"
   dependencies:
     fs-monkey: ^1.0.3
   checksum: dab8dec1ae0b2a92e4d563ac86846047cd7aeb17cde4ad51da85cff6e580c32d12b886354527788e36eb75f733dd8edbaf174476b7cea73fed9c5a0e45a6b428
@@ -32627,7 +32620,7 @@ __metadata:
 
 "webpack-dev-middleware@npm:6.0.1":
   version: 6.0.1
-  resolution: "webpack-dev-middleware@npm:6.0.1::__archiveUrl=http%3A%2F%2Flocalhost%3A4873%2Fwebpack-dev-middleware%2F-%2Fwebpack-dev-middleware-6.0.1.tgz"
+  resolution: "webpack-dev-middleware@npm:6.0.1"
   dependencies:
     colorette: ^2.0.10
     memfs: ^3.4.12


### PR DESCRIPTION
- bump: http-proxy-middleware to 3.0.0-beta.0
- bump: webpack-dev-middleware to 6.0.1
- improve: proxy response interceptor
- improve: `@roots/bud-api/src/methods/proxy/index.ts`

refers:

- #1887 

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
