### PR TITLE
🩹 fix: @roots/bud-dashboard error renderer

### DIFF
--- a/sources/@roots/bud-dashboard/src/dashboard/app.test.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/app.test.tsx
@@ -5,7 +5,13 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import App from './app'
 
-const mockCompilations = [{}]
+const mockCompilations = [
+  {
+    assets: [],
+    entrypoints: {},
+    errors: [],
+  },
+]
 
 describe(`@roots/bud-dashboard app component`, () => {
   let bud

--- a/sources/@roots/bud-dashboard/src/dashboard/compilation/compilation.component.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/compilation/compilation.component.tsx
@@ -51,22 +51,21 @@ const Compilation = ({
 }: Props) => {
   if (!compilation) return null
 
-  const groupAssets = makeAssetGroupCallback(compilation?.assets)
+  const groupAssets = makeAssetGroupCallback(compilation.assets)
 
-  const entrypoints: AssetGroup = compilation?.entrypoints
-    ? Object.values(compilation?.entrypoints)
-        .filter(Boolean)
-        .map(entrypoint => ({
-          ...entrypoint,
-          assets: entrypoint.assets.map(groupAssets),
-        }))
-    : []
+  const entrypoints: AssetGroup = Object.values(compilation.entrypoints)
+    .filter(Boolean)
+    .map(entrypoint => ({
+      ...entrypoint,
+      assets: entrypoint.assets.map(groupAssets),
+    }))
 
-  const assets: Array<AssetGroup> = (compilation?.assets ?? [])
+  const assets: Array<AssetGroup> = compilation.assets
     .filter(onlyNotHot)
     .filter(onlyStatic)
     .filter(Boolean)
     .map(groupAssets)
+
   const truncatedAssets: Array<AssetGroup> = assets.splice(5)
 
   const longestEntrypointAssetLength: number = entrypoints.reduce(
@@ -79,16 +78,16 @@ const Compilation = ({
     <Box flexDirection="column">
       <Box flexDirection="row">
         <Text color={colorFromStats(compilation)}>
-          {compilation?.errorsCount > 0
+          {compilation.errorsCount > 0
             ? figures.cross
             : figures.circleFilled}
         </Text>
 
         <Text>{`  `}</Text>
-        <Text>{compilation?.name}</Text>
+        <Text>{compilation.name}</Text>
         <Text> {``}</Text>
 
-        {compilation?.outputPath && (
+        {compilation.outputPath && (
           <Text color={color.blue}>
             ./{relative(context.basedir, compilation.outputPath)}
           </Text>
@@ -96,10 +95,10 @@ const Compilation = ({
 
         <Text>{` `}</Text>
 
-        <Text dimColor>[{compilation?.hash}]</Text>
+        <Text dimColor>[{compilation.hash}]</Text>
       </Box>
 
-      {!compilation?.isChild && (
+      {!compilation.isChild && (
         <>
           <Text dimColor>{VERT}</Text>
 
@@ -194,8 +193,8 @@ const Compilation = ({
 
       <Title final={true}>
         <Text dimColor>
-          compiled {compilation?.modules?.length} modules in{` `}
-          {duration(compilation?.time) as string}
+          compiled {compilation.modules?.length} modules in{` `}
+          {duration(compilation.time) as string}
         </Text>
       </Title>
     </Box>

--- a/sources/@roots/bud-dashboard/src/dashboard/format.ts
+++ b/sources/@roots/bud-dashboard/src/dashboard/format.ts
@@ -1,8 +1,4 @@
-import type {
-  StatsAsset,
-  StatsChunkGroup,
-  StatsCompilation,
-} from '@roots/bud-support/webpack'
+import type {StatsAsset, StatsChunkGroup} from '@roots/bud-support/webpack'
 import figures from 'figures'
 import {durationFormatter, sizeFormatter} from 'human-readable'
 
@@ -32,9 +28,12 @@ export const longestAssetNameLength = (chunks: StatsChunkGroup) =>
 
 export const size: (int: number) => string = sizeFormatter()
 
-export const colorFromStats = (stats: StatsCompilation) =>
-  stats?.errorsCount > 0
+export const colorFromStats = (compilation: {
+  errorsCount?: number
+  warningsCount?: number
+}) =>
+  compilation.errorsCount > 0
     ? color.red
-    : stats?.warningsCount > 0
+    : compilation.warningsCount > 0
     ? color.yellow
     : color.green

--- a/sources/@roots/bud-dashboard/src/dashboard/messages/messages.component.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/messages/messages.component.tsx
@@ -16,36 +16,12 @@ const Messages = ({
   messages: StatsCompilation['errors'] | StatsCompilation['warnings']
   color: string
 }) => {
-  const formatted = messages
-    ?.reverse()
-    .filter(({message}) => !message?.includes(`HookWebpackError`))
-    .map(({message}: {message: string}) => ({
-      message: message
-        /* Discard unhelpful stack traces */
-        .split(/  at /)
-        .shift()
-        /* Discard unhelpful stuff preceeding message */
-        .split(/SyntaxError:?/)
-        .pop()
-        .split(/Error:?/)
-        .pop()
-        .split(/ModuleError:?/)
-        .pop()
-        /* Discard empty lines */
-        .split(`\n`)
-        // trim and format
-        .filter(ln => ![``, ` `, `\n`].includes(ln))
-        // replace cwd with `.`
-        .map(ln => `${chalk.dim(VERT)} ${ln.replace(process.cwd(), `.`)}`)
-        .join(`\n`),
-    }))
-
-  if (!formatted) return null
+  if (!messages) return null
 
   return (
     <Box flexDirection="column">
-      {formatted?.map(({message}, index: number) => (
-        <Box key={index} flexDirection="column">
+      {messages.map(({message}, id: number) => (
+        <Box key={id} flexDirection="column">
           <Box flexDirection="row">
             <Text dimColor>├─</Text>
             <Text>{` `}</Text>


### PR DESCRIPTION
- fix: error rendering for babel, swc, postcss loaders

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
