### PR TITLE
🔧 fix: normalize paths

### DIFF
--- a/sources/@roots/bud-api/src/methods/assets/index.ts
+++ b/sources/@roots/bud-api/src/methods/assets/index.ts
@@ -1,4 +1,4 @@
-import {relative} from 'node:path'
+import {isAbsolute, relative, sep} from 'node:path'
 
 import type {Bud} from '@roots/bud-framework'
 import type {Plugin as CopyPlugin} from '@roots/bud-support/copy-webpack-plugin'
@@ -79,8 +79,8 @@ export const assets: assets = async function assets(
 export const fromStringFactory =
   (app: Bud, overrides: Partial<CopyPlugin.ObjectPattern>) =>
   (from: string): CopyPlugin.ObjectPattern => ({
-    from: from.startsWith(`/`) ? from : app.path(`@src`, from),
-    to: from.startsWith(`/`)
+    from: isAbsolute(from) ? from : app.path(`@src`, from),
+    to: isAbsolute(from)
       ? relative(app.path(`@src`), from)
       : app.path(`@dist`, from, `@file`),
     context: app.path(`@src`),
@@ -98,8 +98,8 @@ export const fromStringFactory =
 export const fromTupleFactory =
   (app: Bud, overrides: Partial<CopyPlugin.ObjectPattern>) =>
   ([from, to]: [string, string]): CopyPlugin.ObjectPattern => ({
-    from: from.startsWith(`/`) ? from : app.path(`@src`, from),
-    to: to.startsWith(`/`) ? to : app.path(`@dist`, to, `@file`),
+    from: isAbsolute(from) ? from : app.path(`@src`, from),
+    to: isAbsolute(to) ? to : app.path(`@dist`, to, `@file`),
     filter: filterDotFiles,
     context: app.path(`@src`),
     noErrorOnMissing: true,
@@ -108,4 +108,4 @@ export const fromTupleFactory =
   })
 
 const filterDotFiles = (resourcePath: string) =>
-  !resourcePath.split(`/`).pop()?.startsWith(`.`)
+  !resourcePath.split(sep).pop()?.startsWith(`.`)

--- a/sources/@roots/bud-api/src/methods/bundle/index.ts
+++ b/sources/@roots/bud-api/src/methods/bundle/index.ts
@@ -1,4 +1,4 @@
-import {join} from 'node:path'
+import {join, sep} from 'node:path'
 
 import type {Bud} from '@roots/bud-framework'
 import isRegExp from '@roots/bud-support/lodash/isRegExp'
@@ -50,7 +50,7 @@ export const bundle: bundle = function (this: Bud, name, matcher) {
     if (splitChunks === false || splitChunks === undefined) {
       return {
         chunks: `all`,
-        automaticNameDelimiter: `/`,
+        automaticNameDelimiter: sep,
         minSize: 0,
         cacheGroups: {...entry},
       }

--- a/sources/@roots/bud-api/src/methods/runtime/index.ts
+++ b/sources/@roots/bud-api/src/methods/runtime/index.ts
@@ -1,3 +1,5 @@
+import {join} from 'node:path'
+
 import type {Bud} from '@roots/bud-framework'
 import type {EntryObject, Optimization} from '@roots/bud-support/webpack'
 
@@ -17,7 +19,7 @@ export interface runtime {
  * Default options for runtime if no options are passed as parameters.
  */
 const DEFAULT_RUNTIME: Optimization.RuntimeChunk = {
-  name: (entrypoint: EntryObject) => `runtime/${entrypoint.name}`,
+  name: (entrypoint: EntryObject) => join(`runtime`, `${entrypoint.name}`),
 }
 
 export const runtime: runtime = async function (

--- a/sources/@roots/bud-api/src/methods/splitChunks/index.ts
+++ b/sources/@roots/bud-api/src/methods/splitChunks/index.ts
@@ -1,3 +1,5 @@
+import {join, sep} from 'node:path'
+
 import type {Bud} from '@roots/bud-framework'
 import isUndefined from '@roots/bud-support/lodash/isUndefined'
 import type {Optimization} from '@roots/bud-support/webpack'
@@ -61,12 +63,12 @@ export const splitChunks: splitChunks = async function (
   if (options === true || isUndefined(options)) {
     this.hooks.on(`build.optimization.splitChunks`, {
       chunks: `all`,
-      automaticNameDelimiter: `/`,
+      automaticNameDelimiter: sep,
       minSize: 0,
       cacheGroups: {
         vendor: {
           idHint: `vendor`,
-          filename: `js/bundle/vendor/[name].js`,
+          filename: join(`js`, `bundle`, `vendor`, `[name].js`),
           test: /[\\/]node_modules[\\/]/,
           priority: -20,
         },

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
@@ -52,7 +52,8 @@ export const setPath: setPath = function (this: Bud, ...parameters) {
       }
 
       const path = this.path(value)
-      if (isAbsolute(path))
+
+      if (!isAbsolute(path))
         throw new Error(
           `the final result of a bud.setPath transform was not absolute: ${key} => ${value} => ${path}`,
         )

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
@@ -1,4 +1,4 @@
-import {normalize} from 'node:path'
+import {isAbsolute, normalize} from 'node:path'
 
 import isString from '@roots/bud-support/lodash/isString'
 import isUndefined from '@roots/bud-support/lodash/isUndefined'
@@ -51,10 +51,10 @@ export const setPath: setPath = function (this: Bud, ...parameters) {
         )
       }
 
-      const absolutePath = this.path(value)
-      if (!absolutePath.startsWith(`/`))
+      const path = this.path(value)
+      if (isAbsolute(path))
         throw new Error(
-          `the final result of a bud.setPath transform was not absolute: ${key} => ${value} => ${absolutePath}`,
+          `the final result of a bud.setPath transform was not absolute: ${key} => ${value} => ${path}`,
         )
 
       this.hooks.on(`location.${key}`, this.path(value))

--- a/sources/@roots/bud-framework/src/methods/setPublicPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPublicPath.ts
@@ -1,3 +1,5 @@
+import {sep} from 'node:path'
+
 import type {Bud} from '../bud.js'
 
 /**
@@ -39,7 +41,7 @@ export const setPublicPath: setPublicPath = function (publicPath) {
   // Normalize the publicPath in case the user did not end it with a slash.
   app.hooks.on(`build.output.publicPath`, value => {
     if (value === `` || value === `auto`) return value
-    return !value.endsWith(`/`) ? `${value}/` : value
+    return !value.endsWith(sep) ? `${value}${sep}` : value
   })
 
   return app

--- a/sources/@roots/bud-vue/src/extension.ts
+++ b/sources/@roots/bud-vue/src/extension.ts
@@ -1,3 +1,5 @@
+import {join} from 'node:path'
+
 import type {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import {
@@ -205,8 +207,8 @@ export default class Vue extends Extension<
     const type = this.isVue2() ? `esm` : `esm-bundler`
 
     const vue = this.options.runtimeOnly
-      ? `vue/dist/vue.runtime.${type}.js`
-      : `vue/dist/vue.${type}.js`
+      ? join(`vue`, `dist`, `vue.runtime.${type}.js`)
+      : join(`vue`, `dist`, `vue.${type}.js`)
 
     return {...aliases, vue}
   }

--- a/sources/@roots/critical-css-webpack-plugin/src/plugin.ts
+++ b/sources/@roots/critical-css-webpack-plugin/src/plugin.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import {join} from 'node:path'
+
 import * as critical from 'critical'
 import {bind} from 'helpful-decorators'
 import vinyl from 'vinyl'
@@ -141,7 +143,7 @@ export default class CriticalCssWebpackPlugin {
               }
 
               this.webpack.compilation.emitAsset(
-                `critical/${asset.name.split(`.`).shift().concat(`.css`)}`,
+                join(`critical`, asset.name.split(`.`).shift().concat(`.css`)),
                 new Webpack.sources.RawSource(css),
                 asset.info,
               )

--- a/sources/@roots/critical-css-webpack-plugin/src/plugin.ts
+++ b/sources/@roots/critical-css-webpack-plugin/src/plugin.ts
@@ -143,7 +143,10 @@ export default class CriticalCssWebpackPlugin {
               }
 
               this.webpack.compilation.emitAsset(
-                join(`critical`, asset.name.split(`.`).shift().concat(`.css`)),
+                join(
+                  `critical`,
+                  asset.name.split(`.`).shift().concat(`.css`),
+                ),
                 new Webpack.sources.RawSource(css),
                 asset.info,
               )


### PR DESCRIPTION
Still no Windows support but it would be good to do what we can to stay _in the neighborhood_ of it working without a container.

Interop fixes:

- Check for absolute paths with `isAbsolute` from `node:path`
- When we need to reference directory separator use `sep` from `node:path`
- Join paths with `join` from `node:path`

refers:

- #2085

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
