### PR TITLE
🩹 fix(@roots/wordpress-hmr): duplicative block registrations

### DIFF
--- a/sources/@roots/bud-esbuild/src/extension.test.ts
+++ b/sources/@roots/bud-esbuild/src/extension.test.ts
@@ -1,6 +1,7 @@
 import {factory} from '@repo/test-kit/bud'
 import esbuild from '@roots/bud-esbuild'
-import {isArray, isUndefined} from 'lodash-es'
+import isArray from 'lodash/isArray.js'
+import isUndefined from 'lodash/isUndefined.js'
 import {beforeEach, describe, expect, it} from 'vitest'
 
 import Extension from './index.js'

--- a/sources/@roots/entrypoints-webpack-plugin/package.json
+++ b/sources/@roots/entrypoints-webpack-plugin/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "helpful-decorators": "2.1.0",
-    "lodash-es": "4.17.21",
+    "lodash": "4.17.21",
     "tslib": "2.4.1"
   },
   "peerDependencies": {

--- a/sources/@roots/entrypoints-webpack-plugin/src/webpack.plugin.ts
+++ b/sources/@roots/entrypoints-webpack-plugin/src/webpack.plugin.ts
@@ -1,5 +1,5 @@
 import {bind} from 'helpful-decorators'
-import {uniq} from 'lodash-es'
+import uniq from 'lodash/uniq.js'
 import Webpack from 'webpack'
 
 import {HtmlEmitter} from './html.emitter.js'

--- a/sources/@roots/filesystem/package.json
+++ b/sources/@roots/filesystem/package.json
@@ -97,7 +97,7 @@
     "helpful-decorators": "2.1.0",
     "js-yaml": "4.1.0",
     "json5": "2.2.3",
-    "lodash-es": "4.17.21",
+    "lodash": "4.17.21",
     "mime-types": "2.1.35",
     "safe-json-stringify": "1.2.0"
   },

--- a/sources/@roots/filesystem/src/filesystem.ts
+++ b/sources/@roots/filesystem/src/filesystem.ts
@@ -20,7 +20,7 @@ import type {
   WriteOptions,
 } from 'fs-jetpack/types.js'
 import {bind} from 'helpful-decorators'
-import {isNumber} from 'lodash-es'
+import isNumber from 'lodash/isNumber.js'
 
 import * as json from './json.js'
 import * as yml from './yml.js'

--- a/sources/@roots/filesystem/src/s3/index.ts
+++ b/sources/@roots/filesystem/src/s3/index.ts
@@ -8,7 +8,7 @@ import type {
   S3Client,
 } from '@aws-sdk/client-s3'
 import {bind} from 'helpful-decorators'
-import {isString} from 'lodash-es'
+import isString from 'lodash/isString.js'
 import * as mimetypes from 'mime-types'
 
 import {Client} from './client.js'

--- a/sources/@roots/wordpress-externals-webpack-plugin/package.json
+++ b/sources/@roots/wordpress-externals-webpack-plugin/package.json
@@ -58,11 +58,10 @@
   },
   "devDependencies": {
     "@skypack/package-check": "0.2.2",
-    "@types/lodash-es": "4.17.6",
     "@types/node": "16.18.11"
   },
   "dependencies": {
-    "lodash-es": "4.17.21",
+    "lodash": "4.17.21",
     "webpack": "5.75.0"
   },
   "volta": {

--- a/sources/@roots/wordpress-externals-webpack-plugin/src/externals.ts
+++ b/sources/@roots/wordpress-externals-webpack-plugin/src/externals.ts
@@ -1,4 +1,4 @@
-import {join} from 'lodash-es'
+import join from 'lodash/join.js'
 
 export type WordPressScopePkg = `@wordpress/${string}`
 

--- a/sources/@roots/wordpress-hmr/package.json
+++ b/sources/@roots/wordpress-hmr/package.json
@@ -40,49 +40,44 @@
     "src"
   ],
   "type": "module",
-  "module": "./lib/index.js",
-  "types": "./lib/index.d.ts",
   "exports": {
-    ".": "./lib/index.js",
-    "./block": "./lib/block.js",
-    "./blocks": "./lib/block.js",
-    "./cache": "./lib/cache.js",
-    "./editor": "./lib/editor.js",
-    "./format": "./lib/format.js",
-    "./plugin": "./lib/plugin.js",
-    "./plugins": "./lib/plugin.js"
-  },
-  "typesVersions": {
-    "*": {
-      ".": [
-        "./lib/index.d.ts"
-      ],
-      "block": [
-        "./lib/block.d.ts"
-      ],
-      "blocks": [
-        "./lib/block.d.ts"
-      ],
-      "cache": [
-        "./lib/cache.d.ts"
-      ],
-      "editor": [
-        "./lib/editor.d.ts"
-      ],
-      "format": [
-        "./lib/format.d.ts"
-      ],
-      "plugin": [
-        "./lib/plugin.d.ts"
-      ],
-      "plugins": [
-        "./lib/plugin.d.ts"
-      ]
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./block": {
+      "types": "./lib/block.d.ts",
+      "default": "./lib/block.js"
+    },
+    "./blocks": {
+      "types": "./lib/block.d.ts",
+      "default": "./lib/block.js"
+    },
+    "./cache": {
+      "types": "./lib/cache.d.ts",
+      "default": "./lib/cache.js"
+    },
+    "./editor": {
+      "types": "./lib/editor.d.ts",
+      "default": "./lib/editor.js"
+    },
+    "./format": {
+      "types": "./lib/format.d.ts",
+      "default": "./lib/format.js"
+    },
+    "./plugin": {
+      "types": "./lib/plugin.d.ts",
+      "default": "./lib/plugin.js"
+    },
+    "./plugins": {
+      "types": "./lib/plugins.d.ts",
+      "default": "./lib/plugins.js"
     }
   },
