### PR TITLE
🩹 fix: pre 6.6.7

### DIFF
--- a/sources/@roots/bud-extensions/src/extensions/webpack-hot-module-replacement-plugin/index.ts
+++ b/sources/@roots/bud-extensions/src/extensions/webpack-hot-module-replacement-plugin/index.ts
@@ -1,6 +1,6 @@
 import type {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
-import {label} from '@roots/bud-framework/extension/decorators'
+import {bind, label} from '@roots/bud-framework/extension/decorators'
 import type Webpack from '@roots/bud-support/webpack'
 
 /**
@@ -16,16 +16,20 @@ export default class BudHMR extends Extension<
   {},
   Webpack.HotModuleReplacementPlugin
 > {
-  public override async when(bud: Bud) {
-    if (bud.isCLI() && bud.context.args.hot === false) return false
-    return bud.isDevelopment
-  }
-
+  @bind
   public override async make(bud: Bud) {
-    const {
-      default: {HotModuleReplacementPlugin},
-    } = await import(`@roots/bud-support/webpack`)
+    const {HotModuleReplacementPlugin} = await this.import(
+      `@roots/bud-support/webpack`,
+    )
 
     return new HotModuleReplacementPlugin()
+  }
+
+  @bind
+  public override async when(bud: Bud) {
+    if (bud.isProduction) return false
+    if (bud.isCLI() && bud.context.args.hot === false) return false
+
+    return true
   }
 }

--- a/sources/@roots/sage/src/acorn/hooks/event.compiler.done.ts
+++ b/sources/@roots/sage/src/acorn/hooks/event.compiler.done.ts
@@ -38,10 +38,15 @@ const writeIfEnabled = async (bud: Bud) => {
 }
 
 const writeJson = async function (bud: Bud) {
-  const devUrl = bud.root.hooks.filter(`dev.url`)
+  const devUrl = bud.root.hooks.filter(
+    `dev.url`,
+    new URL(`http://0.0.0.0:3000`),
+  )
   const proxyUrl = bud.root.hooks.filter(
     `dev.middleware.proxy.options.target`,
+    new URL(`http://0.0.0.0`),
   )
+
   const publicPath = bud.root.hooks.filter(`build.output.publicPath`)
   const writePath = bud.path(`@dist`, `hmr.json`)
 

--- a/sources/@roots/sage/src/sage/extension.test.ts
+++ b/sources/@roots/sage/src/sage/extension.test.ts
@@ -36,7 +36,7 @@ describe(`@roots/sage`, async () => {
     expect(hooksSpy).toHaveBeenNthCalledWith(
       1,
       `build.output.uniqueName`,
-      `@roots/bud/sage`,
+      `@roots/bud/sage/${bud.label}`,
     )
 
     expect(setPathSpy).toHaveBeenCalledWith({

--- a/sources/@roots/sage/src/sage/extension.ts
+++ b/sources/@roots/sage/src/sage/extension.ts
@@ -41,7 +41,7 @@ export class Sage extends Extension<Options> {
     if (app.extensions.has(`@roots/bud-tailwindcss`))
       await app.extensions.add(`@roots/sage/wp-theme-json-tailwind`)
 
-    app.hooks.on(`build.output.uniqueName`, `@roots/bud/sage`)
+    app.hooks.on(`build.output.uniqueName`, `@roots/bud/sage/${app.label}`)
 
     /* Set paths */
     app.setPath({


### PR DESCRIPTION
- 🩹 fix(@roots/sage): ensure `build.output.uniqueName` is unique
- 🩹 fix(@roots/sage): provide fallback `devUrl` and `proxyUrl`
- ✨ improve(core): lazy resolve hot module plugin with `bud.module`

refers:

- none

## Type of change

**PATCH: backwards compatible change**


This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
