### PR TITLE
🩹 fix: config.after hook for zero conf

### DIFF
--- a/examples/vue-3/bud.config.cjs
+++ b/examples/vue-3/bud.config.cjs
@@ -1,5 +1,0 @@
-module.exports = async app => {
-  app.entry('app', 'index').template({
-    template: app.path('@src/index.html'),
-  })
-}

--- a/examples/vue-3/jsconfig.json
+++ b/examples/vue-3/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@roots/bud/config/jsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@*": ["./*"]
+    },
+    "types": ["@roots/bud-vue"]
+  },
+  "include": ["src", "bud.config.js"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/vue-3/package.json
+++ b/examples/vue-3/package.json
@@ -2,8 +2,9 @@
   "name": "@examples/vue",
   "private": true,
   "browserslist": [
-    "extends @roots/browserslist-config/current"
+    "extends @roots/browserslist-config"
   ],
+  "type": "module",
   "devDependencies": {
     "@roots/browserslist-config": "latest",
     "@roots/bud": "latest",

--- a/examples/vue-3/src/index.html
+++ b/examples/vue-3/src/index.html
@@ -1,1 +1,0 @@
-<div id="app"></div>

--- a/examples/vue-3/src/index.js
+++ b/examples/vue-3/src/index.js
@@ -1,5 +1,5 @@
 import {createApp} from 'vue'
-import App from './App'
+import App from './App.vue'
 
 const app = createApp(App)
 app.mount('#app')

--- a/examples/vue-legacy/bud.config.cjs
+++ b/examples/vue-legacy/bud.config.cjs
@@ -1,5 +1,0 @@
-module.exports = async app => {
-  app.entry('app', 'index').template({
-    template: app.path('@src/index.html'),
-  })
-}

--- a/examples/vue-legacy/bud.config.js
+++ b/examples/vue-legacy/bud.config.js
@@ -1,0 +1,3 @@
+/** @param {import('@roots/bud').Bud} app */
+export default async app =>
+  app.html({template: app.path('@src/index.html')})