+  "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "devDependencies": {
     "@skypack/package-check": "0.2.2",
-    "@types/lodash-es": "4.17.6",
     "@types/node": "16.18.11",
     "@types/react": "18.0.26",
     "@types/wordpress__blocks": "12.0.1",
@@ -93,14 +88,7 @@
     "@wordpress/data": "8.1.0",
     "@wordpress/hooks": "3.24.0",
     "@wordpress/plugins": "5.1.0",
-    "@wordpress/rich-text": "6.1.0",
-    "react": "18.2.0"
-  },
-  "dependencies": {
-    "lodash-es": "4.17.21"
-  },
-  "peerDependencies": {
-    "lodash-es": "*"
+    "@wordpress/rich-text": "6.1.0"
   },
   "volta": {
     "extends": "../../../package.json"

--- a/sources/@roots/wordpress-hmr/src/block.ts
+++ b/sources/@roots/wordpress-hmr/src/block.ts
@@ -1,5 +1,6 @@
 import {
   BlockInstance,
+  getBlockType,
   registerBlockStyle,
   registerBlockType,
   unregisterBlockStyle,
@@ -14,11 +15,14 @@ import * as editor from './editor.js'
  * Register block
  */
 export const register = ({name, settings, filters, styles}) => {
+  if (getBlockType(name)) {
+    unregister({name, filters, styles})
+  }
+
   registerBlockType(name, settings)
 
   styles?.map(style => registerBlockStyle(name, style))
-
-  filters?.forEach(({name, namespace, callback}) => {
+  filters?.map(({name, namespace, callback}) => {
     addFilter(name, namespace, callback)
   })
 }

--- a/sources/@roots/wordpress-hmr/src/block.ts
+++ b/sources/@roots/wordpress-hmr/src/block.ts
@@ -33,11 +33,10 @@ export const register = ({name, settings, filters, styles}) => {
 export const unregister = ({name, filters, styles}) => {
   unregisterBlockType(name)
 
-  filters?.forEach(({hook, namespace}) => {
+  filters?.map(({hook, namespace}) => {
     removeFilter(hook, namespace)
   })
-
-  styles?.forEach(style => unregisterBlockStyle(name, style.name))
+  styles?.map(style => unregisterBlockStyle(name, style.name))
 }
 
 let selected = null
@@ -75,6 +74,12 @@ const after = (changed?: Array<{name: string}>) => {
 }
 
 export const load = (getContext, callback): void => {
-  const blockContextProps = {register, unregister, before, after}
-  editor.load({getContext, callback, ...blockContextProps})
+  editor.load({
+    getContext,
+    callback,
+    register,
+    unregister,
+    before,
+    after,
+  })
 }

--- a/sources/@roots/wordpress-hmr/src/cache.ts
+++ b/sources/@roots/wordpress-hmr/src/cache.ts
@@ -1,12 +1,10 @@
-import {isUndefined} from 'lodash-es'
-
 type Module = any
 
 export class Cache {
   public store: {[key: string]: Module} = {}
 
   public has(key: string): boolean {
-    return !isUndefined(this.store[key])
+    return typeof this.store[key] !== `undefined`
   }
 
   public set(key: string, value: Module): void {

--- a/sources/@roots/wordpress-hmr/src/editor.ts
+++ b/sources/@roots/wordpress-hmr/src/editor.ts
@@ -1,6 +1,7 @@
-import {isFunction, noop} from 'lodash-es'
-
 import {Cache} from './cache.js'
+
+const isFunction = (value: any): boolean => typeof value === `function`
+const noop = (...args: Array<any>) => null
 
 export const load = ({
   getContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7669,7 +7669,7 @@ __metadata:
     "@types/lodash-es": 4.17.6
     "@types/node": 16.18.11
     helpful-decorators: 2.1.0
-    lodash-es: 4.17.21
+    lodash: 4.17.21
     tslib: 2.4.1
     webpack: 5.75.0
   peerDependencies:
@@ -7766,7 +7766,7 @@ __metadata:
     helpful-decorators: 2.1.0
     js-yaml: 4.1.0
     json5: 2.2.3
-    lodash-es: 4.17.21
+    lodash: 4.17.21
     mime-types: 2.1.35
     safe-json-stringify: 1.2.0
   languageName: unknown
@@ -7825,9 +7825,8 @@ __metadata:
   resolution: "@roots/wordpress-externals-webpack-plugin@workspace:sources/@roots/wordpress-externals-webpack-plugin"
   dependencies:
     "@skypack/package-check": 0.2.2
-    "@types/lodash-es": 4.17.6
     "@types/node": 16.18.11
-    lodash-es: 4.17.21
+    lodash: 4.17.21
     webpack: 5.75.0
   languageName: unknown
   linkType: soft
@@ -7837,7 +7836,6 @@ __metadata:
   resolution: "@roots/wordpress-hmr@workspace:sources/@roots/wordpress-hmr"
   dependencies:
     "@skypack/package-check": 0.2.2
-    "@types/lodash-es": 4.17.6
     "@types/node": 16.18.11
     "@types/react": 18.0.26
     "@types/wordpress__blocks": 12.0.1
@@ -7849,10 +7847,6 @@ __metadata:
     "@wordpress/hooks": 3.24.0
     "@wordpress/plugins": 5.1.0
     "@wordpress/rich-text": 6.1.0
-    lodash-es: 4.17.21
-    react: 18.2.0
-  peerDependencies:
-    lodash-es: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- fixes issues in some setups (?) where blocks would be registered more than once
- removes `lodash-es` so this pkg is 0 dep

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
