### PR TITLE
🩹 fix: --cwd flag

### DIFF
--- a/sources/@roots/bud-tailwindcss/src/extension/index.test.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension/index.test.ts
@@ -1,4 +1,4 @@
-import '@roots/bud-tailwindcss'
+import '../types/index.js'
 
 import resolveConfig from 'tailwindcss/resolveConfig.js'
 import {beforeEach, describe, expect, it, vi} from 'vitest'

--- a/sources/@roots/bud-tailwindcss/src/extension/index.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension/index.ts
@@ -42,7 +42,10 @@ export class BudTailwindCss extends Extension<{
     return (
       this.app.context.config[`tailwind.config.js`]?.path ??
       this.app.context.config[`tailwind.config.mjs`]?.path ??
-      this.app.context.config[`tailwind.config.cjs`]?.path
+      this.app.context.config[`tailwind.config.cjs`]?.path ??
+      this.app.root.context.config[`tailwind.config.js`]?.path ??
+      this.app.root.context.config[`tailwind.config.mjs`]?.path ??
+      this.app.root.context.config[`tailwind.config.cjs`]?.path
     )
   }
 
@@ -55,8 +58,10 @@ export class BudTailwindCss extends Extension<{
    * Tailwind config (resolved)
    */
   private declare config: ResolvedConfig | undefined
+
+  @bind
   public getConfig(): this[`config`] {
-    return this.config
+    return this.config ? this.config : this.resolveConfig()
   }
 
   /**
@@ -70,6 +75,8 @@ export class BudTailwindCss extends Extension<{
         colors?: ResolvedConfig['colors']
       })
     | undefined
+
+  @bind
   public getTheme(): this[`theme`] {
     return this.theme
   }
@@ -77,6 +84,7 @@ export class BudTailwindCss extends Extension<{
   /**
    * Get config source module
    */
+  @bind
   public async getSource(): Promise<Config> {
     let config: Config
 
@@ -214,7 +222,7 @@ export class BudTailwindCss extends Extension<{
 
     bud.postcss?.setPlugins({
       nesting: this.dependencies.nesting,
-      tailwindcss: this.dependencies.tailwindcss,
+      tailwindcss: [this.dependencies.tailwindcss, {config: this.config}],
     })
 
     this.logger.success(`postcss configured for tailwindcss`)

--- a/sources/@roots/bud-tailwindcss/src/extension/index.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension/index.ts
@@ -222,7 +222,7 @@ export class BudTailwindCss extends Extension<{
 
     bud.postcss?.setPlugins({
       nesting: this.dependencies.nesting,
-      tailwindcss: [this.dependencies.tailwindcss, {config: this.config}],
+      tailwindcss: [this.dependencies.tailwindcss, this.path],
     })
 
     this.logger.success(`postcss configured for tailwindcss`)

--- a/sources/@roots/bud-tailwindcss/test/implementation.test.ts
+++ b/sources/@roots/bud-tailwindcss/test/implementation.test.ts
@@ -1,0 +1,34 @@
+import {join} from 'node:path'
+import {paths} from '@repo/constants'
+import execa, {ExecaReturnValue} from '@roots/bud-support/execa'
+import {beforeAll, describe, expect, it} from 'vitest'
+import fs from '@roots/bud-support/fs-jetpack'
+
+describe(`@tests/tailwind-implementation`, () => {
+  let child: ExecaReturnValue
+
+  beforeAll(async () => {
+    await execa(`yarn`, [`bud`, `clean`, `--cwd`, `sources/@roots/bud-tailwindcss/test/implementation`])
+
+    try {
+      child = await execa(`yarn`, [`bud`, `build`, `--no-cache`, `--debug`, `--cwd`, `sources/@roots/bud-tailwindcss/test/implementation`])
+    } catch (error) {}
+  }, 30000)
+
+  it(`should generate bg-primary class`, async () => {
+    expect(
+      await fs.existsAsync(
+        join(
+          paths.sources, `@roots`, `bud-tailwindcss`, `test`, `implementation`, `dist`, `css`, `main.css`
+        ),
+      ),
+    ).toBe(`file`)
+    expect(
+      await fs.readAsync(
+       join(
+        paths.sources, `@roots`, `bud-tailwindcss`, `test`, `implementation`, `dist`, `css`, `main.css`
+       )
+      )
+    ).toEqual(expect.stringContaining(`.bg-primary {`))
+  })
+})

--- a/sources/@roots/bud-tailwindcss/test/implementation/package.json
+++ b/sources/@roots/bud-tailwindcss/test/implementation/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@tests/tailwind-integration",
+  "private": true,
+  "dependencies": {
+    "@roots/bud": "workspace:*",
+    "@roots/bud-tailwindcss": "workspace:*"
+  }
+}

--- a/sources/@roots/bud-tailwindcss/test/implementation/src/index.css
+++ b/sources/@roots/bud-tailwindcss/test/implementation/src/index.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';

--- a/sources/@roots/bud-tailwindcss/test/implementation/src/index.html
+++ b/sources/@roots/bud-tailwindcss/test/implementation/src/index.html
@@ -1,0 +1,1 @@
+<div class="bg-primary"></div>

--- a/sources/@roots/bud-tailwindcss/test/implementation/tailwind.config.cjs
+++ b/sources/@roots/bud-tailwindcss/test/implementation/tailwind.config.cjs
@@ -1,0 +1,13 @@
+const {resolve} = require(`path`)
+
+module.exports = {
+  content: [resolve(__dirname, `src/index.html`)],
+  theme: {
+    extend: {
+      colors: {
+        primary: `red`,
+      },
+    },
+  },
+  plugins: [],
+}

--- a/sources/@roots/bud/src/cli/commands/bud.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.tsx
@@ -1,5 +1,3 @@
-import {resolve} from 'node:path'
-
 import {Bud} from '@roots/bud'
 import {checkDependencies} from '@roots/bud/cli/helpers/checkDependencies'
 import {checkPackageManagerErrors} from '@roots/bud/cli/helpers/checkPackageManagerErrors'
@@ -184,10 +182,6 @@ export default class BudCommand extends Command<CommandContext> {
   }
 
   public async makeBud<T extends BudCommand>(command: T) {
-    command.context.basedir = command.cwd
-      ? resolve(command.context.basedir, command.cwd)
-      : command.context.basedir
-
     command.context.mode = command.mode ?? command.context.mode
 
     command.context.args = {

--- a/sources/@roots/bud/src/context/argv.ts
+++ b/sources/@roots/bud/src/context/argv.ts
@@ -1,18 +1,18 @@
-import {resolve} from 'node:path'
+import {join} from 'node:path'
 
 export const argv = process.argv.slice(2)
 
 export const has = (flag: string) => argv.some(arg => arg === `--${flag}`)
 
-export const position = (flags: string) =>
-  argv.findIndex(arg => arg === flags)
+export const position = (flag: string) =>
+  argv.findIndex(arg => arg === `--${flag}`)
 
-const basedirIndex = has(`--cwd`)
-  ? position(`--cwd`)
-  : has(`--basedir`)
-  ? position(`--basedir`)
+const basedirIndex = has(`cwd`)
+  ? position(`cwd`)
+  : has(`basedir`)
+  ? position(`basedir`)
   : undefined
 
 export const basedir = basedirIndex
-  ? resolve(process.cwd(), argv[basedirIndex + 1])
+  ? join(process.cwd(), argv[basedirIndex + 1])
   : process.cwd()

--- a/sources/@roots/bud/src/context/index.ts
+++ b/sources/@roots/bud/src/context/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import * as argv from '@roots/bud/context/argv'
 import bud from '@roots/bud/context/bud'
 import * as projectFiles from '@roots/bud/context/config'
 import getEnv from '@roots/bud/context/env'
@@ -20,7 +21,7 @@ export default async (
     find: false,
   },
 ): Promise<Context> => {
-  if (!basedir) basedir = process.cwd()
+  if (!basedir) basedir = argv.basedir
   if (options.cache && contexts[basedir]) return contexts[basedir]
 
   const fs = new Filesystem(basedir)

--- a/sources/@roots/bud/src/factory/factory.ts
+++ b/sources/@roots/bud/src/factory/factory.ts
@@ -38,7 +38,8 @@ export async function factory(
   if (!overrides.basedir) overrides.basedir = argv.basedir
   if (!overrides.mode) overrides.mode = `production`
 
-  if (options.cache && has(overrides.basedir)) return get(overrides.basedir)
+  if (options.cache && has(overrides.basedir))
+    return get(overrides.basedir)
 
   const bud = new Bud()
   const context = await getContext(overrides, options)

--- a/sources/@roots/bud/src/factory/factory.ts
+++ b/sources/@roots/bud/src/factory/factory.ts
@@ -32,19 +32,16 @@ export interface Options {
  * @returns Bud instance
  */
 export async function factory(
-  {
-    basedir,
-    ...overrides
-  }: Partial<CLIContext | Context | CommandContext> = {},
+  overrides: Partial<CLIContext | Context | CommandContext> = {},
   options: Options = {cache: true, find: false},
 ): Promise<Bud> {
-  if (!basedir) basedir = argv.basedir ?? process.cwd()
+  if (!overrides.basedir) overrides.basedir = argv.basedir
   if (!overrides.mode) overrides.mode = `production`
 
-  if (options.cache && has(basedir)) return get(basedir)
+  if (options.cache && has(overrides.basedir)) return get(overrides.basedir)
 
   const bud = new Bud()
-  const context = await getContext({basedir, ...overrides}, options)
+  const context = await getContext(overrides, options)
 
   if (options.cache) {
     set(context.basedir, bud)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7193,7 +7193,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@roots/bud-tailwindcss@workspace:sources/@roots/bud-tailwindcss":
+"@roots/bud-tailwindcss@workspace:*, @roots/bud-tailwindcss@workspace:sources/@roots/bud-tailwindcss":
   version: 0.0.0-use.local
   resolution: "@roots/bud-tailwindcss@workspace:sources/@roots/bud-tailwindcss"
   dependencies:
@@ -7405,7 +7405,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@roots/bud@workspace:sources/@roots/bud":
+"@roots/bud@workspace:*, @roots/bud@workspace:sources/@roots/bud":
   version: 0.0.0-use.local
   resolution: "@roots/bud@workspace:sources/@roots/bud"
   dependencies:
@@ -8290,8 +8290,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tests/tailwind-integration@workspace:sources/@roots/bud-tailwindcss/test/implementation"
   dependencies:
-    "@roots/bud": "workspace:sources/@roots/bud"
-    "@roots/bud-tailwindcss": "workspace:sources/@roots/bud-tailwindcss"
+    "@roots/bud": "workspace:*"
+    "@roots/bud-tailwindcss": "workspace:*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8286,6 +8286,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@tests/tailwind-integration@workspace:sources/@roots/bud-tailwindcss/test/implementation":
+  version: 0.0.0-use.local
+  resolution: "@tests/tailwind-integration@workspace:sources/@roots/bud-tailwindcss/test/implementation"
+  dependencies:
+    "@roots/bud": "workspace:sources/@roots/bud"
+    "@roots/bud-tailwindcss": "workspace:sources/@roots/bud-tailwindcss"
+  languageName: unknown
+  linkType: soft
+
 "@tootallnate/once@npm:1":
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"


### PR DESCRIPTION
- Fix: `--basedir`/`--cwd` flag handling in `@roots/bud/context`, `@roots/bud/factory`, and `@roots/bud/cli/commands/bud`
- Fix: need to pass config to tailwindcss (tailwindcss doesn't care about webpack context and will always try to find the tailwind config in the process cwd).

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