--- a/examples/vue-legacy/jsconfig.json
+++ b/examples/vue-legacy/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@roots/bud/config/jsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@*": ["./*"]
+    },
+    "types": ["@roots/bud-vue"]
+  },
+  "include": ["./src", "bud.config.js"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/vue-legacy/package.json
+++ b/examples/vue-legacy/package.json
@@ -2,8 +2,9 @@
   "name": "@examples/vue-legacy",
   "private": true,
   "browserslist": [
-    "extends @roots/browserslist-config/current"
+    "extends @roots/browserslist-config"
   ],
+  "type": "module",
   "devDependencies": {
     "@roots/bud": "latest",
     "@roots/bud-vue": "latest"

--- a/sources/@roots/bud-framework/src/configuration/configuration.ts
+++ b/sources/@roots/bud-framework/src/configuration/configuration.ts
@@ -5,13 +5,11 @@ import type {Bud} from '../bud.js'
 
 /**
  * User config parser
- *
  * @public
  */
 class Configuration {
   /**
    * Class constructor
-   *
    * @public
    */
   public constructor(public app: Bud) {}

--- a/sources/@roots/bud-framework/src/configuration/index.test.ts
+++ b/sources/@roots/bud-framework/src/configuration/index.test.ts
@@ -14,8 +14,4 @@ describe(`bud.configuration`, function () {
   it(`should have a process fn`, () => {
     expect(configuration.process).toBeInstanceOf(Function)
   })
-
-  it(`should have a getAllMatchingConfigs fn`, async () => {
-    expect(configuration.getAllMatchingConfigs).toBeInstanceOf(Function)
-  })
 })

--- a/sources/@roots/bud-framework/src/configuration/index.ts
+++ b/sources/@roots/bud-framework/src/configuration/index.ts
@@ -1,7 +1,6 @@
 import {sortBy} from '@roots/bud-support/lodash-es'
 
 import type {Bud} from '../bud.js'
-import type {File} from '../types/options/context.js'
 import Configuration from './configuration.js'
 
 /**
@@ -9,13 +8,16 @@ import Configuration from './configuration.js'
  * @public
  */
 export const process = async (app: Bud) => {
-  if (!app.context.config) return
-
-  const configs = Object.values(app.context.config).filter(({bud}) => bud)
-  if (!configs.length) return
+  const findConfigs = (ofType: string, isLocal: boolean) =>
+    sortBy(
+      configs
+        .filter(({type}) => type === ofType)
+        .filter(({local}) => local === isLocal),
+      `name`,
+    )
 
   const configuration = new Configuration(app)
-  const findConfigs = getAllMatchingConfigs.bind(configs)
+  const configs = Object.values(app.context.config).filter(({bud}) => bud)
 
   await Promise.all(
     findConfigs(`base`, false).map(async description => {
@@ -66,17 +68,4 @@ export const process = async (app: Bud) => {
       throw error
     }
   }
-}
-
-export function getAllMatchingConfigs(
-  this: Array<File>,
-  ofType: string,
-  isLocal: boolean,
-) {
-  return sortBy(
-    this.filter(({type}) => type === ofType).filter(
-      ({local}) => local === isLocal,
-    ),
-    `name`,
-  )
 }

--- a/tests/integration/__snapshots__/vue-3.test.ts.snap
+++ b/tests/integration/__snapshots__/vue-3.test.ts.snap
@@ -2,16 +2,14 @@
 
 exports[`vue > npm > manifest.json > matches snapshot 1`] = `
 {
-  "app.css": "css/app.css",
-  "app.js": "js/app.js",
-  "index.html": "index.html",
+  "main.css": "css/main.css",
+  "main.js": "js/main.js",
 }
 `;
 
 exports[`vue > yarn > manifest.json > matches snapshot 1`] = `
 {
-  "app.css": "css/app.css",
-  "app.js": "js/app.js",
-  "index.html": "index.html",
+  "main.css": "css/main.css",
+  "main.js": "js/main.js",
 }
 `;

--- a/tests/integration/__snapshots__/vue-legacy.test.ts.snap
+++ b/tests/integration/__snapshots__/vue-legacy.test.ts.snap
@@ -2,14 +2,14 @@
 
 exports[`vue (legacy) > npm > manifest.json > matches snapshot 1`] = `
 {
-  "app.js": "js/app.js",
   "index.html": "index.html",
+  "main.js": "js/main.js",
 }
 `;
 
 exports[`vue (legacy) > yarn > manifest.json > matches snapshot 1`] = `
 {
-  "app.js": "js/app.js",
   "index.html": "index.html",
+  "main.js": "js/main.js",
 }
 `;

--- a/tests/integration/vue-3.test.ts
+++ b/tests/integration/vue-3.test.ts
@@ -1,7 +1,7 @@
 import {Project} from '@repo/test-kit/project'
 import {beforeAll, describe, expect, it} from 'vitest'
 
-const run = pacman => () => {
+const run = (pacman: `npm` | `yarn`) => () => {
   let project: Project
 
   beforeAll(async () => {
@@ -11,23 +11,23 @@ const run = pacman => () => {
     }).setup()
   })
 
-  describe(`app.css`, () => {
+  describe(`main.css`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`app.css`].length).toBeGreaterThan(10)
+      expect(project.assets[`main.css`].length).toBeGreaterThan(10)
     })
 
     it(`is transpiled`, () => {
-      expect(project.assets[`app.css`].includes(`from '`)).toBeFalsy()
+      expect(project.assets[`main.css`].includes(`from '`)).toBeFalsy()
     })
   })
 
-  describe(`app.js`, () => {
+  describe(`main.js`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`app.js`].length).toBeGreaterThan(10)
+      expect(project.assets[`main.js`].length).toBeGreaterThan(10)
     })
 
     it(`is transpiled`, () => {
-      expect(project.assets[`app.js`].includes(`from '`)).toBeFalsy()
+      expect(project.assets[`main.js`].includes(`from '`)).toBeFalsy()
     })
   })
 

--- a/tests/integration/vue-legacy.test.ts
+++ b/tests/integration/vue-legacy.test.ts
@@ -11,13 +11,13 @@ const run = pacman => () => {
     }).setup()
   })
 
-  describe(`app.js`, () => {
+  describe(`main.js`, () => {
     it(`has contents`, () => {
-      expect(project.assets[`app.js`].length).toBeGreaterThan(10)
+      expect(project.assets[`main.js`].length).toBeGreaterThan(10)
     })
 
     it(`is transpiled`, () => {
-      expect(project.assets[`app.js`].includes(`from '`)).toBeFalsy()
+      expect(project.assets[`main.js`].includes(`from '`)).toBeFalsy()
     })
   })
 


### PR DESCRIPTION
- fix: `config.after` hook not called when there are no config files processed
- example: update `examples/vue-3` to esm. with vue you have to include the file extension to resolve modules if you opt in to esm 🧠!
- example: `examples/vue-3` is also zero-config now
- example: `examples/vue-legacy` also now esm, but is not zero conf.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
