### PR TITLE
🩹 fix: bud.provide does not accept string values in object

### DIFF
--- a/sources/@roots/bud-api/src/methods/provide/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/provide/index.test.ts
@@ -1,11 +1,11 @@
-import {factory} from '@repo/test-kit/bud'
+import {Bud, factory} from '@repo/test-kit/bud'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {provide as provideFn} from './index.js'
 
 describe(`bud.provide`, () => {
-  let bud
-  let provide
+  let bud: Bud
+  let provide: provideFn
 
   beforeEach(async () => {
     bud = await factory()
@@ -14,6 +14,7 @@ describe(`bud.provide`, () => {
 
   it(`should thrown when no packages are provided`, async () => {
     try {
+      // @ts-ignore
       expect(await provide()).toThrowError(
         `bud.provide: packages must be an object`,
       )
@@ -25,6 +26,32 @@ describe(`bud.provide`, () => {
     await provide({jquery: [`$`, `jQuery`]})
 
     expect(getSpy).toHaveBeenCalled()
+  })
+
+  it(`should call setOptions when called with an array`, async () => {
+    const plugin = bud.extensions.get(
+      `@roots/bud-extensions/webpack-provide-plugin`,
+    )
+    const setOptionsSpy = vi.spyOn(plugin, `setOptions`)
+    await provide({jquery: [`$`, `jQuery`]})
+
+    expect(setOptionsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({$: `jquery`, jQuery: `jquery`}),
+    )
+  })
+
+  it(`should call setOptions when called with a string`, async () => {
+    const plugin = bud.extensions.get(
+      `@roots/bud-extensions/webpack-provide-plugin`,
+    )
+    const setOptionsSpy = vi.spyOn(plugin, `setOptions`)
+    await provide({jquery: `$`})
+
+    expect(setOptionsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $: `jquery`,
+      }),
+    )
   })
 
   it(`should return bud`, async () => {

--- a/sources/@roots/bud-api/src/methods/provide/index.ts
+++ b/sources/@roots/bud-api/src/methods/provide/index.ts
@@ -1,6 +1,6 @@
 import type {Bud} from '@roots/bud-framework'
 
-export type Parameters = [Record<string, Array<string>>]
+export type Parameters = [Record<string, Array<string> | string>]
 
 export interface provide {
   (...parameters: Parameters): Promise<Bud>
@@ -18,17 +18,21 @@ export const provide: provide = async function (this: Bud, packages) {
   const modified = Object.entries(packages).reduce(
     (
       acc: Record<string, string>,
-      [key, value]: [string, Array<string>],
-    ) => ({
-      ...(acc ?? {}),
-      ...value.reduce(
-        (all, item) => ({
-          ...(all ?? {}),
-          [item]: key,
-        }),
-        {},
-      ),
-    }),
+      [key, value]: [string, Array<string> | string],
+    ) => {
+      const normalValue = Array.isArray(value) ? value : [value]
+
+      return {
+        ...(acc ?? {}),
+        ...normalValue.reduce(
+          (all, item) => ({
+            ...(all ?? {}),
+            [item]: key,
+          }),
+          {},
+        ),
+      }
+    },
     options ?? {},
   )
 

--- a/sources/@roots/bud-api/src/methods/provide/provide.docs.md
+++ b/sources/@roots/bud-api/src/methods/provide/provide.docs.md
@@ -6,14 +6,22 @@ Makes a variable/module available throughout the entire application.
 
 ## Usage
 
-The following specifies that `$` is the default `jQuery` export:
+The following specifies that `$` is the default `jquery` export:
 
 ```js
 bud.provide({jquery: '$'})
 ```
 
-Now, in any module in our application, we can invoke jQuery with `$`. There is no need to import it.
+Now, in any module in our application, we can invoke `jquery` with `$`. There is no need to import it.
 
 ```js
 $(`#modal`) // it just works
+```
+
+If you have multiple references to resolve against a module, you can specify them with an array:
+
+```js
+bud.provide({
+  jquery: ['$', 'jQuery'],
+})
 ```


### PR DESCRIPTION
- 🩹 fix: `bud.provide` should accept `object` with `string` values.
- 📕 docs: update [bud.provide](https://bud.js.org/docs/bud.provide) documentation
- 🧪 test: add unit tests for `string` and `array` values

refers:

- https://discourse.roots.io/t/how-to-use-provide-in-bud-js/24315

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
