### PR TITLE
🩹 fix: ^ version mismatch complaints

### DIFF
--- a/sources/@roots/bud/src/cli/helpers/checkDependencies.tsx
+++ b/sources/@roots/bud/src/cli/helpers/checkDependencies.tsx
@@ -11,7 +11,10 @@ export const checkDependencies = async (bud: Bud) => {
     ...(bud.context.manifest?.devDependencies ?? {}),
   })
     .filter(([name]) => name.startsWith(`@roots/`))
-    .filter(([_, v]) => v !== bud.context.bud.version)
+    .filter(([signifier, version]: [string, string]) => {
+      version = version.replace(`^`, ``)
+      return version !== bud.context.bud.version
+    })
 
   mismatches?.length &&
     bud.dashboard.renderer.once(


### PR DESCRIPTION
- bad experience running `yarn add @roots/bud` since it complains immediately about version mismatch. just discarding `^`.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
