### PR TITLE
✨ improve: node api

### DIFF
--- a/examples/node-api/01-simple.js
+++ b/examples/node-api/01-simple.js
@@ -1,0 +1,34 @@
+import {factory} from '@roots/bud'
+
+/**
+ * Run this example with:
+ *
+ * ```sh
+ * yarn node 01-simple.js
+ * ```
+ */
+
+/**
+ * Instantiate bud
+ */
+const bud = await factory()
+
+/**
+ * Set path
+ */
+bud.setPath(`@dist`, `dist/build-a`)
+
+/**
+ * Add extensions
+ */
+await bud.extensions.add([`@roots/bud-swc`])
+
+/**
+ * Set entrypoints and do other config as usual
+ */
+bud.minimize(false).splitChunks(false)
+
+/**
+ * Run build
+ */
+await bud.run()

--- a/examples/node-api/02-factory.js
+++ b/examples/node-api/02-factory.js
@@ -1,0 +1,87 @@
+import {join} from 'node:path'
+import {factory, instances, get} from '@roots/bud'
+
+/**
+ * Run this example with:
+ *
+ * ```sh
+ * yarn node factory.js
+ * ```
+ */
+
+/**
+ * Before anything has ran you should expect {@link instances} to be defined but empty.
+ */
+console.assert(Object.entries(instances).length === 0)
+
+/**
+ * When you use {@link factory} to create a new instance of {@link bud}
+ */
+const bud = await factory()
+
+/**
+ * You can observe our old assertion is no longer valid.
+ * {@link bud} was registered to {@link instances}
+ */
+console.assert(Object.entries(instances).length !== 0)
+
+/**
+ * If we call {@link factory} again we get {@link bud} again. This is because
+ * we are requesting an instance with the same {@link bud.context.basedir}.
+ *
+ * We are using the default context so the basedir is the current working directory.
+ */
+const bud2 = await factory()
+console.assert(bud2 === bud)
+
+/** bud.js instance still only created once */
+console.assert(Object.keys(instances).length === 1)
+console.log(Object.keys(instances))
+
+/**
+ * Since they are literally the same object
+ * a change made to {@link bud} is a change made to {@link bud2}
+ */
+bud.setPath(`@dist`, `dist/changed-path`)
+console.assert(bud2.path(`@dist`) === bud.path(`@dist`))
+
+/**
+ * If we want a separate instance of {@link bud}
+ * we can pass a {@link bud.context} with a unique {@link bud.context.basedir}
+ */
+const bud3 = await factory({basedir: join(process.cwd(), `src/demo`)})
+
+console.assert(bud3 !== bud) // it's a new instance
+console.assert(Object.keys(instances).length === 2) // it's registered with a unique key
+console.log(Object.keys(instances)) // see for yourself in the terminal
+
+/**
+ * Generally you probably don't want multiple instances referring to the same directory.
+ * But, we can force a fresh instance regardless of its context by explicitly
+ * requesting it with {@link factory}. This might be helpful for testing.
+ */
+
+/** normally would return the {@link bud} instance */
+const bud4Context = {basedir: process.cwd()}
+
+/** but we'll skip the {@link instances} cache */
+const bud4Options = {cache: false}
+
+/** Pass an options object as a second parameter to {@link factory} */
+const bud4 = await factory(bud4Context, bud4Options)
+
+/** They are different instances despite sharing the same context */
+console.assert(bud4 !== bud)
+
+/** But, note that the new instance is not registered in the {@link instances} registry */
+console.assert(Object.keys(instances).length === 2)
+
+/**
+ * You can request an instance from the registry using {@link get}
+ */
+const bud6 = get(process.cwd())
+/**
+ * The returned instance is the same object referenced by {@link bud} and {@link bud2}
+ */
+console.assert(bud6 === bud)
+console.assert(bud6 === bud2)

--- a/examples/node-api/package.json
+++ b/examples/node-api/package.json
@@ -6,10 +6,9 @@
   ],
   "type": "module",
   "devDependencies": {
-    "@roots/browserslist-config": "latest",
-    "@roots/bud": "latest",
-    "@roots/bud-babel": "latest",
-    "webpack": "5.75.0",
+    "@roots/browserslist-config": "workspace:sources/@roots/browserslist-config",
+    "@roots/bud": "workspace:sources/@roots/bud",
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc",
     "webpack-cli": "5.0.1"
   }
 }

--- a/examples/node-api/webpack.config.js
+++ b/examples/node-api/webpack.config.js
@@ -1,22 +1,24 @@
 import {factory} from '@roots/bud'
 
 /**
- * For info on configuring webpack with a function or promise:
- * {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-promise}
+ * Run this example with:
+ *
+ * ```sh
+ * yarn webpack
+ * ```
  */
-export default async env => {
-  /**
-   * Instantiate bud
-   */
-  const bud = await factory()
 
-  /**
-   * Set entrypoints and do other config as usual
-   */
-  bud.when(env.production, () => bud.minimize().splitChunks())
+/**
+ * Instantiate bud
+ */
+const bud = await factory()
 
-  /**
-   * This is our final config object. Return it for webpack.
-   */
-  return await bud.build.make()
-}
+/**
+ * Set entrypoints and do other config as usual
+ */
+bud.minimize().splitChunks()
+
+/**
+ * Export for webpack
+ */
+export default bud.build.make

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -9,10 +9,10 @@
     "build": "yarn ts-bud build"
   },
   "devDependencies": {
-    "@roots/browserslist-config": "0.0.0",
-    "@roots/bud": "0.0.0",
-    "@roots/bud-babel": "0.0.0",
-    "@roots/bud-typescript": "0.0.0",
+    "@roots/browserslist-config": "latest",
+    "@roots/bud": "latest",
+    "@roots/bud-babel": "latest",
+    "@roots/bud-typescript": "latest",
     "@types/webpack-env": "latest",
     "ts-node": "10.9.1"
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
       "sources/@roots/*",
       "sources/@repo/*",
       "sources/@roots/*/src/__fixtures__/*",
+      "examples/node-api",
       "tests/util/project",
       "tests/reproductions/*"
     ]

--- a/sources/@repo/test-kit/bud.ts
+++ b/sources/@repo/test-kit/bud.ts
@@ -4,9 +4,11 @@ import '@roots/bud'
 import {join} from 'node:path'
 
 import {paths} from '@repo/constants'
-import {Bud} from '@roots/bud'
+import type {Bud as BaseBud} from '@roots/bud'
 import {factory as makeInstance} from '@roots/bud/factory'
 import type * as Options from '@roots/bud-framework/options'
+
+type Bud = BaseBud & {context: Options.CommandContext}
 
 export const repoPath = (...path: Array<string>) =>
   join(paths.root, ...(path ?? []))
