### PR TITLE
✨ improve: config exports

### DIFF
--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -86,6 +86,12 @@
       "types": "./lib/cli/helpers/*.d.ts",
       "default": "./lib/cli/helpers/*.js"
     },
+    "./config/jsconfig.json": {
+      "default": "./config/jsconfig.json"
+    },
+    "./config/tsconfig.json": {
+      "default": "./config/tsconfig.json"
+    },
     "./context": {
       "types": "./lib/context/index.d.ts",
       "default": "./lib/context/index.js"

--- a/sources/@roots/sage/package.json
+++ b/sources/@roots/sage/package.json
@@ -52,6 +52,8 @@
     "./client": "./lib/client/index.js",
     "./client/dom-ready": "./lib/client/dom-ready.js",
     "./client/lazy": "./lib/client/lazy.js",
+    "./config/jsconfig.json": "./config/jsconfig.json",
+    "./config/tsconfig.json": "./config/tsconfig.json",
     "./wp-theme-json": "./lib/wp-theme-json/index.js",
     "./wp-theme-json-tailwind": "./lib/wp-theme-json-tailwind/index.js",
     "./stylelint": "./config/stylelint.cjs",


### PR DESCRIPTION
- this prevents IDE complaints when extending `@roots/bud/config/tsconfig.json` and `@roots/sage/config/tsconfig.json` (or jsconfig exports).

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
