### PR TITLE
🩹 fix: @asset directive

### DIFF
--- a/sources/@roots/blade-loader/test/index.test.ts
+++ b/sources/@roots/blade-loader/test/index.test.ts
@@ -7,6 +7,7 @@ import BladeWebpackPlugin from '../lib/plugin';
 describe('@roots/blade-loader', () => {
   let compiler
   let modules
+  let assets
   let errors
   let entrypoints
 
@@ -41,6 +42,7 @@ describe('@roots/blade-loader', () => {
         if (err) reject(err);
         modules = stats?.toJson({assets: true});
         entrypoints = stats?.toJson().entrypoints
+        assets = stats?.toJson().assets
         return resolve(modules)
       });
     });
@@ -51,7 +53,6 @@ describe('@roots/blade-loader', () => {
   })
 
   it('works good', ()  => {
-    expect(Object.values(entrypoints)).toHaveLength(1)
     expect(Object.values(entrypoints)[0]).toEqual(expect.objectContaining({
       assets: [expect.objectContaining({
         name: `main.js`,

--- a/sources/@roots/bud-imagemin/src/extension/extension.ts
+++ b/sources/@roots/bud-imagemin/src/extension/extension.ts
@@ -92,5 +92,28 @@ export class BudImageminExtension extends Extension {
   public override async init(bud: Bud): Promise<void> {
     this.sharp = bud.extensions.get(`@roots/bud-imagemin/sharp`)
     this.svgo = bud.extensions.get(`@roots/bud-imagemin/svgo`)
+
+    bud.extensions.get(`@roots/bud-extensions/webpack-manifest-plugin`)
+      .setOption(`generate`, () => () => (_seed, files, _entrypoints) => {
+        return files.reduce((acc, file) => {
+          const match = file.path.match(/generated\..*@(\d*)x(\d*)\.(.*)$/)
+
+          if (match) {
+            const [_, width, height, rest] = match
+            const as = rest.split(`.`).pop()
+            return {
+              ...acc,
+              [`${file.name}?as=${as}`]: file.path,
+              [`${file.name}?as=${as}&width=${width}`]: file.path,
+              [`${file.name}?as=${as}&width=${width}&height=${height}`]: file.path,
+            }
+          }
+
+          return {
+            ...acc,
+            [file.name]: file.path,
+          }
+        },{})
+      })
   }
 }

--- a/sources/@roots/bud-imagemin/src/extension/extension.ts
+++ b/sources/@roots/bud-imagemin/src/extension/extension.ts
@@ -93,7 +93,8 @@ export class BudImageminExtension extends Extension {
     this.sharp = bud.extensions.get(`@roots/bud-imagemin/sharp`)
     this.svgo = bud.extensions.get(`@roots/bud-imagemin/svgo`)
 
-    bud.extensions.get(`@roots/bud-extensions/webpack-manifest-plugin`)
+    bud.extensions
+      .get(`@roots/bud-extensions/webpack-manifest-plugin`)
       .setOption(`generate`, () => () => (_seed, files, _entrypoints) => {
         return files.reduce((acc, file) => {
           const match = file.path.match(/generated\..*@(\d*)x(\d*)\.(.*)$/)
@@ -105,7 +106,8 @@ export class BudImageminExtension extends Extension {
               ...acc,
               [`${file.name}?as=${as}`]: file.path,
               [`${file.name}?as=${as}&width=${width}`]: file.path,
-              [`${file.name}?as=${as}&width=${width}&height=${height}`]: file.path,
+              [`${file.name}?as=${as}&width=${width}&height=${height}`]:
+                file.path,
             }
           }
 
@@ -113,7 +115,7 @@ export class BudImageminExtension extends Extension {
             ...acc,
             [file.name]: file.path,
           }
-        },{})
+        }, {})
       })
   }
 }

--- a/sources/@roots/bud-imagemin/src/extension/extension.ts
+++ b/sources/@roots/bud-imagemin/src/extension/extension.ts
@@ -20,9 +20,9 @@ import type BudImageminSvgo from '../svgo/index.js'
  *
  * @see {@link https://bud.js.org/extensions/bud-imagemin}
  *
- * @public
  * @decorator `@label`
  * @decorator `@expose`
+ * @decorator `@dependsOn`
  */
 @label(`@roots/bud-imagemin`)
 @expose(`imagemin`)
@@ -78,8 +78,7 @@ export class BudImageminExtension extends Extension {
   public addPreset<K extends keyof SharpEncodeOptions>(
     ...params: [key: K, value: Partial<Generator>]
   ) {
-    const [key, value] = params
-    this.sharp.setGenerator(key, value)
+    this.sharp.setGenerator(...params)
     return this
   }
 
@@ -104,17 +103,24 @@ export class BudImageminExtension extends Extension {
             const as = rest.split(`.`).pop()
             return {
               ...acc,
-              [`${file.name}?as=${as}`]: file.path,
+
+              /**
+               * Prevent overwriting of full resolution
+               *
+               * Not sure that this behaves exactly as expected. But, it's
+               * more predictable in practice than leaving it unhandled.
+               */
+              ...(!acc[`${file.name}?as=${as}`]
+                ? {[`${file.name}?as=${as}`]: file.path}
+                : {}),
+
               [`${file.name}?as=${as}&width=${width}`]: file.path,
               [`${file.name}?as=${as}&width=${width}&height=${height}`]:
                 file.path,
             }
           }
 
-          return {
-            ...acc,
-            [file.name]: file.path,
-          }
+          return {...acc, [file.name]: file.path}
         }, {})
       })
   }

--- a/sources/@roots/bud-imagemin/src/sharp/sharp.test.ts
+++ b/sources/@roots/bud-imagemin/src/sharp/sharp.test.ts
@@ -35,7 +35,7 @@ describe(`@roots/bud-imagemin/sharp`, () => {
     await sharp.init()
 
     expect(sharp.generators.get(`webp`)).toStrictEqual({
-      filename: `[path][name]-[width]x[height][ext]`,
+      filename: `[path]generated.[name]@[width]x[height][ext]`,
       implementation: Plugin.sharpGenerate,
       preset: `webp`,
       options: {
@@ -60,7 +60,7 @@ describe(`@roots/bud-imagemin/sharp`, () => {
     expect(sharp.generators.get(`foo`)).toStrictEqual({
       preset: `foo`,
       implementation: expect.any(Function),
-      filename: `[path][name]-[width]x[height][ext]`,
+      filename: `[path]generated.[name]@[width]x[height][ext]`,
       options: definition.options,
     })
     expect(result).toBe(sharp)

--- a/sources/@roots/bud-imagemin/src/sharp/sharp.ts
+++ b/sources/@roots/bud-imagemin/src/sharp/sharp.ts
@@ -53,7 +53,7 @@ export class BudImageminSharp extends Extension {
   ): this {
     this.generators.set(preset, {
       preset: generator?.preset ?? preset,
-      filename: `[path][name]-[width]x[height][ext]`,
+      filename: `[path]generated.[name]@[width]x[height][ext]`,
       implementation: generator?.implementation ?? Plugin.sharpGenerate,
       ...generator,
     })
@@ -70,7 +70,11 @@ export class BudImageminSharp extends Extension {
   public override async init() {
     this.generators = new Map()
     this.implementation = Plugin.sharpMinify
-    this.setGenerator(`webp`, {options: {encodeOptions: {webp: {}}}})
+    this.setGenerator(`webp`, {
+      options: {
+        encodeOptions: {webp: {}},
+      },
+    })
   }
 
   /**

--- a/sources/@roots/bud-imagemin/test/index.test.ts
+++ b/sources/@roots/bud-imagemin/test/index.test.ts
@@ -62,7 +62,7 @@ describe(`@roots/bud-imagemin test projects`, () => {
         `quality-50`,
         `dist`,
         `images`,
-        `bud-1200x630.webp`,
+        `generated.bud@1200x630.webp`,
       ),
       `utf-8`,
     )
@@ -72,7 +72,7 @@ describe(`@roots/bud-imagemin test projects`, () => {
         `quality-default`,
         `dist`,
         `images`,
-        `bud-1200x630.webp`,
+        `generated.bud@1200x630.webp`,
       ),
       `utf-8`,
     )

--- a/tests/reproductions/issue-1886.test.ts
+++ b/tests/reproductions/issue-1886.test.ts
@@ -23,7 +23,7 @@ describe('issue-1886', () => {
         `issue-1886`,
         `dist`,
         `images`,
-        `bud-1200x630.webp`,
+        `generated.bud@1200x630.webp`,
       ),
       `utf-8`,
     )
@@ -38,7 +38,7 @@ describe('issue-1886', () => {
         `issue-1886`,
         `dist`,
         `images`,
-        `bud-1200x630.jpeg`,
+        `generated.bud@1200x630.jpeg`,
       ),
       `utf-8`,
     )
@@ -53,7 +53,7 @@ describe('issue-1886', () => {
         `issue-1886`,
         `dist`,
         `images`,
-        `bud-50-1200x630.webp`,
+        `generated.bud-50@1200x630.webp`,
       ),
       `utf-8`,
     )
@@ -68,7 +68,7 @@ describe('issue-1886', () => {
         `issue-1886`,
         `dist`,
         `images`,
-        `bud-css-1200x630.webp`,
+        `generated.bud-css@1200x630.webp`,
       ),
       `utf-8`,
     )


### PR DESCRIPTION
Fixes manifest generation related to `@roots/blade-loader`.

Ensures roots/acorn can find generated files based on their key.

```json
{
  "images/404.png": "images/404.e3e14e.png",
  "images/404.png?as=webp": "images/generated.404@3840x1078.7bb3cb.webp",
  "images/404.png?as=webp&width=3840": "images/generated.404@3840x1078.7bb3cb.webp",
  "images/404.png?as=webp&width=3840&height=1078": "images/generated.404@3840x1078.7bb3cb.webp",
  "images/404.png?as=webp&width=200": "images/generated.404@200x56.fab3cb.webp",
  "images/404.png?as=webp&width=200&height=56": "images/generated.404@200x56.fab3cb.webp"
}
```

@retlehs @QWp6t still interested in talking about how acorn might be able to handle this in a less finicky way. for now it works good. 

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
