### PR TITLE
✨ improve(@roots/bud-eslint): deprecate bud.eslint.fix

### DIFF
--- a/examples/eslint/bud.config.cjs
+++ b/examples/eslint/bud.config.cjs
@@ -1,1 +1,6 @@
-module.exports = async bud => bud.template().entry('app', 'app.js')
+module.exports = async bud => {
+  bud
+    .html()
+    .entry('app', 'app.js')
+    .eslint.set(`fix`, true)
+}

--- a/examples/eslint/src/app.js
+++ b/examples/eslint/src/app.js
@@ -1,6 +1,6 @@
 const target = document.querySelector('body')
 target.innerHTML = `
   <div>
-    <h1>Hello from esbuild!</h1>
+    <h1>Hello</h1>
   </div>
 `

--- a/sources/@roots/bud-eslint/package.json
+++ b/sources/@roots/bud-eslint/package.json
@@ -29,7 +29,6 @@
   },
   "keywords": [
     "bud",
-    "bud-extension",
     "eslint"
   ],
   "engines": {
@@ -41,11 +40,15 @@
     "src"
   ],
   "type": "module",
-  "module": "./lib/index.js",
-  "types": "./lib/index.d.ts",
   "exports": {
-    ".": "./lib/index.js",
-    "./extension": "./lib/extension.js"
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./extension": {
+      "types": "./lib/extension.d.ts",
+      "default": "./lib/extension.js"
+    }
   },
   "typesVersions": {
     "*": {
@@ -57,6 +60,8 @@
       ]
     }
   },
+  "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "devDependencies": {
     "@roots/bud": "workspace:sources/@roots/bud",
     "@skypack/package-check": "0.2.2",
@@ -72,13 +77,17 @@
   },
   "peerDependencies": {
     "@roots/bud": "*",
-    "eslint": "*"
+    "eslint": "*",
+    "eslint-webpack-plugin": "*"
   },
   "peerDependenciesMeta": {
     "@roots/bud": {
       "optional": true
     },
     "eslint": {
+      "optional": true
+    },
+    "eslint-webpack-plugin": {
       "optional": true
     }
   },

--- a/sources/@roots/bud-eslint/src/bud/commands/bud.eslint.command.tsx
+++ b/sources/@roots/bud-eslint/src/bud/commands/bud.eslint.command.tsx
@@ -27,7 +27,7 @@ export class BudEslintCommand extends BudCommand {
     )
 
     if (!this.options?.length)
-      this.options = [this.bud.path(`@src`, `**/*.{ts,tsx,js,jsx}`)]
+      this.options = [this.bud.path(`@src`, `**`, `*.{ts,tsx,js,jsx}`)]
 
     await this.$(this.bin, [eslint, ...this.options])
   }

--- a/sources/@roots/bud-eslint/src/extension.ts
+++ b/sources/@roots/bud-eslint/src/extension.ts
@@ -11,12 +11,6 @@ import EslintPlugin from 'eslint-webpack-plugin'
 
 /**
  * Eslint webpack plugin adapter
- *
- * @public
- * @decorator `@label`
- * @decorator `@expose`
- * @decorator `@plugin`
- * @decorator `@options`
  */
 @label(`@roots/bud-eslint`)
 @expose(`eslint`)
@@ -29,17 +23,13 @@ import EslintPlugin from 'eslint-webpack-plugin'
   resolvePluginsRelativeTo: app => app.context.basedir,
   threads: false,
 })
-export default class BudEslint extends Extension<Options, EslintPlugin> {
+export class BudEslint extends Extension<Options, EslintPlugin> {
   /**
    * `register` callback
-   *
-   * @public
-   * @decorator `@bind`
    */
   @bind
   public override async register(bud: Bud) {
-    const eslintPath = await this.resolve(`eslint`)
-    this.setOption(`eslintPath`, eslintPath)
+    this.set(`eslintPath`, await this.resolve(`eslint`))
 
     const findFlatConfig = ({name}) => name.includes(`eslint.config`)
 
@@ -47,18 +37,17 @@ export default class BudEslint extends Extension<Options, EslintPlugin> {
     if (!userConfigs.some(findFlatConfig)) return
 
     const flatConfig = userConfigs.find(findFlatConfig)
-    this.setOption(`baseConfig`, flatConfig.module)
+    this.set(`baseConfig`, flatConfig.module)
   }
 
   /**
    * auto-fix rule violations
    *
-   * @public
-   * @decorator `@bind`
+   * @deprecated - Use `bud.eslint.set('fix', true)` instead.
    */
   @bind
   public fix(fix: boolean = true): this {
-    this.setOption(`fix`, fix)
+    this.set(`fix`, fix)
     return this
   }
 }

--- a/sources/@roots/bud-eslint/src/index.ts
+++ b/sources/@roots/bud-eslint/src/index.ts
@@ -12,5 +12,5 @@
 
 import './types.js'
 
-import BudEslint from './extension.js'
+import {BudEslint} from './extension.js'
 export default BudEslint

--- a/sources/@roots/bud-eslint/src/types.ts
+++ b/sources/@roots/bud-eslint/src/types.ts
@@ -6,6 +6,7 @@ declare module '@roots/bud-framework' {
   interface Bud {
     eslint: {
       enable: BudEslint[`enable`]
+      get: BudEslint[`get`]
       set: BudEslint[`set`]
     }
   }

--- a/sources/@roots/bud-eslint/src/types.ts
+++ b/sources/@roots/bud-eslint/src/types.ts
@@ -1,10 +1,13 @@
 /// <reference types="@roots/bud" />
 
-import type BudEslint from './extension.js'
+import type {BudEslint} from './extension.js'
 
 declare module '@roots/bud-framework' {
   interface Bud {
-    eslint: BudEslint
+    eslint: {
+      enable: BudEslint[`enable`]
+      set: BudEslint[`set`]
+    }
   }
 
   interface Modules {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7266,10 +7266,13 @@ __metadata:
   peerDependencies:
     "@roots/bud": "*"
     eslint: "*"
+    eslint-webpack-plugin: "*"
   peerDependenciesMeta:
     "@roots/bud":
       optional: true
     eslint:
+      optional: true
+    eslint-webpack-plugin:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
- deprecate `bud.eslint.fix`
- improve packaging
- update `examples/eslint`
- improve typings/intellisense: only expose to the public interface:
  - `bud.eslint.set`
  - `bud.eslint.get`
  - `bud.eslint.enable`

refers:

- #2079 

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
