### PR TITLE
✨ improve(@roots/bud-build): allow adding raw webpack rules

### DIFF
--- a/sources/@repo/docs/content/guides/general-use/customizing-loaders.mdx
+++ b/sources/@repo/docs/content/guides/general-use/customizing-loaders.mdx
@@ -7,6 +7,37 @@ sidebar_label: Customizing loaders
 
 The **bud.build** service allows you to customize the loaders used to process modules.
 
+## Adding a rule
+
+The majority of this guide is focused on adding support for additional filetypes to bud.js in a way that is compatible
+with the rest of the framework and composable with rules added by other extensions.
+
+However, if you just want to add a rule in the context of the bud config file, you might find it easiest to use the `build.module.rules.oneOf` hook:
+
+```js title=bud.config.js
+export default async bud => {
+  bud.hooks.on(`build.module.rules.oneOf`, (rules = []) => {
+    rules.push({
+      test: /\.example$/,
+      use: [
+        {
+          loader: `babel-loader`,
+          options: {
+            presets: [`@babel/preset-env`],
+          },
+        },
+      ],
+    })
+
+    return rules
+  })
+}
+```
+
+If you are authoring an extension, you should use the API described below.
+
+## Overview
+
 **bud.build** divides its handling of loaders into three related objects:
 
 - [Loaders](#loaders) — A resolved path to a script which processes source modules

--- a/sources/@roots/bud-build/src/config/module.ts
+++ b/sources/@roots/bud-build/src/config/module.ts
@@ -30,7 +30,9 @@ const getRules = ({filter, path, rules}: Props) => [
   {
     oneOf: filter(
       `build.module.rules.oneOf`,
-      Object.values(rules).map(rule => rule.toWebpack()),
+      Object.values(rules).map(rule =>
+        `toWebpack` in rule ? rule.toWebpack() : rule,
+      ),
     ),
   },
   ...filter(`build.module.rules.after`, []),

--- a/sources/@roots/bud-build/src/rule/index.ts
+++ b/sources/@roots/bud-build/src/rule/index.ts
@@ -292,7 +292,7 @@ class Rule extends Base implements Interface {
       generator: this.getGenerator(),
       use: this.getUse()
         ?.map(item => (isString(item) ? this.app.build.items[item] : item))
-        .map(item => item.toWebpack()),
+        .map(item => (`toWebpack` in item ? item.toWebpack() : item)),
       resourceQuery: this.getResourceQuery(),
       include: this.getInclude(),
       exclude: this.getExclude(),


### PR DESCRIPTION
Ducktypes rules registered to `build.module.rules.oneOf` hook for `toWebpack` method. If it isn't found the object will be used directly. This means users can add rules without needing to learn about the `bud.build` service.

Example:

```js
bud.hooks.on(`build.module.rules.oneOf`, (rules = []) => {
  rules.push({
    test: /\.example$/,
    use: [
      {
        loader: `babel-loader`,
        options: {
          presets: [`@babel/preset-env`],
        },
      },
    ],
  })

  return rules
})
```

Also updates documentation accordingly.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
