### PR TITLE
🩹 fix (@roots/bud): CLI healthcheck complaints when version is "latest"

### DIFF
--- a/sources/@roots/bud/src/cli/helpers/checkDependencies.tsx
+++ b/sources/@roots/bud/src/cli/helpers/checkDependencies.tsx
@@ -13,7 +13,11 @@ export const checkDependencies = async (bud: Bud) => {
     .filter(([name]) => name.startsWith(`@roots/`))
     .filter(([signifier, version]: [string, string]) => {
       version = version.replace(`^`, ``)
-      return version !== bud.context.bud.version
+      return (
+        version !== `latest` &&
+        !version.includes(`workspace:`) &&
+        version !== bud.context.bud.version
+      )
     })
 
   mismatches?.length &&

--- a/sources/@roots/bud/src/cli/helpers/checkPackageManagerErrors.tsx
+++ b/sources/@roots/bud/src/cli/helpers/checkPackageManagerErrors.tsx
@@ -1,22 +1,11 @@
-/* eslint-disable react/no-unescaped-entities */
 import type {Bud} from '@roots/bud'
 import React from '@roots/bud-support/react'
 
 import {Error} from '../components/Error.js'
-import {isLockConflict, isNoLock} from './isLockfileError.js'
+import {isLockConflict} from './isLockfileError.js'
 
 export const checkPackageManagerErrors = (bud: Bud): boolean => {
   if (!bud.context.config) return false
-
-  if (isNoLock(bud)) {
-    bud.dashboard.renderer.once(
-      <Error
-        label="Not installed?"
-        message="No lockfile was found in your project. Please run an installation."
-      />,
-    )
-    return true
-  }
 
   if (isLockConflict(bud)) {
     bud.dashboard.renderer.once(


### PR DESCRIPTION
Fix: when version is "latest" bud healthcheck will complain that it doesn't match installed version.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