@@ -14,9 +16,9 @@ export const repoPath = (...path: Array<string>) =>
 export const basedir = repoPath(`tests`, `util`, `project`)
 
 export const factory = async (
-  overrides?: Partial<Options.Context> | undefined,
+  overrides: Partial<Options.CommandContext> = {},
   run = false,
-): Promise<Bud> => {
+): Promise<Bud & {context: Options.CommandContext}> => {
   const bud = await makeInstance(
     {
       basedir,
@@ -28,8 +30,11 @@ export const factory = async (
         ...(overrides?.args ?? {}),
       },
     },
-    false,
+    {cache: false, find: true},
   )
+
+  if (!bud.isCLI())
+    throw new Error(`test error: bud is not a CLI instance`)
 
   if (run) await bud.run()
 

--- a/sources/@roots/bud-api/src/methods/html/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/html/index.test.ts
@@ -1,4 +1,5 @@
-import {Bud, factory} from '@repo/test-kit/bud'
+import {factory} from '@repo/test-kit/bud'
+import {Bud} from '@roots/bud'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import * as source from './index.js'

--- a/sources/@roots/bud-build/src/config/infrastructureLogging.ts
+++ b/sources/@roots/bud-build/src/config/infrastructureLogging.ts
@@ -14,8 +14,5 @@ export const infrastructureLogging: Factory<
       time: bud.context.logger.time,
       timeEnd: bud.context.logger.timeEnd,
     }),
-    level: bud.hooks.filter(
-      `build.infrastructureLogging.level`,
-      bud.context.args.verbose ? `log` : `info`,
-    ),
+    level: bud.hooks.filter(`build.infrastructureLogging.level`, `log`),
   })

