### PR TITLE
✨ improve(@roots/bud): options api

### DIFF
--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -496,9 +496,11 @@ export class Extension<
   ): this {
     if (!this.optionsMap) this.optionsMap = {}
 
-    set(this.optionsMap, key, isFunction(value)
-      ? value(this.getOption(key))
-      : value)
+    set(
+      this.optionsMap,
+      key,
+      isFunction(value) ? value(this.getOption(key)) : value,
+    )
 
     return this
   }

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -1,7 +1,9 @@
 import {bind} from '@roots/bud-support/decorators'
+import get from '@roots/bud-support/lodash/get'
 import has from '@roots/bud-support/lodash/has'
 import isFunction from '@roots/bud-support/lodash/isFunction'
 import isUndefined from '@roots/bud-support/lodash/isUndefined'
+import set from '@roots/bud-support/lodash/set'
 import type {Instance as Signale} from '@roots/bud-support/signale'
 
 import type {Bud} from '../bud.js'
@@ -476,8 +478,10 @@ export class Extension<
   public getOption<K extends keyof ExtensionOptions & string>(
     key: K,
   ): ExtensionOptions[K] {
-    return this.options[key]
+    const raw = this.getOptions()
+    return get(raw, key)
   }
+  public get = this.getOption
 
   /**
    * Set extension option
@@ -492,12 +496,13 @@ export class Extension<
   ): this {
     if (!this.optionsMap) this.optionsMap = {}
 
-    this.optionsMap[key] = isFunction(value)
-      ? value(this.options[key])
-      : () => value
+    set(this.optionsMap, key, isFunction(value)
+      ? value(this.getOption(key))
+      : value)
 
     return this
   }
+  public set = this.setOption
 
   /**
    * Normalize options to functions

--- a/sources/@roots/bud-typescript/src/typecheck/extension.test.ts
+++ b/sources/@roots/bud-typescript/src/typecheck/extension.test.ts
@@ -60,8 +60,7 @@ describe(`@roots/bud-typescript/typecheck`, () => {
       bud.typescript.typecheck.enable()
 
       expect(
-        bud.extensions.get(`@roots/bud-typescript`).getOption(`loader`)
-          .transpileOnly,
+        bud.extensions.get(`@roots/bud-typescript`).getOption(`transpileOnly`)
       ).toBe(true)
 
       expect(

--- a/sources/@roots/bud-typescript/src/typecheck/extension.test.ts
+++ b/sources/@roots/bud-typescript/src/typecheck/extension.test.ts
@@ -60,7 +60,9 @@ describe(`@roots/bud-typescript/typecheck`, () => {
       bud.typescript.typecheck.enable()
 
       expect(
-        bud.extensions.get(`@roots/bud-typescript`).getOption(`transpileOnly`)
+        bud.extensions
+          .get(`@roots/bud-typescript`)
+          .getOption(`transpileOnly`),
       ).toBe(true)
 
       expect(

--- a/sources/@roots/bud-vue/src/extension.test.ts
+++ b/sources/@roots/bud-vue/src/extension.test.ts
@@ -57,7 +57,7 @@ describe(`@roots/bud-vue`, () => {
   it(`should register typescript support if @roots/bud-typescript is installed`, async () => {
     await bud.extensions.add(`@roots/bud-typescript`)
     await bud.extensions.get(`@roots/bud-typescript`).configAfter(bud)
-    await instance.buildBefore(bud)
+    await instance.boot(bud)
 
     expect(bud.build.items.ts.getOptions().appendTsSuffixTo).toStrictEqual(
       expect.arrayContaining([/\.vue$/]),

--- a/sources/@roots/bud-vue/src/extension.ts
+++ b/sources/@roots/bud-vue/src/extension.ts
@@ -114,7 +114,9 @@ export default class Vue extends Extension<
     })
 
     bud.alias(this.resolveAlias)
-    bud.typescript?.set(`appendTsSuffixTo`, [bud.hooks.filter(`pattern.vue`)])
+    bud.typescript?.set(`appendTsSuffixTo`, [
+      bud.hooks.filter(`pattern.vue`),
+    ])
   }
 
   /**

--- a/sources/@roots/bud-vue/src/extension.ts
+++ b/sources/@roots/bud-vue/src/extension.ts
@@ -114,13 +114,7 @@ export default class Vue extends Extension<
     })
 
     bud.alias(this.resolveAlias)
-  }
-
-  public override async buildBefore(bud: Bud) {
-    bud.build.items.ts?.setOptions({
-      ...(bud.build.items.ts.getOptions() ?? {}),
-      appendTsSuffixTo: [bud.hooks.filter(`pattern.vue`)],
-    })
+    bud.typescript?.set(`appendTsSuffixTo`, [bud.hooks.filter(`pattern.vue`)])
   }
 
   /**


### PR DESCRIPTION
A small change but a good one. Backwards compatible but it will let us remove a lot of extension methods in bud@7.0.

```ts
export default async bud => {
    bud.wpjson
      .set(`settings.color.customDuotone`, false)
      .set(`settings.color.customGradient`, false)
      .set(`settings.color.defaultDuotone`, false)
      .set(`settings.color.defaultGradients`, false)
      .set(`settings.color.defaultPalette`, false)
      .set(`settings.color.duotone`, [])
      .enable()

    bud.tailwind.set(`generateImports`, true)

    bud.typescript
      .set(`appendTsSuffixTo`, [/\.vue$/])
      .set(`babel`, false)
      .typecheck.enable()

    bud.terser
      .set(`extractComments`, false)
      .set(`terserOptions.mangle.safari10`, false)

    bud.vue.set(`runtimeOnly`, false)

    bud.imagemin.sharp
      .set(`encodeOptions.png.quality`, 60)
      .set(`encodeOptions.webp.quality`, 60)
}
```

Can also retrieve options with `get`:

```ts
bud.vue.get(`runtimeOnly`)
```

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
