### PR TITLE
🩹 fix(@roots/bud-swc): tree shaking

### DIFF
--- a/sources/@roots/bud-swc/src/extension/index.test.ts
+++ b/sources/@roots/bud-swc/src/extension/index.test.ts
@@ -21,13 +21,6 @@ describe(`@roots/bud-swc`, () => {
     expect(onSpy).toHaveBeenCalled()
   })
 
-  it(`should call registerSWC during buildBefore`, async () => {
-    const extension = new BudSWCExtension(bud)
-    const registerSWCSpy = vi.spyOn(extension, `registerSWC`)
-    await extension.buildBefore(bud)
-    expect(registerSWCSpy).toHaveBeenCalled()
-  })
-
   it(`should add a plugin`, async () => {
     const extension = new BudSWCExtension(bud)
     extension.plugins(plugins => {

--- a/tests/integration/__snapshots__/remote-sources.test.ts.snap
+++ b/tests/integration/__snapshots__/remote-sources.test.ts.snap
@@ -1,5 +1,3 @@
 // Vitest Snapshot v1
 
-exports[`remote-sources > npm > app.js > should be present in the manifest 1`] = `"js/app.js"`;
-
-exports[`remote-sources > yarn > app.js > should be present in the manifest 1`] = `"js/app.js"`;
+exports[`app.js > app.js should be present in the manifest 1`] = `"js/app.js"`;

--- a/tests/integration/remote-sources.test.ts
+++ b/tests/integration/remote-sources.test.ts
@@ -1,38 +1,27 @@
 import {Project} from '@repo/test-kit/project'
-import {beforeAll, describe, expect, it} from 'vitest'
+import {describe, expect, it} from 'vitest'
 
-const run = pacman => () => {
-  let project: Project
+let project: Project
 
-  beforeAll(async () => {
-    project = await new Project({
-      label: `@examples/remote-sources`,
-      with: pacman,
-    }).setup()
+describe(`app.js`, async () => {
+  project = await new Project({
+    label: `@examples/remote-sources`,
+    with: `npm`,
+  }).setup()
+
+  it(`app.js should not be empty`, () => {
+    expect(project.assets[`app.js`].length).toBeGreaterThan(10)
   })
 
-  describe(`app.js`, () => {
-    it(`should not be empty`, () => {
-      expect(project.assets[`app.js`].length).toBeGreaterThan(10)
-    })
-
-    it(`should not contain import statements`, () => {
-      expect(project.assets[`app.js`].includes(`import `)).toBeFalsy()
-    })
-
-    it(`should be present in the manifest`, () => {
-      expect(project.manifest[`app.js`]).toMatchSnapshot()
-    })
+  it(`app.js should not contain import statements`, () => {
+    expect(project.assets[`app.js`].includes(`import `)).toBeFalsy()
   })
 
-  describe(`manifest.json`, () => {
-    it(`should have expected number of items`, () => {
-      expect(Object.keys(project.manifest)).toHaveLength(3)
-    })
+  it(`app.js should be present in the manifest`, () => {
+    expect(project.manifest[`app.js`]).toMatchSnapshot()
   })
-}
 
-describe(`remote-sources`, () => {
-  describe(`npm`, run(`npm`))
-  describe(`yarn`, run(`yarn`))
+  it(`manifest.json should have expected number of items`, () => {
+    expect(Object.keys(project.manifest)).toHaveLength(4)
+  })
 }, 240000)

--- a/tests/reproductions/issue-2088.test.ts
+++ b/tests/reproductions/issue-2088.test.ts
@@ -1,0 +1,30 @@
+import {join} from 'node:path'
+import {paths} from '@repo/constants'
+import execa from '@roots/bud-support/execa'
+import {beforeAll, describe, expect, it} from 'vitest'
+import {readFile} from '@roots/bud-support/fs'
+
+describe('issue-2088', () => {
+  it('should generate app.js', async () => {
+    await execa(`yarn`, [`bud`, `clean`, `@dist`], {
+      cwd: join(paths.tests, `reproductions`, `issue-2088`),
+    })
+
+    await execa(`yarn`, [`bud`, `build`, `--force`], {
+      cwd: join(paths.tests, `reproductions`, `issue-2088`),
+    })
+
+    const file = await readFile(
+      join(
+        paths.tests,
+        `reproductions`,
+        `issue-2088`,
+        `dist`,
+        `js`,
+        `main.js`,
+      ),
+      `utf-8`,
+    )
+    expect(file.length).toBeLessThan(65000)
+  }, 300000)
+})

--- a/tests/reproductions/issue-2088/bud.config.mjs
+++ b/tests/reproductions/issue-2088/bud.config.mjs
@@ -1,0 +1,8 @@
+// @ts-check
+
+/**
+ * @param {import('@roots/bud').Bud} bud
+ */
+export default async bud => {
+  bud.use([`@roots/bud-swc`])
+}

--- a/tests/reproductions/issue-2088/package.json
+++ b/tests/reproductions/issue-2088/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tests/issue-2088",
+  "type": "module",
+  "private": true,
+  "bud": {
+    "extensions": {
+      "discovery": false
+    }
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/free-solid-svg-icons": "^6.1.1",
+    "@roots/bud": "workspace:sources/@roots/bud",
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc"
+  }
+}

--- a/tests/reproductions/issue-2088/src/index.ts
+++ b/tests/reproductions/issue-2088/src/index.ts
@@ -1,0 +1,10 @@
+// Font Awesome
+import {library, dom} from '@fortawesome/fontawesome-svg-core'
+
+import {faAngleDown} from '@fortawesome/free-solid-svg-icons'
+
+// Add the imported icons to the library
+library.add(faAngleDown)
+
+// Tell FontAwesome to watch the DOM and add the SVGs when it detects icon markup
+dom.watch()

--- a/tests/reproductions/issue-2088/tsconfig.json
+++ b/tests/reproductions/issue-2088/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@roots/bud/config/tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "@roots/bud", "@roots/bud-swc"]
+  },
+  "include": ["./src"],
+  "exclude": ["./node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4840,6 +4840,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fortawesome/fontawesome-common-types@npm:6.2.1":
+  version: 6.2.1
+  resolution: "@fortawesome/fontawesome-common-types@npm:6.2.1"
+  checksum: 1a6e202beac46bc7e7bf791b37b6164b15453cc70b078456121c77d516a1077a1cfdab8aa9c77358c71f87f54560c0d9cbfb440cfb871f6d0f1f4671aabf9a0a
+  languageName: node
+  linkType: hard
+
+"@fortawesome/fontawesome-svg-core@npm:^6.1.1":
+  version: 6.2.1
+  resolution: "@fortawesome/fontawesome-svg-core@npm:6.2.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.2.1
+  checksum: 16caf6052b77c03826274325d4bd76d11cba486411c3101a635d3342dd764df8f5b4789456c9caa1667c232853a670f91dddf0449218e5fea7a27f4396b838af
+  languageName: node
+  linkType: hard
+
+"@fortawesome/free-solid-svg-icons@npm:^6.1.1":
+  version: 6.2.1
+  resolution: "@fortawesome/free-solid-svg-icons@npm:6.2.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.2.1
+  checksum: a24170b676fced926cccdd08171357b20714483ceddeb052985a9acae3a347ffe853de2e757bf95cc7add74807d82eb1cc578e17430c32ca2c6a844c8276f91a
+  languageName: node
+  linkType: hard
+
 "@fullhuman/postcss-purgecss@npm:5.0.0":
   version: 5.0.0
   resolution: "@fullhuman/postcss-purgecss@npm:5.0.0"
@@ -8732,6 +8757,17 @@ __metadata:
   dependencies:
     "@roots/bud": "workspace:sources/@roots/bud"
     "@roots/bud-postcss": "workspace:sources/@roots/bud-postcss"
+  languageName: unknown
+  linkType: soft
+
+"@tests/issue-2088@workspace:tests/reproductions/issue-2088":
+  version: 0.0.0-use.local
+  resolution: "@tests/issue-2088@workspace:tests/reproductions/issue-2088"
+  dependencies:
+    "@fortawesome/fontawesome-svg-core": ^6.1.1
+    "@fortawesome/free-solid-svg-icons": ^6.1.1
+    "@roots/bud": "workspace:sources/@roots/bud"
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- Fix tree-shaking
- Add unit test covering tree-shaking (as described in #2088)
- Setup swc earlier in lifecycle (`register` callback), so options can be easily manipulated in config. The fix in this sandbox https://codesandbox.io/p/sandbox/upbeat-heyrovsky-0vxh19?file=%2Fbud.config.js has to be wrapped in a hook for little reason. Manipulating options should be as easy as `bud.swc.set('module', undefined)`.

refers:

- #2088

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
