### PR TITLE
hotfix: v6.6.8

### DIFF
--- a/sources/@roots/bud-compiler/src/compiler.service.ts
+++ b/sources/@roots/bud-compiler/src/compiler.service.ts
@@ -79,11 +79,10 @@ export class Compiler extends Service implements Contract.Service {
     this.app.context.logger.timeEnd(`initialize`)
 
     this.instance = this.implementation(this.config)
-
     this.instance.hooks.done.tap(this.app.label, this.onStats)
     this.instance.hooks.done.tap(
       `${this.app.label}-close`,
-      async () => await this.app.hooks.fire(`compiler.after`),
+      async () => await this.app.hooks.fire(`compiler.close`),
     )
 
     await this.app.hooks.fire(`compiler.after`)

--- a/sources/@roots/bud-preset-wordpress/package.json
+++ b/sources/@roots/bud-preset-wordpress/package.json
@@ -62,7 +62,7 @@
         "./lib/extension.d.ts"
       ],
       "theme": [
-        "./lib/theme.types.d.ts"
+        "./lib/theme.d.ts"
       ]
     }
   },

--- a/sources/@roots/bud-preset-wordpress/src/theme.ts
+++ b/sources/@roots/bud-preset-wordpress/src/theme.ts
@@ -27,13 +27,13 @@ export type SettingsProperties = SettingsPropertiesAppearanceTools &
  * via the `patternProperty` "[a-z0-9]/[a-z0-9]$".
  */
 export type SettingsPropertiesComplete = SettingsProperties & {
-  appearanceTools?: unknown
-  border?: unknown
-  color?: unknown
-  layout?: unknown
-  spacing?: unknown
-  typography?: unknown
-  custom?: unknown
+  appearanceTools?: SettingsPropertiesAppearanceTools[`appearanceTools`]
+  color?: SettingsPropertiesColor[`color`]
+  layout?: SettingsPropertiesLayout[`layout`]
+  spacing?: SettingsPropertiesSpacing[`spacing`]
+  typography?: SettingsPropertiesTypography[`typography`]
+  border?: SettingsPropertiesBorder[`border`]
+  custom?: SettingsPropertiesCustom[`custom`]
 }
 
 /**
@@ -84,13 +84,13 @@ export interface GlobalSettingsAndStyles {
    * - And the default layout of the editor (widths and available alignments).
    */
   settings?: SettingsProperties & {
-    appearanceTools?: unknown
-    color?: unknown
-    layout?: unknown
-    spacing?: unknown
-    typography?: unknown
-    border?: unknown
-    custom?: unknown
+    appearanceTools?: SettingsPropertiesAppearanceTools[`appearanceTools`]
+    color?: SettingsPropertiesColor[`color`]
+    layout?: SettingsPropertiesLayout[`layout`]
+    spacing?: SettingsPropertiesSpacing[`spacing`]
+    typography?: SettingsPropertiesTypography[`typography`]
+    border?: SettingsPropertiesBorder[`border`]
+    custom?: SettingsPropertiesCustom[`custom`]
 
     /**
      * Settings defined on a per-block basis.

--- a/sources/@roots/bud/src/cli/commands/bud.upgrade.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.upgrade.tsx
@@ -75,7 +75,7 @@ export default class BudUpgradeCommand extends BudCommand {
     }
 
     if (this.hasUpgradeableDependencies(`devDependencies`)) {
-      await this.$(this.bin, [
+      await this.$(this.pacman, [
         this.command,
         ...this.getUpgradeableDependencies(`devDependencies`),
         ...this.getFlags(`devDependencies`),
@@ -83,7 +83,7 @@ export default class BudUpgradeCommand extends BudCommand {
     }
 
     if (this.hasUpgradeableDependencies(`dependencies`)) {
-      await this.$(this.bin, [
+      await this.$(this.pacman, [
         this.command,
         ...this.getUpgradeableDependencies(`dependencies`),
         ...this.getFlags(`dependencies`),
@@ -128,7 +128,7 @@ export default class BudUpgradeCommand extends BudCommand {
     const flags = []
 
     if (type === `devDependencies`) {
-      switch (this.bin) {
+      switch (this.pacman) {
         case `npm`:
           flags.push(`--save-dev`)
           break
@@ -138,7 +138,7 @@ export default class BudUpgradeCommand extends BudCommand {
       }
     }
 
-    if (type === `dependencies` && this.bin === `npm`) {
+    if (type === `dependencies` && this.pacman === `npm`) {
       flags.push(`--save`)
     }
 

--- a/sources/@roots/sage/src/sage/extension.ts
+++ b/sources/@roots/sage/src/sage/extension.ts
@@ -6,7 +6,6 @@ import {
   dependsOnOptional,
   expose,
   label,
-  options,
 } from '@roots/bud-framework/extension/decorators'
 
 interface Options {
@@ -16,9 +15,7 @@ interface Options {
 /**
  * roots/sage support extension
  *
- * @public
- * @decorator `@label`
- * @decorator `@dependsOn`
+ * @see https://bud.js.org/extensions/sage/
  */
 @label(`@roots/sage`)
 @dependsOn([
@@ -27,14 +24,10 @@ interface Options {
   `@roots/sage/acorn`,
 ])
 @dependsOnOptional([`@roots/bud-tailwindcss`])
-@options<Options>({acorn: `v2`})
 @expose(`sage`)
 export class Sage extends Extension<Options> {
   /**
    * `boot` callback
-   *
-   * @public
-   * @decorator `@bind`
    */
   @bind
   public override async register(app: Bud) {
@@ -74,23 +67,19 @@ export class Sage extends Extension<Options> {
   }
 
   /**
-   * `configAfter` callback
-   *
-   * @public
-   */
-  @bind
-  public override async configAfter(app: Bud) {
-    if (this.options.acorn === `v2`)
-      await app.extensions.add(`@roots/sage/acorn-v2-public-path`)
-  }
-
-  /**
    * Set acorn version
    *
-   * @public
+   * @deprecated - This function is deprecated. It is unneeded; you can just remove the call.
    */
   @bind
-  public setAcornVersion(version: 'v2' | 'v3') {
-    this.setOption(`acorn`, version)
+  public setAcornVersion(version?: 'v2' | 'v3') {
+    this.logger.warn(
+      `\n\n`,
+      `bud.sage.setAcornVersion: This function is deprecated.\n It is unneeded; you can just remove the call.\n\n`,
+      `If you feel that you need to run it you can add the following to your config:\n\n`,
+      `bud.use(\`@roots/sage/acorn-v2-public-path\`)\n\n`,
+      `If you are experiencing an issue and adding this extension fixes it, please open an issue.\n\n`,
+      `https://github.com/roots/bud.\n\n`,
+    )
   }
 }

--- a/sources/@roots/sage/src/types.ts
+++ b/sources/@roots/sage/src/types.ts
@@ -13,16 +13,12 @@ declare module '@roots/bud-framework' {
     /**
      * Set options related to sage
      *
-     * @public
+     * @see {@link https://bud.js.org/extensions/sage/}
      */
     sage: Sage
 
     /**
      * Generate a WordPress `theme.json`
-     *
-     * @example
-     * ```js
-     * bud.wpjson.
      *
      * @see {@link https://bud.js.org/extensions/sage/theme.json/}
      * @see {@link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/}

--- a/sources/@roots/sage/src/wp-theme-json/plugin.ts
+++ b/sources/@roots/sage/src/wp-theme-json/plugin.ts
@@ -15,36 +15,28 @@ import type {
 export interface Options {
   /**
    * WordPress `settings`
-   *
-   * @public
+   * @see https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/
    */
   settings?: Partial<ThemeJSON.GlobalSettingsAndStyles['settings']>
 
   /**
    * WordPress `customTemplates`
-   *
-   * @public
+   * @see https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/
    */
   customTemplates?: ThemeJSON.GlobalSettingsAndStyles['customTemplates']
 
   /**
    * Emit path
-   *
-   * @public
    */
   path: string
 }
 
 /**
  * ThemeJSONWebpackPlugin
- *
- * @public
  */
 export class ThemeJsonWebpackPlugin implements WebpackPluginInstance {
   /**
    * theme.json path
-   *
-   * @public
    */
   public get path(): string {
     return this.options.path
@@ -52,8 +44,6 @@ export class ThemeJsonWebpackPlugin implements WebpackPluginInstance {
 
   /**
    * theme.json settings
-   *
-   * @public
    */
   public get settings(): string {
     return JSON.stringify(
@@ -72,8 +62,6 @@ export class ThemeJsonWebpackPlugin implements WebpackPluginInstance {
    * Class constructor
    *
    * @param options - Plugin options
-   *
-   * @public
    */
   public constructor(public options: Options) {}
 
@@ -82,9 +70,6 @@ export class ThemeJsonWebpackPlugin implements WebpackPluginInstance {
    *
    * @param compiler - Webpack compiler
    * @returns void
-   *
-   * @public
-   * @decorator `@bind`
    */
   @bind
   public apply(compiler: Compiler) {
@@ -92,12 +77,9 @@ export class ThemeJsonWebpackPlugin implements WebpackPluginInstance {
   }
 
   /**
-   * Compiler done
+   * Compiler done callback
    *
    * @returns Promise
-   *
-   * @public
-   * @decorator `@bind`
    */
   @bind
   public async done() {


### PR DESCRIPTION
- deprecates `bud.sage.setAcornVersion` (great that we don't need it!)
- fixes `bud upgrade`, which got janked.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
