### PR TITLE
🩹 fix: `server is not a constructor`

### DIFF
--- a/sources/@roots/bud-server/src/server/https.ts
+++ b/sources/@roots/bud-server/src/server/https.ts
@@ -1,7 +1,7 @@
 import type {RequestListener} from 'node:http'
 import {createServer, Server as HttpsServer} from 'node:https'
 
-import type {Server} from '@roots/bud-framework/services'
+import type {Connection} from '@roots/bud-framework/services/server'
 import {BaseServer} from '@roots/bud-server/server/base'
 import {bind} from '@roots/bud-support/decorators'
 
@@ -10,7 +10,7 @@ import {bind} from '@roots/bud-support/decorators'
  *
  * @public
  */
-export class Https extends BaseServer implements Server.Connection {
+export class Server extends BaseServer implements Connection {
   /**
    * Server instance
    *

--- a/sources/@roots/bud-support/package.json
+++ b/sources/@roots/bud-support/package.json
@@ -207,7 +207,6 @@
     "parse5-htmlparser2-tree-adapter": ">=7",
     "patch-console": ">=2",
     "pretty-format": ">=29",
-    "react": "*",
     "signale": ">=1",
     "terser-webpack-plugin": "*",
     "toml": "*",
@@ -328,9 +327,6 @@
       "optional": true
     },
     "pretty-format": {
-      "optional": true
-    },
-    "react": {
       "optional": true
     },
     "signale": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6947,7 +6947,6 @@ __metadata:
     parse5-htmlparser2-tree-adapter: ">=7"
     patch-console: ">=2"
     pretty-format: ">=29"
-    react: "*"
     signale: ">=1"
     terser-webpack-plugin: "*"
     toml: "*"
@@ -7031,8 +7030,6 @@ __metadata:
     patch-console:
       optional: true
     pretty-format:
-      optional: true
-    react:
       optional: true
     signale:
       optional: true


### PR DESCRIPTION
Also removes `react` from `@roots/bud-support` peerDependencies (since we don't want it overridden there, ref #1974)

refers:

- Fixes #1975

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