--- a/sources/@roots/bud-cache/src/invalidate-cache-extension/index.ts
+++ b/sources/@roots/bud-cache/src/invalidate-cache-extension/index.ts
@@ -37,7 +37,7 @@ export default class InvalidateCacheExtension extends Extension {
   public override async register(bud: Bud) {
     const invalidate = await bud.fs?.exists(this.invalidationFile)
 
-    if (invalidate || bud.context.args.flush) {
+    if (invalidate || (bud.isCLI() && bud.context.args.flush)) {
       await bud.fs.remove(this.invalidationFile)
       await bud.fs.remove(bud.cache.cacheDirectory)
     }

--- a/sources/@roots/bud-compiler/src/compiler.service.ts
+++ b/sources/@roots/bud-compiler/src/compiler.service.ts
@@ -84,7 +84,7 @@ export class Compiler extends Service implements Contract.Service {
 
     this.app.context.logger.timeEnd(`initialize`)
 
-    if (this.app.context.args.dry) {
+    if (this.app.isCLI() && this.app.context.args.dry) {
       this.logger.log(`running in dry mode. exiting early.`)
       return
     }

--- a/sources/@roots/bud-compiler/src/compiler.test.ts
+++ b/sources/@roots/bud-compiler/src/compiler.test.ts
@@ -45,7 +45,7 @@ describe(`@roots/bud-compiler`, function () {
   })
 
   it(`should log early exit (--dry)`, async () => {
-    compiler.app.context.args.dry = true
+    bud.context.args.dry = true
     const logSpy = vi.spyOn(compiler.logger, `log`)
     await compiler.compile()
     expect(logSpy).toHaveBeenCalledTimes(3)

--- a/sources/@roots/bud-dashboard/src/service.tsx
+++ b/sources/@roots/bud-dashboard/src/service.tsx
@@ -32,7 +32,7 @@ export class Dashboard extends Service implements Contract {
   }
 
   public get silent() {
-    return this.app.context.args.log === false
+    return this.app.isCLI() && this.app.context.args.log === false
   }
 
   /**
@@ -46,7 +46,7 @@ export class Dashboard extends Service implements Contract {
     if (!stats || this.silent || this.stale(stats)) return this
     this.stats = stats
 
-    if (this.app.context.args?.ci === true) {
+    if (!this.app.isCLI() || this.app.context.args?.ci === true) {
       const stringCompilation = stats.toString({
         preset: `minimal`,
         colors: true,

--- a/sources/@roots/bud-extensions/src/extensions/webpack-manifest-plugin/index.ts
+++ b/sources/@roots/bud-extensions/src/extensions/webpack-manifest-plugin/index.ts
@@ -5,6 +5,7 @@ import {
   options,
   plugin,
 } from '@roots/bud-framework/extension/decorators'
+import {isUndefined} from '@roots/bud-support/lodash-es'
 import {
   ManifestPluginOptions as Options,
   WebpackManifestPlugin,
@@ -41,9 +42,11 @@ export default class BudWebpackManifestPlugin extends Extension<
    */
   @bind
   public override async when(bud: Bud) {
-    return (
-      bud.hooks.filter(`feature.manifest`) &&
-      bud.context.args.manifest !== false
-    )
+    if (!bud.isCLI()) return bud.hooks.filter(`feature.manifest`, true)
+
+    if (!isUndefined(bud.context.args.manifest))
+      return bud.context.args.manifest
+
+    return bud.hooks.filter(`feature.manifest`, true)
   }
 }

--- a/sources/@roots/bud-extensions/src/service/index.ts
+++ b/sources/@roots/bud-extensions/src/service/index.ts
@@ -101,7 +101,6 @@ export default class Extensions
     if (manifest?.[this.app.label]?.extensions) {
       const {discovery, allowlist, denylist} =
         manifest[this.app.label].extensions
-
       if (!isUndefined(discovery)) this.options.set(`discovery`, discovery)
       if (!isUndefined(allowlist))
         this.options.merge(`allowlist`, allowlist)
@@ -116,10 +115,10 @@ export default class Extensions
         bud.context.extensions.builtIn.filter(Boolean).map(this.import),
       )
 
-    if (!isUndefined(bud.context.args.discovery)) {
+    if (bud.isCLI() && !isUndefined(bud.context.args.discovery)) {
       this.options.set(`discovery`, bud.context.args.discovery)
     }
-    if (!isUndefined(bud.context.args.discovery)) {
+    if (bud.isCLI() && !isUndefined(bud.context.args.discovery)) {
       this.options.set(`discovery`, bud.context.args.discovery)
     }
 

--- a/sources/@roots/bud-extensions/src/service/index.ts
+++ b/sources/@roots/bud-extensions/src/service/index.ts
@@ -87,7 +87,7 @@ export default class Extensions
    */
   @bind
   public override async booted?(bud: Bud): Promise<void> {
-    const {manifest} = bud.context
+    const {extensions, manifest} = bud.context
 
     if (manifest?.bud?.extensions) {
       const {discovery, allowlist, denylist} = manifest.bud.extensions
@@ -108,16 +108,13 @@ export default class Extensions
     }
 
     if (
-      !isUndefined(bud.context.extensions.builtIn) &&
-      Array.isArray(bud.context.extensions.builtIn)
+      !isUndefined(extensions.builtIn) &&
+      Array.isArray(extensions.builtIn)
     )
       await Promise.all(
-        bud.context.extensions.builtIn.filter(Boolean).map(this.import),
+        extensions.builtIn.filter(Boolean).map(this.import),
       )
 
-    if (bud.isCLI() && !isUndefined(bud.context.args.discovery)) {
-      this.options.set(`discovery`, bud.context.args.discovery)
-    }
     if (bud.isCLI() && !isUndefined(bud.context.args.discovery)) {
       this.options.set(`discovery`, bud.context.args.discovery)
     }
@@ -125,7 +122,6 @@ export default class Extensions
     if (
       this.options.is(`discovery`, true) &&
       this.options.isEmpty(`allowlist`) &&
-      bud.context.extensions?.discovered &&
       Array.isArray(bud.context.extensions.discovered)
     )
       await Promise.all(

--- a/sources/@roots/bud-framework/src/bud.ts
+++ b/sources/@roots/bud-framework/src/bud.ts
@@ -29,7 +29,14 @@ export class Bud {
    *
    * @public
    */
-  public context: Options.Context
+  public context:
+    | Options.CommandContext
+    | Options.CLIContext
+    | Options.Context
+
+  public isCLI(): this is Bud & {context: Options.CommandContext} {
+    return !isUndefined((this as any).context.args)
+  }
 
   /**
    * Implementation
@@ -241,6 +248,18 @@ export class Bud {
     const context: Options.Context = isString(request)
       ? {...this.context, label: request, root: this}
       : {...this.context, ...request, root: this}
+
+    if (
+      this.isCLI() &&
+      !isUndefined(this.context.args.filter) &&
+      !this.context.args.filter.includes(context.label)
+    ) {
+      this.log(
+        `skipping child instance based on --filter flag:`,
+        context.label,
+      )
+      return this
+    }
 
     if (this.children && this.children[context.label]) {
       this.log(`returning requested child instance:`, context.label)

--- a/sources/@roots/bud-framework/src/bud.ts
+++ b/sources/@roots/bud-framework/src/bud.ts
@@ -35,7 +35,7 @@ export class Bud {
     | Options.Context
 
   public isCLI(): this is Bud & {context: Options.CommandContext} {
-    return !isUndefined((this as any).context.args)
+    return `args` in this.context
   }
 
   /**

--- a/sources/@roots/bud-framework/src/lifecycle/init.ts
+++ b/sources/@roots/bud-framework/src/lifecycle/init.ts
@@ -1,3 +1,5 @@
+import {isString} from '@roots/bud-support/lodash-es'
+
 import type {Bud} from '../bud.js'
 
 /**
@@ -40,10 +42,25 @@ export const initialize = (bud: Bud): Bud =>
       'pattern.json5': /\.json5$/,
     })
     .hooks.fromMap({
-      'location.@src': bud.context.args.input ?? `src`,
-      'location.@dist': bud.context.args.output ?? `dist`,
-      'location.@storage': bud.context.args.storage ?? `.budfiles`,
-      'location.@modules': bud.context.args.modules ?? `node_modules`,
+      'location.@src':
+        bud.isCLI() && isString(bud.context.args.input)
+          ? bud.context.args.input
+          : `src`,
+
+      'location.@dist':
+        bud.isCLI() && isString(bud.context.args.output)
+          ? bud.context.args.output
+          : `dist`,
+
+      'location.@storage':
+        bud.isCLI() && isString(bud.context.args.storage)
+          ? bud.context.args.storage
+          : `.budfiles`,
+
+      'location.@modules':
+        bud.isCLI() && isString(bud.context.args.modules)
+          ? bud.context.args.modules
+          : `node_modules`,
     })
     .when(bud.isDevelopment, ({hooks}) =>
       hooks.fromMap({

--- a/sources/@roots/bud-framework/src/methods/glob/glob.test.ts
+++ b/sources/@roots/bud-framework/src/methods/glob/glob.test.ts
@@ -92,8 +92,8 @@ describe(`bud.glob`, function () {
   })
 
   it(`returns glob results with negation`, async () => {
-    const results = await glob(`src/**/*.js`, `!**/main.js`)
-    const syncResults = globSync(`src/**/*.js`, `!**/main.js`)
+    const results = await glob(`!**/main.js`, `src/**/*.js`)
+    const syncResults = globSync(`!**/main.js`, `src/**/*.js`)
 
     expect(results).toEqual(
       expect.arrayContaining([expect.stringContaining(`scripts/app.js`)]),

--- a/sources/@roots/bud-framework/src/service.ts
+++ b/sources/@roots/bud-framework/src/service.ts
@@ -1,7 +1,9 @@
 import {lowerCase} from '@roots/bud-support/lodash-es'
 import Container from '@roots/container'
+import type {Context} from 'vm'
 
 import type {Bud} from './index.js'
+import type {CLIContext, CommandContext} from './types/options/context.js'
 import type {Logger} from './types/services/logger/index.js'
 
 interface Contract {
@@ -10,7 +12,7 @@ interface Contract {
    *
    * @public
    */
-  app: Bud
+  app?: Bud & {context: CommandContext | CLIContext | Context}
 
   /**
    * Scopoed logger
@@ -27,7 +29,7 @@ interface Contract {
    *
    * @public
    */
-  init?(app: Bud): Promise<void>
+  init?(app?: Bud): Promise<void>
 
   /**
    * Lifecycle method: bootstrap
@@ -37,7 +39,7 @@ interface Contract {
    *
    * @public
    */
-  bootstrap?(app: Bud): Promise<void>
+  bootstrap?(app?: Bud): Promise<void>
 
   /**
    * Lifecycle method: bootstrapped
@@ -48,7 +50,7 @@ interface Contract {
    *
    * @public
    */
-  bootstrapped?(app: Bud): Promise<any>
+  bootstrapped?(app?: Bud): Promise<any>
 
   /**
    * Lifecycle method: register
@@ -59,7 +61,7 @@ interface Contract {
    *
    * @public
    */
-  register?(app: Bud): Promise<any>
+  register?(app?: Bud): Promise<any>
 
   /**
    * Lifecycle method: registered
@@ -70,7 +72,7 @@ interface Contract {
    *
    * @public
    */
-  registered?(app: Bud): Promise<any>
+  registered?(app?: Bud): Promise<any>
 
   /**
    * Lifecycle method: boot
@@ -81,7 +83,7 @@ interface Contract {
    *
    * @public
    */
-  boot?(app: Bud): Promise<any>
+  boot?(app?: Bud): Promise<any>
 
   /**
    * Lifecycle method: booted
@@ -91,37 +93,37 @@ interface Contract {
    *
    * @public
    */
-  booted?(app: Bud): Promise<any>
+  booted?(app?: Bud): Promise<any>
 
   /**
    * After config callback
    * @public
    */
-  configAfter?(app: Bud): Promise<void>
+  configAfter?(app?: Bud): Promise<void>
 
   /**
    * Before build service
    * @public
    */
-  buildBefore?(app: Bud): Promise<void>
+  buildBefore?(app?: Bud): Promise<void>
 
   /**
    * After build service
    * @public
    */
-  buildAfter?(app: Bud): Promise<void>
+  buildAfter?(app?: Bud): Promise<void>
 
   /**
    * Before Compiler service
    * @public
    */
-  compilerBefore?(app: Bud): Promise<void>
+  compilerBefore?(app?: Bud): Promise<void>
 
   /**
    * After Compiler service
    * @public
    */
-  compilerAfter?(app: Bud): Promise<void>
+  compilerAfter?(app?: Bud): Promise<void>
 }
 
 /**
@@ -286,7 +288,9 @@ abstract class BaseContainer
    *
    * @public @readonly
    */
-  public get app(): Bud {
+  public get app(): Bud & {
+    context: CommandContext | CLIContext | Context
+  } {
     return this._app()
   }
 

--- a/sources/@roots/bud-framework/src/services/console.ts
+++ b/sources/@roots/bud-framework/src/services/console.ts
@@ -55,7 +55,7 @@ export default class ConsoleBuffer extends Service {
    */
   @bind
   public override async init?(bud: Bud) {
-    if (bud.context.args?.ci) return
+    if (!bud.isCLI() || (bud.isCLI() && bud.context.args?.ci)) return
 
     // Patch the console, and assign the restore function
     this.restore = patchConsole((stream, data) => {

--- a/sources/@roots/bud-framework/src/types/options/context.ts
+++ b/sources/@roots/bud-framework/src/types/options/context.ts
@@ -5,7 +5,7 @@ import type {InspectResult} from '@roots/filesystem/filesystem'
 import type {Bud} from '../../bud.js'
 import type {Logger} from '../services/logger/index.js'
 
-export interface BudContext {
+export interface Context {
   label: string
   basedir: string
   mode: 'development' | 'production'
@@ -16,13 +16,28 @@ export interface BudContext {
     builtIn: Array<string>
     discovered: Array<string>
   }
+  manifest: Record<string, any>
+  services: Array<string>
+  logger: Logger
+  root?: Bud | undefined
+  dependsOn?: Array<string> | undefined
+}
+
+export interface CLIContext extends Context {
+  stdin: Readable
+  stdout: Writable
+  stderr: Writable
+  colorDepth: number
+}
+
+export interface CommandContext extends CLIContext {
   args: Partial<{
-    basedir?: string
-    browser?: string | boolean
-    cache?: `filesystem` | `memory` | true | false
-    ci?: boolean
-    clean?: boolean
-    debug?: boolean
+    basedir: string | undefined
+    browser: string | boolean | undefined
+    cache: `filesystem` | `memory` | true | false | undefined
+    ci: boolean | undefined
+    clean: boolean | undefined | undefined
+    debug: boolean | undefined
     devtool?:
       | false
       | `eval`
@@ -49,45 +64,33 @@ export interface BudContext {
       | `hidden-cheap-source-map`
       | `hidden-cheap-module-source-map`
       | `hidden-source-map`
-    discovery?: boolean
-    dry?: boolean
-    output?: string
-    editor?: string | boolean
-    esm?: boolean
-    filter?: Array<string>
-    flush?: boolean
-    hash?: boolean
-    html?: boolean | string
-    immutable?: boolean
-    indicator?: boolean
-    input?: string
-    log?: boolean
-    manifest?: boolean
-    minimize?: boolean
-    mode?: `production` | `development`
-    modules?: string
-    notify?: boolean
-    overlay?: boolean
-    publicPath?: string
-    reload?: boolean
-    runtime?: `single` | `multiple` | boolean
-    splitChunks?: boolean
-    storage?: string
-    target?: Array<string>
-    verbose?: boolean
+      | undefined
+    discovery: boolean | undefined
+    dry: boolean | undefined
+    output: string | undefined
+    editor: string | boolean | undefined
+    esm: boolean | undefined
+    filter: Array<string> | undefined
+    flush: boolean | undefined
+    hash: boolean | undefined
+    html: boolean | string | undefined
+    immutable: boolean | undefined
+    indicator: boolean | undefined
+    input: string | undefined
+    log: boolean | undefined
+    manifest: boolean | undefined
+    minimize: boolean | undefined
+    modules: string | undefined
+    notify: boolean | undefined
+    overlay: boolean | undefined
+    publicPath: string | undefined
+    reload: boolean | undefined
+    runtime: `single` | `multiple` | boolean | undefined
+    splitChunks: boolean | undefined
+    storage: string | undefined
+    target: Array<string> | undefined
+    verbose: boolean | undefined
   }>
-  manifest: Record<string, any>
-  services: Array<string>
-  logger: Logger
-  root?: Bud
-  dependsOn?: Array<string>
-}
-
-export interface CommandContext extends BudContext {
-  stdin: Readable
-  stdout: Writable
-  stderr: Writable
-  colorDepth: number
 }
 
 export interface File extends Omit<InspectResult, `type`> {
@@ -106,5 +109,3 @@ export interface File extends Omit<InspectResult, `type`> {
   md5: string
   mode: number
 }
-
-export type {BudContext as Context}

--- a/sources/@roots/bud-framework/src/types/options/index.ts
+++ b/sources/@roots/bud-framework/src/types/options/index.ts
@@ -1,3 +1,3 @@
-import type {CommandContext, Context, File} from './context.js'
+import type {CLIContext, CommandContext, Context, File} from './context.js'
 
-export type {CommandContext, Context, File}
+export type {CLIContext, CommandContext, Context, File}

--- a/sources/@roots/bud-server/src/hooks/dev.client.scripts.ts
+++ b/sources/@roots/bud-server/src/hooks/dev.client.scripts.ts
@@ -46,18 +46,21 @@ export const hmrClient = (app: Bud) => {
     name: app.label,
 
     indicator:
+      !app.isCLI() ||
       isUndefined(app.context.args.indicator) ||
       isNull(app.context.args.indicator)
         ? `true`
         : app.context.args.indicator.toString(),
 
     overlay:
+      !app.isCLI() ||
       isUndefined(app.context.args.overlay) ||
       isNull(app.context.args.overlay)
         ? `true`
         : app.context.args.overlay.toString(),
 
     reload:
+      !app.isCLI() ||
       isUndefined(app.context.args.reload) ||
       isNull(app.context.args.reload)
         ? `true`

--- a/sources/@roots/bud-server/src/middleware/proxy/index.ts
+++ b/sources/@roots/bud-server/src/middleware/proxy/index.ts
@@ -68,9 +68,11 @@ export const makeOptions = (app: Bud): Options => {
       ),
       logger: app.hooks.filter(
         `dev.middleware.proxy.options.logger`,
-        app.context.args.log
+        app.isCLI() && app.context.args.log
           ? new signale().scope(app.label, `proxy`)
-          : undefined,
+          : app.isCLI()
+          ? undefined
+          : console,
       ),
       on: filterUndefined(
         app.hooks.filter(`dev.middleware.proxy.options.on`, {

--- a/sources/@roots/bud-server/src/server/server.watcher.ts
+++ b/sources/@roots/bud-server/src/server/server.watcher.ts
@@ -86,7 +86,7 @@ export class Watcher implements Server.Watcher {
    */
   @bind
   public async watch(): Promise<Watcher['instance']> {
-    if (this.app.context.args.dry) return
+    if (this.app.isCLI() && this.app.context.args.dry) return
 
     this.files = this.app.hooks.filter(`dev.watch.files`, new Set([]))
     this.options = this.app.hooks.filter(`dev.watch.options`, {

--- a/sources/@roots/bud-server/src/service/service.ts
+++ b/sources/@roots/bud-server/src/service/service.ts
@@ -158,7 +158,7 @@ export class Server extends Service implements BaseService {
   public async run() {
     await this.app.hooks.fire(`server.before`)
 
-    if (!this.app.context.args.dry) {
+    if (!this.app.isCLI() || !this.app.context.args.dry) {
       await this.connection.createServer(this.application)
       await this.connection.listen()
     }

--- a/sources/@roots/bud-tailwindcss/src/__snapshots__/extension.test.ts.snap
+++ b/sources/@roots/bud-tailwindcss/src/__snapshots__/extension.test.ts.snap
@@ -531,7 +531,7 @@ exports[`@roots/bud-tailwindcss extension > should throw when key does not exist
 
 {
   \\"content\\": [
-    \\"**/*.stub\\"
+    \\"src/index.html\\"
   ],
   \\"theme\\": {
     \\"extend\\": {
@@ -539,6 +539,7 @@ exports[`@roots/bud-tailwindcss extension > should throw when key does not exist
         \\"primary\\": \\"red\\"
       }
     }
-  }
+  },
+  \\"plugins\\": []
 }"
 `;

--- a/sources/@roots/bud-tailwindcss/src/extension.test.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension.test.ts
@@ -10,31 +10,6 @@ describe(`@roots/bud-tailwindcss extension`, () => {
 
   beforeEach(async () => {
     bud = await factory()
-    bud.context.config[`tailwind.config.js`] = {
-      name: `tailwind.config.js`,
-      path: `test/path`,
-      bud: false,
-      dynamic: true,
-      local: false,
-      extension: null,
-      type: `base`,
-      file: true,
-      dir: false,
-      symlink: false,
-      size: 1020,
-      md5: `test-md5`,
-      mode: 0o777,
-      module: {
-        content: [`**/*.stub`],
-        theme: {
-          extend: {
-            colors: {
-              primary: `red`,
-            },
-          },
-        },
-      },
-    }
     await bud.extensions.add(`@roots/bud-postcss`)
     extension = new BudTailwindCss(bud)
     await extension.init()
@@ -76,15 +51,21 @@ describe(`@roots/bud-tailwindcss extension`, () => {
 
   it(`should return a copy of the resolved config`, async () => {
     const configInitial = resolveConfig(
-      bud.context.config[`tailwind.config.js`].module,
+      await bud.module
+        .import(bud.context.config[`tailwind.config.cjs`].path)
+        .then(mod => mod.default ?? mod),
     )
 
-    expect(extension.theme?.colors).not.toBe(configInitial?.theme?.colors)
+    expect(extension.getTheme()?.colors).not.toBe(
+      configInitial?.theme?.colors,
+    )
   })
 
   it(`should have a config prop`, async () => {
-    expect(extension.configSource).toBe(
-      bud.context.config[`tailwind.config.js`].module,
+    expect(await extension.getSource()).toBe(
+      await bud.module
+        .import(bud.context.config[`tailwind.config.cjs`].path)
+        .then(mod => mod.default ?? mod),
     )
   })
 

--- a/sources/@roots/bud/src/cli/app.ts
+++ b/sources/@roots/bud/src/cli/app.ts
@@ -12,7 +12,7 @@ import getContext from '@roots/bud/context'
 import {argv, basedir} from '@roots/bud/context/argv'
 import {Builtins, Cli, CommandClass} from '@roots/bud-support/clipanion'
 
-const context = await getContext({basedir})
+const context = await getContext({basedir}, {cache: true, find: true})
 
 const application = new Cli({
   binaryLabel: `bud`,

--- a/sources/@roots/bud/src/cli/commands/bud.build.development.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.build.development.tsx
@@ -1,6 +1,5 @@
 import {Option} from '@roots/bud/cli/commands/bud'
 import BuildCommand from '@roots/bud/cli/commands/bud.build'
-import type {Context} from '@roots/bud-framework/options'
 import type {CommandContext} from '@roots/bud-framework/options'
 
 /**
@@ -62,7 +61,7 @@ export default class BuildDevelopmentCommand extends BuildCommand {
     }
   }
   public override withSubcommandArguments = async (
-    args: Context[`args`],
+    args: CommandContext[`args`],
   ) => {
     return {
       ...args,

--- a/sources/@roots/bud/src/cli/commands/bud.build.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.build.tsx
@@ -1,10 +1,9 @@
-import type {Bud} from '@roots/bud'
 import BudCommand from '@roots/bud/cli/commands/bud'
 import {Command, Option} from '@roots/bud-support/clipanion'
 import {bind} from '@roots/bud-support/decorators'
 import * as t from '@roots/bud-support/typanion'
 
-import type {CommandContext, Context} from './bud.js'
+import type {CommandContext} from './bud.js'
 
 /**
  * Build command
@@ -26,7 +25,7 @@ export default class BudBuildCommand extends BudCommand {
     examples: [[`compile source assets`, `$0 build`]],
   })
 
-  public override withBud = async (bud: Bud) => {
+  public override withBud = async (bud: BudCommand[`bud`]) => {
     bud.hooks.action(`compiler.close`, async bud => {
       await this.notifier.compilationNotification()
     })
@@ -157,7 +156,9 @@ export default class BudBuildCommand extends BudCommand {
     return context
   }
 
-  public override withArguments = async (args: Context[`args`]) => {
+  public override withArguments = async (
+    args: BudCommand[`bud`][`context`][`args`],
+  ) => {
     if (this.withSubcommandArguments) {
       args = await this.withSubcommandArguments(args)
     }

--- a/sources/@roots/bud/src/cli/commands/bud.clean.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.clean.tsx
@@ -8,6 +8,12 @@ import React from '@roots/bud-support/react'
 import {dry} from '../decorators/command.dry.js'
 import BudCommand from './bud.js'
 
+/**
+ * `bud clean`
+ *
+ * @public
+ * @decorator `@dry`
+ */
 @dry
 export default class BudCleanCommand extends BudCommand {
   public static override paths = [[`clean`]]
@@ -16,9 +22,7 @@ export default class BudCleanCommand extends BudCommand {
     description: `Clean project artifacts and caches`,
     details: `
       \`bud clean\` empties the \`@dist\` and \`@storage\` directories.
-
       \`bud clean @dist\` empties the \`@dist\` directory.
-
       \`bud clean @storage\` empties the \`@storage\` directory.
 `,
     examples: [
@@ -28,35 +32,38 @@ export default class BudCleanCommand extends BudCommand {
     ],
   })
 
-  public shouldCleanStorage = Option.Boolean(`@storage`, false, {
+  public _cleanStorage = Option.Boolean(`@storage`, false, {
     description: `empty @storage`,
   })
-  public shouldCleanDist = Option.Boolean(`@dist`, false, {
+  public _cleanOutput = Option.Boolean(`@dist`, false, {
     description: `empty @dist`,
   })
 
+  /**
+   * Execute command
+   *
+   * @public
+   * @decorator `@bind`
+   */
   @bind
   public override async execute() {
     await this.makeBud(this)
     await this.healthcheck(this)
 
     if (
-      this.shouldCleanStorage ||
-      (!this.shouldCleanStorage && !this.shouldCleanDist)
+      this._cleanStorage ||
+      (!this._cleanStorage && !this._cleanOutput)
     ) {
       await this.cleanStorage()
     }
 
-    if (
-      this.shouldCleanDist ||
-      (!this.shouldCleanDist && !this.shouldCleanDist)
-    ) {
-      await this.cleanDist()
+    if (this._cleanOutput || (!this._cleanOutput && !this._cleanOutput)) {
+      await this.cleanOutput()
     }
   }
 
   @bind
-  public async cleanDist() {
+  public async cleanOutput() {
     try {
       await remove(this.bud.path(`@dist`))
 

--- a/sources/@roots/bud/src/cli/commands/bud.doctor.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.doctor.tsx
@@ -1,5 +1,5 @@
 import BudCommand from '@roots/bud/cli/commands/bud'
-import type {Context} from '@roots/bud-framework/options'
+import type {CommandContext} from '@roots/bud-framework/options'
 import {Command} from '@roots/bud-support/clipanion'
 import {Box, Text} from '@roots/bud-support/ink'
 import React from '@roots/bud-support/react'
@@ -35,7 +35,7 @@ for a lot of edge cases so it might return a false positive.
       [`Check compiled configuration against webpack`, `$0 doctor`],
     ],
   })
-  public override withArguments = async (args: Context[`args`]) => {
+  public override withArguments = async (args: CommandContext[`args`]) => {
     return {...args, dry: true}
   }
 

--- a/sources/@roots/bud/src/cli/commands/bud.repl.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.repl.tsx
@@ -1,5 +1,6 @@
 import type {Bud} from '@roots/bud'
 import {dry} from '@roots/bud/cli/decorators'
+import {bind} from '@roots/bud-framework/extension/decorators'
 import {Command, Option} from '@roots/bud-support/clipanion'
 import {highlight} from '@roots/bud-support/highlight'
 import * as Ink from '@roots/bud-support/ink'
@@ -40,9 +41,12 @@ export default class BudReplCommand extends BudCommand {
   })
 
   /**
-   * Command execute
+   * Execute command
+   *
    * @public
+   * @decorator `@bind`
    */
+  @bind
   public override async execute() {
     await this.makeBud(this)
     await this.run(this)

--- a/sources/@roots/bud/src/cli/decorators/command.dry.ts
+++ b/sources/@roots/bud/src/cli/decorators/command.dry.ts
@@ -1,5 +1,5 @@
 import type BudCommand from '@roots/bud/cli/commands/bud'
-import type {Context} from '@roots/bud-framework/options'
+import type {CommandContext} from '@roots/bud-framework/options'
 
 export function dry<T extends new (...args: any[]) => BudCommand>(
   constructor: T,
@@ -9,7 +9,7 @@ export function dry<T extends new (...args: any[]) => BudCommand>(
       super(...args)
       if (this.withArguments) {
         const existingFn = this.withArguments
-        this.withArguments = async (args: Context[`args`]) => {
+        this.withArguments = async (args: CommandContext[`args`]) => {
           args = await existingFn(args)
           return {
             ...args,

--- a/sources/@roots/bud/src/context/extensions.ts
+++ b/sources/@roots/bud/src/context/extensions.ts
@@ -39,8 +39,8 @@ const extensions: Extensions = {
   discovered: [],
 }
 
-export default (manifest: Context[`manifest`]) => {
-  if (argv.has(`no-discovery`)) return extensions
+export default (manifest: Context[`manifest`], find: boolean) => {
+  if (argv.has(`no-discovery`) || !find) return extensions
 
   Object.keys({
     ...(manifest?.devDependencies ?? {}),

--- a/sources/@roots/bud/src/context/index.test.ts
+++ b/sources/@roots/bud/src/context/index.test.ts
@@ -9,9 +9,12 @@ describe(`context.get`, () => {
   let context: Context
 
   beforeEach(async () => {
-    context = await getContext({
-      basedir: join(paths.root, `tests`, `util`, `project`),
-    })
+    context = await getContext(
+      {
+        basedir: join(paths.root, `tests`, `util`, `project`),
+      },
+      {cache: false, find: true},
+    )
   })
 
   it(`should be accessible`, () => {

--- a/sources/@roots/bud/src/factory/factory.test.ts
+++ b/sources/@roots/bud/src/factory/factory.test.ts
@@ -15,7 +15,7 @@ describe(`@roots/bud/factory`, () => {
           log: false,
         },
       },
-      true,
+      {cache: false, find: true},
     )
 
     expect(bud.label).toBe(`@tests/project`)

--- a/sources/@roots/bud/src/factory/index.ts
+++ b/sources/@roots/bud/src/factory/index.ts
@@ -1,3 +1,3 @@
-import {factory} from './factory.js'
+import {factory, Options} from './factory.js'
 
-export {factory}
+export {factory, Options}

--- a/sources/@roots/bud/src/logger/index.ts
+++ b/sources/@roots/bud/src/logger/index.ts
@@ -15,8 +15,8 @@ export class Logger {
   public constructor(options: Options = {}) {
     options = {...defaults, ...options}
     if (argv.has(`no-log`)) options.disabled = true
-    if (argv.has(`log`)) options.logLevel = `info`
-    if (argv.has(`verbose`)) options.logLevel = `log`
+    if (argv.has(`log`)) options.logLevel = `log`
+    if (argv.has(`verbose`)) options.logLevel = `info`
     if (!argv.has(`log`) && !argv.has(`no-log`)) options.logLevel = `warn`
 
     this.instance = new Signale(options)
@@ -107,7 +107,7 @@ export class Logger {
   }
   @bind
   public debug(...messages: Array<unknown>) {
-    if (!argv.has(`debug`)) return this
+    if (!argv.has(`verbose`)) return this
     this.instance.debug(...this.format(...messages))
     return this
   }

--- a/sources/@roots/bud/src/notifier/notifier.ts
+++ b/sources/@roots/bud/src/notifier/notifier.ts
@@ -1,6 +1,7 @@
 import {platform} from 'node:os'
 
 import type {Bud} from '@roots/bud-framework'
+import type {CommandContext} from '@roots/bud-framework/options'
 import {bind} from '@roots/bud-support/decorators'
 import {
   isEmpty,
@@ -47,7 +48,7 @@ interface Notification extends NodeNotification {
  * @public
  */
 export class Notifier {
-  public bud: Bud
+  public bud: Bud & {context: CommandContext}
   public browser: string | boolean
   public stats?: StatsCompilation | undefined
   public url: string
@@ -60,9 +61,11 @@ export class Notifier {
   public get notificationsEnabled(): boolean {
     return this.bud?.context.args.notify !== false
   }
+
   public get openEditorEnabled(): boolean {
     return isString(this.editor)
   }
+
   public get openBrowserEnabled(): boolean {
     return this.browser === true || isString(this.browser)
   }
@@ -97,7 +100,7 @@ export class Notifier {
   }
 
   @bind
-  public setBud(bud: Bud) {
+  public setBud(bud: Bud & {context: CommandContext}) {
     this.bud = bud
     return this
   }

--- a/sources/@roots/bud/src/services/project/project.ts
+++ b/sources/@roots/bud/src/services/project/project.ts
@@ -16,7 +16,11 @@ class Project extends Service {
    */
   @bind
   public override async buildAfter?(bud: Bud) {
-    if (!bud.context.args.debug) {
+    if (!bud.isCLI()) {
+      bud.info(`not a CLI build. skipping project profile.`)
+      return
+    }
+    if (!bud.context.args?.debug) {
       bud.info(`--debug not \`true\`. skipping fs write.`)
       return
     }

--- a/sources/@roots/sage/src/wp-theme-json-tailwind/extension.ts
+++ b/sources/@roots/sage/src/wp-theme-json-tailwind/extension.ts
@@ -27,11 +27,9 @@ export class WPThemeJsonTailwind extends Extension {
   @bind
   public override async register(bud: Bud) {
     bud.wpjson.useTailwindColors = this.useTailwindColors.bind(bud.wpjson)
-
     bud.wpjson.useTailwindFontFamily = this.useTailwindFontFamily.bind(
       bud.wpjson,
     )
-
     bud.wpjson.useTailwindFontSize = this.useTailwindFontSize.bind(
       bud.wpjson,
     )

--- a/tests/util/project/tailwind.config.cjs
+++ b/tests/util/project/tailwind.config.cjs
@@ -1,7 +1,11 @@
 module.exports = {
   content: [`src/index.html`],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        primary: `red`,
+      },
+    },
   },
   plugins: [],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,6 +3527,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discoveryjs/json-ext@npm:^0.5.0":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
+  languageName: node
+  linkType: hard
+
 "@docsearch/css@npm:3.1.1":
   version: 3.1.1
   resolution: "@docsearch/css@npm:3.1.1"
@@ -4278,6 +4285,17 @@ __metadata:
   checksum: f03e9d6727efd3e0719da2051ea80c0c73d20e28c171121527dbb868cd34232ca9c1d0525a66e517a404afea26624b1e47895b6a92474678418c2f50c9566694
   languageName: node
   linkType: hard
+
+"@examples/node-api@workspace:examples/node-api":
+  version: 0.0.0-use.local
+  resolution: "@examples/node-api@workspace:examples/node-api"
+  dependencies:
+    "@roots/browserslist-config": "workspace:sources/@roots/browserslist-config"
+    "@roots/bud": "workspace:sources/@roots/bud"
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc"
+    webpack-cli: 5.0.1
+  languageName: unknown
+  linkType: soft
 
 "@fullhuman/postcss-purgecss@npm:5.0.0":
   version: 5.0.0
@@ -9273,6 +9291,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webpack-cli/configtest@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@webpack-cli/configtest@npm:2.0.1"
+  peerDependencies:
+    webpack: 5.x.x
+    webpack-cli: 5.x.x
+  checksum: 15d0ca835f2e16ec99e9f295f07b676435b9e706d7700df0ad088692fea065e34772fc44b96a4f6a86178b9ca8cf1ff941fbce15269587cf0925d70b18928cea
+  languageName: node
+  linkType: hard
+
+"@webpack-cli/info@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@webpack-cli/info@npm:2.0.1"
+  peerDependencies:
+    webpack: 5.x.x
+    webpack-cli: 5.x.x
+  checksum: b8fba49fee10d297c2affb0b064c9a81e9038d75517c6728fb85f9fb254cae634e5d33e696dac5171e6944ae329d85fddac72f781c7d833f7e9dfe43151ce60d
+  languageName: node
+  linkType: hard
+
+"@webpack-cli/serve@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@webpack-cli/serve@npm:2.0.1"
+  peerDependencies:
+    webpack: 5.x.x
+    webpack-cli: 5.x.x
+  peerDependenciesMeta:
+    webpack-dev-server:
+      optional: true
+  checksum: 75c55f8398dd60e4821f81bec6e96287cebb3ab1837ef016779bc2f0c76a1d29c45b99e53daa99ba1fa156b5e2b61c19abf58098de20c2b58391b1f496ecc145
+  languageName: node
+  linkType: hard
+
 "@wordpress/a11y@npm:^3.22.0":
   version: 3.22.0
   resolution: "@wordpress/a11y@npm:3.22.0"
@@ -12803,6 +12854,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^2.0.14":
+  version: 2.0.19
+  resolution: "colorette@npm:2.0.19"
+  checksum: 888cf5493f781e5fcf54ce4d49e9d7d698f96ea2b2ef67906834bb319a392c667f9ec69f4a10e268d2946d13a9503d2d19b3abaaaf174e3451bfe91fb9d82427
+  languageName: node
+  linkType: hard
+
 "colors-option@npm:^3.0.0":
   version: 3.0.0
   resolution: "colors-option@npm:3.0.0"
@@ -12869,7 +12927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:9.4.1, commander@npm:^9.4.0":
+"commander@npm:9.4.1, commander@npm:^9.4.0, commander@npm:^9.4.1":
   version: 9.4.1
   resolution: "commander@npm:9.4.1"
   checksum: bfb18e325a5bdf772763c2213d5c7d9e77144d944124e988bcd8e5e65fb6d45d5d4e86b09155d0f2556c9a59c31e428720e57968bcd050b2306e910a0bf3cf13
@@ -15118,7 +15176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:7.8.1, envinfo@npm:^7.3.1":
+"envinfo@npm:7.8.1, envinfo@npm:^7.3.1, envinfo@npm:^7.7.3":
   version: 7.8.1
   resolution: "envinfo@npm:7.8.1"
   bin:
@@ -16675,7 +16733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastest-levenshtein@npm:^1.0.16":
+"fastest-levenshtein@npm:^1.0.12, fastest-levenshtein@npm:^1.0.16":
   version: 1.0.16
   resolution: "fastest-levenshtein@npm:1.0.16"
   checksum: a78d44285c9e2ae2c25f3ef0f8a73f332c1247b7ea7fb4a191e6bb51aa6ee1ef0dfb3ed113616dcdc7023e18e35a8db41f61c8d88988e877cf510df8edafbc71
@@ -19322,6 +19380,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-local@npm:^3.0.2":
+  version: 3.1.0
+  resolution: "import-local@npm:3.1.0"
+  dependencies:
+    pkg-dir: ^4.2.0
+    resolve-cwd: ^3.0.0
+  bin:
+    import-local-fixture: fixtures/cli.js
+  checksum: bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
+  languageName: node
+  linkType: hard
+
 "import-meta-resolve@npm:2.2.0":
   version: 2.2.0
   resolution: "import-meta-resolve@npm:2.2.0"
@@ -19571,6 +19641,13 @@ __metadata:
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
   checksum: 2e5f51268b5941e4a17e4ef0575bc91ed0ab5f8515e3cf77486f7c14d13f3010df9c0959f37063dcc96e78d12dc6b0bb1b9e111cdfe69771f4656d2993d36155
+  languageName: node
+  linkType: hard
+
+"interpret@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "interpret@npm:3.1.1"
+  checksum: 35cebcf48c7351130437596d9ab8c8fe131ce4038da4561e6d665f25640e0034702a031cf7e3a5cea60ac7ac548bf17465e0571ede126f3d3a6933152171ac82
   languageName: node
   linkType: hard
 
@@ -25113,7 +25190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pkg-dir@npm:^4.1.0":
+"pkg-dir@npm:^4.1.0, pkg-dir@npm:^4.2.0":
   version: 4.2.0
   resolution: "pkg-dir@npm:4.2.0"
   dependencies:
@@ -27426,6 +27503,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rechoir@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rechoir@npm:0.8.0"
+  dependencies:
+    resolve: ^1.20.0
+  checksum: ad3caed8afdefbc33fbc30e6d22b86c35b3d51c2005546f4e79bcc03c074df804b3640ad18945e6bef9ed12caedc035655ec1082f64a5e94c849ff939dc0a788
+  languageName: node
+  linkType: hard
+
 "recursive-readdir@npm:^2.2.2":
   version: 2.2.2
   resolution: "recursive-readdir@npm:2.2.2"
@@ -27964,6 +28050,15 @@ __metadata:
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
   checksum: f558071fcb2c60b04054c99aebd572a2af97ef64128d59bef7ab73bd50d896a222a056de40ffc545b633d99b304c259ea9d0c06830d5c867c34f0bfa60b8eae0
+  languageName: node
+  linkType: hard
+
+"resolve-cwd@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-cwd@npm:3.0.0"
+  dependencies:
+    resolve-from: ^5.0.0
+  checksum: 546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
   languageName: node
   linkType: hard
 
@@ -32531,6 +32626,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-cli@npm:5.0.1":
+  version: 5.0.1
+  resolution: "webpack-cli@npm:5.0.1"
+  dependencies:
+    "@discoveryjs/json-ext": ^0.5.0
+    "@webpack-cli/configtest": ^2.0.1
+    "@webpack-cli/info": ^2.0.1
+    "@webpack-cli/serve": ^2.0.1
+    colorette: ^2.0.14
+    commander: ^9.4.1
+    cross-spawn: ^7.0.3
+    envinfo: ^7.7.3
+    fastest-levenshtein: ^1.0.12
+    import-local: ^3.0.2
+    interpret: ^3.1.1
+    rechoir: ^0.8.0
+    webpack-merge: ^5.7.3
+  peerDependencies:
+    webpack: 5.x.x
+  peerDependenciesMeta:
+    "@webpack-cli/generators":
+      optional: true
+    webpack-bundle-analyzer:
+      optional: true
+    webpack-dev-server:
+      optional: true
+  bin:
+    webpack-cli: bin/cli.js
+  checksum: b1544eea669442e78c3dba9f79c0f8d0136759b8b2fe9cd32c0d410250fd719988ae037778ba88993215d44971169f2c268c0c934068be561711615f1951bd53
+  languageName: node
+  linkType: hard
+
 "webpack-dev-middleware@npm:6.0.1":
   version: 6.0.1
   resolution: "webpack-dev-middleware@npm:6.0.1"
@@ -32617,7 +32744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.8.0":
+"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
   version: 5.8.0
   resolution: "webpack-merge@npm:5.8.0"
   dependencies:


### PR DESCRIPTION
Improves node api and updates examples/node-api.

The biggest code change here is a predicate narrowing fn added to base bud object. It is used to determine if the code is being run from a node api call or from the `bud` cli:

```ts
import {factory} from '@roots/bud'
const bud = await factory()
console.assert(bud.isCLI() === false)
```

This prevents reference to `bud.context.args` without first checking if `bud.isCLI` returns `true`. 

```ts
import {factory} from '@roots/bud'
const bud = await factory()
console.log(bud.context.args.verbose) // <-- typescript will get mad

if (bud.isCLI()) {
  console.log(bud.context.args.verbose) // <-- but this is cool
}
```

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
