### PR TITLE
🩹 fix: @examples/vue-typescript

### DIFF
--- a/sources/@roots/bud-build/src/config/module.ts
+++ b/sources/@roots/bud-build/src/config/module.ts
@@ -30,9 +30,9 @@ const getRules = ({filter, path, rules}: Props) => [
   {
     oneOf: filter(
       `build.module.rules.oneOf`,
-      Object.values(rules).filter(Boolean).map(rule =>
-        `toWebpack` in rule ? rule.toWebpack() : rule,
-      ),
+      Object.values(rules)
+        .filter(Boolean)
+        .map(rule => (`toWebpack` in rule ? rule.toWebpack() : rule)),
     ),
   },
   ...filter(`build.module.rules.after`, []),

--- a/sources/@roots/bud-build/src/config/module.ts
+++ b/sources/@roots/bud-build/src/config/module.ts
@@ -30,7 +30,7 @@ const getRules = ({filter, path, rules}: Props) => [
   {
     oneOf: filter(
       `build.module.rules.oneOf`,
-      Object.values(rules).map(rule =>
+      Object.values(rules).filter(Boolean).map(rule =>
         `toWebpack` in rule ? rule.toWebpack() : rule,
       ),
     ),

--- a/sources/@roots/bud-build/src/rule/index.ts
+++ b/sources/@roots/bud-build/src/rule/index.ts
@@ -291,8 +291,10 @@ class Rule extends Base implements Interface {
       parser: this.getParser(),
       generator: this.getGenerator(),
       use: this.getUse()
-        ?.map(item => (isString(item) ? this.app.build.items[item] : item))
-        .map(item => (`toWebpack` in item ? item.toWebpack() : item)),
+        ?.filter(Boolean)
+        .map(item => (isString(item) && item in this.app.build.items ? this.app.build.items[item] : item))
+        .filter(Boolean)
+        .map(item => (!isString(item) && `toWebpack` in item ? item.toWebpack() : item)),
       resourceQuery: this.getResourceQuery(),
       include: this.getInclude(),
       exclude: this.getExclude(),

--- a/sources/@roots/bud-build/src/rule/index.ts
+++ b/sources/@roots/bud-build/src/rule/index.ts
@@ -292,9 +292,15 @@ class Rule extends Base implements Interface {
       generator: this.getGenerator(),
       use: this.getUse()
         ?.filter(Boolean)
-        .map(item => (isString(item) && item in this.app.build.items ? this.app.build.items[item] : item))
+        .map(item =>
+          isString(item) && item in this.app.build.items
+            ? this.app.build.items[item]
+            : item,
+        )
         .filter(Boolean)
-        .map(item => (!isString(item) && `toWebpack` in item ? item.toWebpack() : item)),
+        .map(item =>
+          !isString(item) && `toWebpack` in item ? item.toWebpack() : item,
+        ),
       resourceQuery: this.getResourceQuery(),
       include: this.getInclude(),
       exclude: this.getExclude(),

--- a/sources/@roots/bud-sass/src/extension.ts
+++ b/sources/@roots/bud-sass/src/extension.ts
@@ -52,7 +52,7 @@ export class BudSass extends Extension {
       .setItem(`sass`, {
         ident: `sass`,
         loader: `sass-loader`,
-        options: () => this.options,
+        options: this.options,
       })
       .setRule(`sass`, {
         test: (app: Bud) => app.hooks.filter(`pattern.sass`),

--- a/sources/@roots/bud-sass/src/extension.ts
+++ b/sources/@roots/bud-sass/src/extension.ts
@@ -48,16 +48,22 @@ export class BudSass extends Extension {
   @bind
   public override async configAfter(bud: Bud) {
     bud.build
-      .setLoader(`sass-loader`)
+      .setLoader(`sass-loader`, await this.resolve(`sass-loader`))
       .setItem(`sass`, {
         ident: `sass`,
         loader: `sass-loader`,
-        options: this.options,
+        options: () => this.options,
       })
       .setRule(`sass`, {
         test: (app: Bud) => app.hooks.filter(`pattern.sass`),
         include: [app => app.path(`@src`)],
-        use: [`precss`, `css`, `postcss`, `resolveUrl`, `sass`],
+        use: [
+          bud.build.items.precss,
+          bud.build.items.css,
+          bud.build.items.postcss,
+          bud.build.items.resolveUrl,
+          bud.build.items.sass,
+        ].filter(Boolean),
       })
 
     bud.hooks.on(`build.resolve.extensions`, ext =>

--- a/sources/@roots/bud-sass/src/resolve-url/extension.ts
+++ b/sources/@roots/bud-sass/src/resolve-url/extension.ts
@@ -12,8 +12,7 @@ export class BudResolveUrl extends Extension {
   public override async register(bud: Bud) {
     const loader = await this.resolve(`resolve-url-loader`)
 
-    bud.build.setLoader(`resolveUrl`, loader)
-    bud.build.setItem(`resolveUrl`, {
+    bud.build.setLoader(`resolveUrl`, loader).setItem(`resolveUrl`, {
       loader: `resolveUrl`,
       options: ({path, hooks}) => ({
         root: path(`@src`),

--- a/sources/@roots/bud-sass/test/extension.test.ts
+++ b/sources/@roots/bud-sass/test/extension.test.ts
@@ -4,6 +4,7 @@ import {factory} from '@repo/test-kit/bud'
 import BudPostCSS from '@roots/bud-postcss'
 
 import BudSass from '../src/index.js'
+import { Item } from '@roots/bud-build/item'
 
 describe(`@roots/bud-sass/extension`, () => {
   let bud
@@ -61,7 +62,7 @@ describe(`@roots/bud-sass/extension`, () => {
       await sass.configAfter(bud)
     } catch (e) {}
 
-    expect(setLoaderSpy).toHaveBeenCalledWith(`sass-loader`)
+    expect(setLoaderSpy).toHaveBeenCalledWith(`sass-loader`, expect.stringContaining(`sass-loader`))
   })
 
   it(`should call setItem when configAfter is called`, async () => {
@@ -74,7 +75,7 @@ describe(`@roots/bud-sass/extension`, () => {
     expect(setItemSpy).toHaveBeenCalledWith(
       `sass`,
       expect.objectContaining({
-        loader: `sass-loader`,
+        loader: expect.stringContaining(`sass-loader`),
         options: {
           additionalData: `$primary-color: #ff0000;`,
           implementation: expect.any(Object),
@@ -96,7 +97,7 @@ describe(`@roots/bud-sass/extension`, () => {
       expect.objectContaining({
         include: expect.arrayContaining([expect.any(Function)]),
         test: expect.any(Function),
-        use: [`precss`, `css`, `postcss`, `resolveUrl`, `sass`],
+        use: expect.arrayContaining([expect.any(Item), expect.any(Item), expect.any(Item), expect.any(Item), expect.any(Item)]),
       }),
     )
   })

--- a/sources/@roots/bud/src/context/index.test.ts
+++ b/sources/@roots/bud/src/context/index.test.ts
@@ -28,7 +28,7 @@ describe(`context.get`, () => {
         basedir: expect.stringMatching(/\/bud$/),
         label: `bud`,
         manifestPath: expect.stringMatching(/\/package.json$/),
-        version: `0.0.0`,
+        version: expect.stringMatching(/^\d+\.\d+\.\d+$/),
       }),
     )
     expect(context.extensions.builtIn).toEqual(

--- a/tests/integration/__snapshots__/vue-typescript.test.ts.snap
+++ b/tests/integration/__snapshots__/vue-typescript.test.ts.snap
@@ -1,13 +1,6 @@
 // Vitest Snapshot v1
 
-exports[`vue (typescript) > npm > manifest.json > matches snapshot 1`] = `
-{
-  "main.css": "css/main.css",
-  "main.js": "js/main.js",
-}
-`;
-
-exports[`vue (typescript) > yarn > manifest.json > matches snapshot 1`] = `
+exports[`vue (typescript) > should compile js and css as expected 1`] = `
 {
   "main.css": "css/main.css",
   "main.js": "js/main.js",

--- a/tests/integration/vue-typescript.test.ts
+++ b/tests/integration/vue-typescript.test.ts
@@ -1,34 +1,17 @@
 import {Project} from '@repo/test-kit/project'
-import {beforeAll, describe, expect, it} from 'vitest'
-
-const run = pacman => () => {
-  let project: Project
-
-  beforeAll(async () => {
-    project = await new Project({
-      label: `@examples/vue-typescript`,
-      with: pacman,
-    }).setup()
-  })
-
-  describe(`main.js`, () => {
-    it(`has contents`, () => {
-      expect(project.assets[`main.js`].length).toBeGreaterThan(10)
-    })
-
-    it(`is transpiled`, () => {
-      expect(project.assets[`main.js`].includes(`from '`)).toBeFalsy()
-    })
-  })
-
-  describe(`manifest.json`, () => {
-    it(`matches snapshot`, () => {
-      expect(project.manifest).toMatchSnapshot()
-    })
-  })
-}
+import {describe, expect, it} from 'vitest'
 
 describe(`vue (typescript)`, () => {
-  describe(`npm`, run(`npm`))
-  describe(`yarn`, run(`yarn`))
-}, 240000)
+  it(`should compile js and css as expected`, async () => {
+    const project = await new Project({
+      label: `@examples/vue-typescript`,
+      with: `npm`,
+    }).setup()
+
+    expect(project.manifest).toMatchSnapshot()
+    expect(project.assets[`main.js`].length).toBeGreaterThan(10)
+    expect(project.assets[`main.js`].includes(`from '`)).toBeFalsy()
+    expect(project.assets[`main.css`].length).toBeGreaterThan(10)
+    expect(project.assets[`main.css`].includes(`$vue-green`)).toBeFalsy()
+  })
+})


### PR DESCRIPTION
- moves `css`, `scss`, `ts` rules out of `oneOf` and into the main `module.rules` array
- simplifies integration test. i don't know why but this might have been silently failing (even though it says 3/3 tests executed)

refers:

- #2080
- #2081

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
