### PR TITLE
🩹 fix: 6.6.6 pre-release fixes

### DIFF
--- a/sources/@repo/docs/netlify.toml
+++ b/sources/@repo/docs/netlify.toml
@@ -16,7 +16,7 @@
   force = true
 
 [[redirects]]
-  from = "https://bud.js.org/docs/bud.html"
+  from = "https://bud.js.org/docs/bud.template"
   to = "https://bud.js.org/docs/bud.html"
   status = 301
   force = true

--- a/sources/@roots/bud-babel/src/extension.ts
+++ b/sources/@roots/bud-babel/src/extension.ts
@@ -24,13 +24,7 @@ export default class BabelExtension extends Extension {
    */
   public get cacheDirectory(): LoaderOptions[`cacheDirectory`] {
     return this.app.cache.enabled
-      ? this.app.path(
-          `@storage`,
-          this.app.label,
-          `cache`,
-          this.app.mode,
-          `babel`,
-        )
+      ? this.app.path(this.app.cache.cacheDirectory, `babel`)
       : false
   }
 
@@ -81,6 +75,7 @@ export default class BabelExtension extends Extension {
    */
   public get loaderOptions(): LoaderOptions {
     return {
+      cacheIdentifier: `babel`,
       cacheDirectory: this.cacheDirectory,
       presets: Object.values(this.presets),
       plugins: Object.values(this.plugins),

--- a/sources/@roots/bud-cache/src/invalidate-cache-extension/extension.test.ts
+++ b/sources/@roots/bud-cache/src/invalidate-cache-extension/extension.test.ts
@@ -12,25 +12,20 @@ describe(`@roots/bud-cache/invalidate-cache-extension`, () => {
       async pkg => await pkg.factory(),
     )
 
-    expect(
-      new Extension(
-        // @ts-ignore
-        bud,
-      ),
-    ).toHaveProperty(`label`, `@roots/bud-cache/invalidate-cache`)
+    expect(new Extension(bud)).toHaveProperty(
+      `label`,
+      `@roots/bud-cache/invalidate-cache`,
+    )
   })
 
   it(`should have an error file accessor`, async () => {
     const bud = await import(`@repo/test-kit/bud`).then(
       async pkg => await pkg.factory(),
     )
-    const extension = new Extension(
-      // @ts-ignore
-      bud,
-    )
+    const extension = new Extension(bud)
 
     expect(extension.invalidationFile).toStrictEqual(
-      expect.stringContaining(`${bud.label}/production.error.json`),
+      expect.stringContaining(`${bud.label}/cache/production/error.json`),
     )
   })
 

--- a/sources/@roots/bud-cache/src/invalidate-cache-extension/index.ts
+++ b/sources/@roots/bud-cache/src/invalidate-cache-extension/index.ts
@@ -24,11 +24,7 @@ export default class InvalidateCacheExtension extends Extension {
    * @public
    */
   public get invalidationFile(): string {
-    return join(
-      this.app.cache.cacheDirectory,
-      this.app.label,
-      `${this.app.mode}.error.json`,
-    )
+    return join(this.app.cache.cacheDirectory, `error.json`)
   }
 
   /**

--- a/sources/@roots/bud-dashboard/src/dashboard/app.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/app.tsx
@@ -28,11 +28,8 @@ const App = ({
       {compilations.map((compilation, id) => (
         <Box key={id} flexDirection="column" paddingY={1}>
           <Compilation
-            id={id}
-            mode={mode}
             compilation={compilation}
             context={context}
-            compilerCount={compilations.length}
             displayAssets={displayAssets}
             displayEntrypoints={displayEntrypoints}
           />

--- a/sources/@roots/bud-dashboard/src/dashboard/messages/messages.component.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/messages/messages.component.tsx
@@ -19,30 +19,32 @@ const Messages = ({
   const formatted = messages
     ?.reverse()
     .filter(({message}) => !message?.includes(`HookWebpackError`))
-    .map(({stack, message}: {stack: string; message: string}) => ({
-      stack,
+    .map(({message}: {message: string}) => ({
       message: message
-        .split(`SyntaxError`)
+        /* Discard unhelpful stack traces */
+        .split(/  at /)
+        .shift()
+        /* Discard unhelpful stuff preceeding message */
+        .split(/SyntaxError:?/)
         .pop()
-        .trim()
+        .split(/Error:?/)
+        .pop()
+        .split(/ModuleError:?/)
+        .pop()
+        /* Discard empty lines */
         .split(`\n`)
-        .map(ln => `${chalk.dim(VERT)} ${ln.replace(process.cwd(), `.`)}`)
-        .join(`\n`)
-        .split(`Error:`)
-        .pop()
-        .split(`ModuleError`)
-        .pop()
-        .split(`\n`)
+        // trim and format
         .filter(ln => ![``, ` `, `\n`].includes(ln))
-        .join(`\n`)
-        .trim(),
+        // replace cwd with `.`
+        .map(ln => `${chalk.dim(VERT)} ${ln.replace(process.cwd(), `.`)}`)
+        .join(`\n`),
     }))
 
   if (!formatted) return null
 
   return (
     <Box flexDirection="column">
-      {formatted?.map(({message, stack}, index: number) => (
+      {formatted?.map(({message}, index: number) => (
         <Box key={index} flexDirection="column">
           <Box flexDirection="row">
             <Text dimColor>├─</Text>

--- a/sources/@roots/bud-extensions/src/service/__snapshots__/index.test.ts.snap
+++ b/sources/@roots/bud-extensions/src/service/__snapshots__/index.test.ts.snap
@@ -14,9 +14,6 @@ exports[`@roots/bud-extensions > bud.extensions.repository options should match 
   "@roots/bud-extensions/webpack-hot-module-replacement-plugin",
   "@roots/bud-extensions/webpack-manifest-plugin",
   "@roots/bud-extensions/webpack-provide-plugin",
-  "@roots/bud-postcss",
-  "@roots/bud-swc",
-  "@roots/bud-tailwindcss",
   "@roots/bud-terser",
   "@roots/bud-terser/css-minimizer",
 ]

--- a/sources/@roots/bud-swc/src/extension.ts
+++ b/sources/@roots/bud-swc/src/extension.ts
@@ -77,6 +77,7 @@ export default class BudSWC extends Extension<Options> {
         ) => Options['jsc']['experimental']['plugins']),
   ) {
     const options = this.getOptions()
+
     const value =
       typeof plugins === `function`
         ? plugins(options?.jsc?.experimental?.plugins)
@@ -111,7 +112,7 @@ export default class BudSWC extends Extension<Options> {
         ...(options?.jsc ?? {}),
         experimental: {
           ...(options?.jsc?.experimental ?? {}),
-          cacheRoot: bud.path(bud.cache.cacheDirectory),
+          cacheRoot: bud.path(bud.cache.cacheDirectory, `swc`),
         },
         target: this.app.esm.enabled ? `es2022` : `es2019`,
       },

--- a/sources/@roots/bud-tailwindcss/src/extension.test.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension.test.ts
@@ -35,7 +35,7 @@ describe(`@roots/bud-tailwindcss extension`, () => {
         },
       },
     }
-
+    await bud.extensions.add(`@roots/bud-postcss`)
     extension = new BudTailwindCss(bud)
     await extension.init()
   })
@@ -60,13 +60,18 @@ describe(`@roots/bud-tailwindcss extension`, () => {
 
   it(`should attempt to resolve modules`, async () => {
     const bud = await factory()
+    const extension = new BudTailwindCss(bud)
+    await bud.extensions.add(`@roots/bud-postcss`)
     const resolveSpy = vi.spyOn(bud.module, `resolve`)
 
-    const extension = new BudTailwindCss(bud)
     await extension.init()
     await extension.configAfter(bud)
 
-    expect(resolveSpy).toHaveBeenCalledTimes(2)
+    expect(resolveSpy).toHaveBeenNthCalledWith(1, `tailwindcss`)
+    expect(resolveSpy).toHaveBeenNthCalledWith(
+      2,
+      `tailwindcss/nesting/index.js`,
+    )
   })
 
   it(`should return a copy of the resolved config`, async () => {

--- a/sources/@roots/bud-tailwindcss/src/extension.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension.ts
@@ -175,7 +175,13 @@ export class BudTailwindCss extends Extension<{
    */
   @bind
   public override async configAfter(bud: Bud) {
-    bud.postcss.setPlugins({
+    if (!bud.postcss) {
+      throw new Error(
+        `@roots/bud-postcss is required to run @roots/bud-tailwindcss`,
+      )
+    }
+
+    bud.postcss?.setPlugins({
       nesting: this.dependencies.nesting,
       tailwindcss: this.dependencies.tailwindcss,
     })
@@ -199,8 +205,8 @@ export class BudTailwindCss extends Extension<{
         ),
     })
 
-    bud.hooks.async(`build.resolve.alias`, async alias => ({
-      ...alias,
+    bud.hooks.async(`build.resolve.alias`, async (aliases = {}) => ({
+      ...aliases,
       [`@tailwind`]: `${bud.path(`@src`, `__bud`, `@tailwind`)}`,
     }))
   }

--- a/sources/@roots/bud/src/cli/commands/bud.doctor.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.doctor.tsx
@@ -5,24 +5,17 @@ import {Box, Text} from '@roots/bud-support/ink'
 import React from '@roots/bud-support/react'
 import webpack from '@roots/bud-support/webpack'
 
+import {dry} from '../decorators/command.dry.js'
+
 /**
  * `bud doctor` command
  *
  * @public
+ * @decorator `@dry`
  */
+@dry
 export default class BudDoctorCommand extends BudCommand {
-  /**
-   * Command paths
-   *
-   * @public
-   */
   public static override paths = [[`doctor`]]
-
-  /**
-   * Command usage
-   *
-   * @public
-   */
   public static override usage = Command.Usage({
     description: `Check project for common errors`,
     details: `\
@@ -49,9 +42,10 @@ for a lot of edge cases so it might return a false positive.
   public configuration: webpack.Configuration
 
   /**
-   * Command execute
+   * Execute command
    *
    * @public
+   * @decorator `@bind`
    */
   public override async execute() {
     await this.makeBud(this)

--- a/sources/@roots/bud/src/context/__snapshots__/index.test.ts.snap
+++ b/sources/@roots/bud/src/context/__snapshots__/index.test.ts.snap
@@ -3,10 +3,7 @@
 exports[`context.get > should match expectations 1`] = `
 {
   "extensions": {
-    "denylist": [
-      "@roots/bud-babel",
-    ],
-    "discover": false,
+    "discovery": false,
   },
 }
 `;

--- a/sources/@roots/bud/src/notifier/index.test.ts
+++ b/sources/@roots/bud/src/notifier/index.test.ts
@@ -71,9 +71,9 @@ describe(`notifier`, () => {
   })
 
   it(`should call open`, async () => {
+    bud.compiler.stats = {toJson: () => ({})}
     bud.context.mode = `development`
     bud.context.args.browser = true
-    notifier.setStats({errors: [{message: `foo`}]})
 
     const openBrowserSpy = vi.spyOn(notifier, `openBrowser`)
 
@@ -89,6 +89,7 @@ describe(`notifier`, () => {
   })
 
   it(`should call notificationCenter.notify`, async () => {
+    bud.compiler.stats = {toJson: () => ({})}
     const notifySpy = vi.spyOn(notifier, `notify`)
     await notifier.compilationNotification()
     expect(notifySpy).toBeCalledTimes(1)

--- a/sources/@roots/sage/src/sage/extension.test.ts
+++ b/sources/@roots/sage/src/sage/extension.test.ts
@@ -12,19 +12,19 @@ describe(`@roots/sage`, async () => {
     sage = new Sage(bud)
   })
 
-  it(`shouldn't try to call tailwindcss if it doesn't exist`, async () => {
-    // @ts-ignore
-    bud.extensions.remove(`@roots/bud-tailwindcss`)
-    const extensionsGetSpy = vi.spyOn(bud.extensions, `get`)
-
+  it(`shouldn't add @roots/sage/wp-theme-json-tailwind when @roots/bud-tailwindcss is not present`, async () => {
+    const addSpy = vi.spyOn(bud.extensions, `add`)
     await sage.register(bud)
-    expect(extensionsGetSpy).not.toHaveBeenCalled()
+    expect(addSpy).not.toHaveBeenCalled()
   })
 
-  it(`shouldn't try to call tailwindcss if it doesn't exist`, async () => {
-    const extensionsGetSpy = vi.spyOn(bud.extensions, `get`)
+  it(`should add @roots/sage/wp-theme-json-tailwind when @roots/bud-tailwindcss is present`, async () => {
+    await bud.extensions.add(`@roots/bud-tailwindcss`)
+    const addSpy = vi.spyOn(bud.extensions, `add`)
     await sage.register(bud)
-    expect(extensionsGetSpy).toHaveBeenCalled()
+    expect(addSpy).toHaveBeenCalledWith(
+      `@roots/sage/wp-theme-json-tailwind`,
+    )
   })
 
   it(`should register errything`, async () => {

--- a/tests/unit/__snapshots__/extensions.production.test.ts.snap
+++ b/tests/unit/__snapshots__/extensions.production.test.ts.snap
@@ -15,9 +15,6 @@ exports[`production extensions > should match snapshot 1`] = `
   "@roots/bud-extensions/webpack-hot-module-replacement-plugin",
   "@roots/bud-extensions/webpack-manifest-plugin",
   "@roots/bud-extensions/webpack-provide-plugin",
-  "@roots/bud-postcss",
-  "@roots/bud-swc",
-  "@roots/bud-tailwindcss",
   "@roots/bud-terser",
   "@roots/bud-terser/css-minimizer",
 ]

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -13,8 +13,17 @@ describe(`test environment sanity checks`, () => {
     )
   })
 
-  it(`bud mock should be banning @roots/bud-swc`, async () => {
+  it(`bud should be prevented from auto-loading extensions`, async () => {
     const bud = await factory({mode: `production`})
-    expect(bud.extensions.repository).toHaveProperty(`@roots/bud-swc`)
+    expect(bud.extensions.repository).not.toHaveProperty(
+      `@roots/bud-postcss`,
+    )
+    expect(bud.extensions.repository).not.toHaveProperty(`@roots/bud-swc`)
+    expect(bud.extensions.repository).not.toHaveProperty(
+      `@roots/bud-tailwindcss`,
+    )
+    expect(bud.extensions.repository).not.toHaveProperty(
+      `@roots/bud-babel`,
+    )
   })
 })

--- a/tests/util/project/package.json
+++ b/tests/util/project/package.json
@@ -6,10 +6,7 @@
   ],
   "bud": {
     "extensions": {
-      "discover": false,
-      "denylist": [
-        "@roots/bud-babel"
-      ]
+      "discovery": false
     }
   },
   "devDependencies": {

--- a/tests/util/project/src/scripts/app.js
+++ b/tests/util/project/src/scripts/app.js
@@ -7,4 +7,4 @@ const init = async () =>
 
 init()
 
-import.meta.webpackHot?.accept()
+import.meta.webpackHot?.accept(console.error)


### PR DESCRIPTION
- 🩹🧪 fix: extra extensions being loaded by test env
- 🩹 fix: `bud doctor` isn't dry-run
- 🩹 fix: cache conflicts with `@roots/bud-swc` in multi-instance
- 🩹 fix: `--editor` flag not opening errors emitted by `@roots/bud-babel`
- ✨ improve: better error display in `@roots/bud-dashboard` compilation summary

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
