### PR TITLE
🩹 fix(@roots/bud-emotion): dependency hoisting

### DIFF
--- a/examples/emotion/package.json
+++ b/examples/emotion/package.json
@@ -5,7 +5,6 @@
     "extends @roots/browserslist-config"
   ],
   "devDependencies": {
-    "@roots/browserslist-config": "latest",
     "@roots/bud": "latest",
     "@roots/bud-emotion": "latest",
     "@roots/bud-react": "latest"

--- a/sources/@roots/bud-build/src/config/optimization.ts
+++ b/sources/@roots/bud-build/src/config/optimization.ts
@@ -12,8 +12,9 @@ export const optimization: Factory<`optimization`> = async ({
     moduleIds: filter(`build.optimization.moduleIds`, `named`),
     removeEmptyChunks: filter(
       `build.optimization.removeEmptyChunks`,
-      true,
+      false,
     ),
     runtimeChunk: filter(`build.optimization.runtimeChunk`, false),
     splitChunks: filter(`build.optimization.splitChunks`, false),
+    usedExports: filter(`build.optimization.usedExports`, isProduction),
   })

--- a/sources/@roots/bud-emotion/package.json
+++ b/sources/@roots/bud-emotion/package.json
@@ -74,9 +74,7 @@
     "@roots/bud-swc": "workspace:sources/@roots/bud-swc",
     "@skypack/package-check": "0.2.2",
     "@types/babel__core": "7.20.0",
-    "@types/node": "18.11.18",
-    "@types/react": "18.0.26",
-    "react": "18.2.0"
+    "@types/node": "18.11.18"
   },
   "dependencies": {
     "@emotion/babel-plugin": "^11.10.5",
@@ -93,10 +91,7 @@
     "@emotion/css": "*",
     "@emotion/react": "*",
     "@emotion/styled": "*",
-    "@roots/bud": "*",
-    "@roots/bud-babel": "*",
-    "@roots/bud-swc": "*",
-    "@swc/plugin-emotion": "*"
+    "@roots/bud": "*"
   },
   "peerDependenciesMeta": {
     "@babel/core": {

--- a/sources/@roots/bud-emotion/test/dependencies.test.ts
+++ b/sources/@roots/bud-emotion/test/dependencies.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'vitest'
+import {resolve} from '@roots/bud-support/import-meta-resolve'
+
+describe(`@roots/bud-emotion dependencies`, () => {
+  it(`should resolve dependencies from hoisted modules`, async () => {
+    expect(
+      await resolve(`@emotion/babel-plugin`, import.meta.url),
+    ).toMatch(/\/bud\/node_modules\/@emotion\/babel-plugin/)
+    expect(
+      await resolve(`@swc/plugin-emotion`, import.meta.url),
+    ).toMatch(/\/bud\/node_modules\/@swc\/plugin-emotion/)
+    expect(
+      await resolve(`@emotion/styled`, import.meta.url),
+    ).toMatch(/\/bud\/node_modules\/@emotion\/styled/)
+    expect(
+      await resolve(`@emotion/react`, import.meta.url),
+    ).toMatch(/\/bud\/node_modules\/@emotion\/react/)
+    expect(
+      await resolve(`@emotion/css`, import.meta.url),
+    ).toMatch(/\/bud\/node_modules\/@emotion\/css/)
+  })
+})

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -509,6 +509,7 @@ export class Extension<
    */
   @bind
   public isEnabled(): boolean {
+    if (!isUndefined(this.enabled)) return this.enabled
     return this.when(this.app, this.options)
   }
 }

--- a/sources/@roots/bud-framework/src/types/registry/build.ts
+++ b/sources/@roots/bud-framework/src/types/registry/build.ts
@@ -50,6 +50,7 @@ export interface Sync {
     | Configuration['optimization']['removeEmptyChunks']
   'optimization.runtimeChunk': Configuration['optimization']['runtimeChunk']
   'optimization.splitChunks': Optimization.SplitChunks | false
+  'optimization.usedExports': Configuration['optimization']['usedExports']
   output: Configuration['output']
   'output.assetModuleFilename': Configuration['output']['assetModuleFilename']
   'output.chunkFilename': Configuration['output']['chunkFilename']

--- a/sources/@roots/bud-support/src/terser-webpack-plugin/index.ts
+++ b/sources/@roots/bud-support/src/terser-webpack-plugin/index.ts
@@ -1,3 +1,2 @@
-import Plugin from 'terser-webpack-plugin'
-
-export {Plugin}
+import Terser = require('terser-webpack-plugin')
+export default Terser

--- a/sources/@roots/bud-swc/README.md
+++ b/sources/@roots/bud-swc/README.md
@@ -32,31 +32,40 @@ npm install @roots/bud-swc --save-dev
 
 ## Configuration
 
-You have two options for configuring SWC:
-
-### bud.swc
-
-You may use `bud.swc` api in your bud configuration file:
-
-```ts
-bud.swc.setOptions({
-  jsc: {
-    // ...,
-  },
-});
-```
-
 ### .swcrc
 
-You may also use a standard `.swcrc` config file in the root of your project.
+Including a `.swcrc` config file in the root of your project will replace all default options.
+
+Be aware that extensions may still modify the options even if you use `.swcrc`. For example, [@roots/bud-react](https://bud.js.org/extensions/bud-react) will modify the `jsc.transform` option to support react refresh if `bud.react.refresh` is enabled.
+
+### API
+
+You can modify swc options directly using `bud.swc`. These options are passed in more or less directly to swc-loader.
+
+```ts
+bud.swc.set(`jsc.parser.dynamicImport`, false);
+```
+
+```ts
+bud.swc.setOptions((options) => ({
+  ...options,
+  jsc: {
+    ...(options?.jsc ?? {}),
+    parser: {
+      ...(options?.jsc?.parser ?? {}),
+      dynamicImports: false,
+    },
+  },
+}));
+```
 
 ## Typechecking
 
-`@roots/bud-swc` does not currently support typechecking during compilation.
+`@roots/bud-swc` does not currently support typechecking during compilation as swc does not natively support it yet.
 
-Our recommendation is to run typechecking as a separate process. You can use the `bud typecheck` command or even use `tsc` directly: `tsc --noEmit`.
+Our recommendation is to run typechecking as a separate process. You can use `tsc` directly: `tsc --noEmit`.
 
-You could also add the `fork-ts-webpack-plugin` in your bud configuration. This approach conflicts with bud.config files authored in typescript.
+You could also add the `fork-ts-webpack-plugin`.
 
 Subscribe to [swc-project/swc#571](https://github.com/swc-project/swc/issues/571) for more information on where swc-project is at with its typecheck implementation.
 

--- a/sources/@roots/bud-swc/docs/01-configuration.md
+++ b/sources/@roots/bud-swc/docs/01-configuration.md
@@ -2,20 +2,29 @@
 title: Configuration
 ---
 
-You have two options for configuring SWC:
-
-### bud.swc
-
-You may use `bud.swc` api in your bud configuration file:
-
-```ts
-bud.swc.setOptions({
-  jsc: {
-    // ...,
-  },
-})
-```
-
 ### .swcrc
 
-You may also use a standard `.swcrc` config file in the root of your project.
+Including a `.swcrc` config file in the root of your project will replace all default options.
+
+Be aware that extensions may still modify the options even if you use `.swcrc`. For example, [@roots/bud-react](https://bud.js.org/extensions/bud-react) will modify the `jsc.transform` option to support react refresh if `bud.react.refresh` is enabled.
+
+### API
+
+You can modify swc options directly using `bud.swc`. These options are passed in more or less directly to swc-loader.
+
+```ts
+bud.swc.set(`jsc.parser.dynamicImport`, false)
+```
+
+```ts
+bud.swc.setOptions(options => ({
+  ...options,
+  jsc: {
+    ...(options?.jsc ?? {}),
+    parser: {
+      ...(options?.jsc?.parser ?? {}),
+      dynamicImports: false,
+    }
+  }
+}))
+```

--- a/sources/@roots/bud-swc/docs/02-typechecking.md
+++ b/sources/@roots/bud-swc/docs/02-typechecking.md
@@ -2,10 +2,10 @@
 title: Typechecking
 ---
 
-`@roots/bud-swc` does not currently support typechecking during compilation.
+`@roots/bud-swc` does not currently support typechecking during compilation as swc does not natively support it yet.
 
-Our recommendation is to run typechecking as a separate process. You can use the `bud typecheck` command or even use `tsc` directly: `tsc --noEmit`.
+Our recommendation is to run typechecking as a separate process. You can use `tsc` directly: `tsc --noEmit`.
 
-You could also add the `fork-ts-webpack-plugin` in your bud configuration. This approach conflicts with bud.config files authored in typescript.
+You could also add the `fork-ts-webpack-plugin`.
 
 Subscribe to [swc-project/swc#571](https://github.com/swc-project/swc/issues/571) for more information on where swc-project is at with its typecheck implementation.

--- a/sources/@roots/bud-swc/src/extension/index.ts
+++ b/sources/@roots/bud-swc/src/extension/index.ts
@@ -55,12 +55,11 @@ export default class BudSWC extends Extension<Options> {
    */
   @bind
   public override async boot({build}: Bud) {
-    build
-      .setRule(`ts`, {
-        test: ({hooks}) => hooks.filter(`pattern.ts`),
-        include: [({path}) => path(`@src`)],
-        use: [`swc`],
-      })
+    build.setRule(`ts`, {
+      test: ({hooks}) => hooks.filter(`pattern.ts`),
+      include: [({path}) => path(`@src`)],
+      use: [`swc`],
+    })
 
     build.getRule(`js`).setUse(() => [`swc`])
   }

--- a/sources/@roots/bud-swc/src/extension/index.ts
+++ b/sources/@roots/bud-swc/src/extension/index.ts
@@ -72,7 +72,8 @@ export default class BudSWC extends Extension<Options> {
   public override async configAfter(bud: Bud) {
     this.set(
       `jsc.experimental.cacheRoot` as any,
-      (cacheRoot: string) => cacheRoot ?? bud.path(bud.cache.cacheDirectory, `swc`),
+      (cacheRoot: string) =>
+        cacheRoot ?? bud.path(bud.cache.cacheDirectory, `swc`),
     )
     bud.build.getItem(`swc`).setOptions(this.options)
   }

--- a/sources/@roots/bud-swc/src/extension/index.ts
+++ b/sources/@roots/bud-swc/src/extension/index.ts
@@ -43,6 +43,7 @@ export default class BudSWC extends Extension<Options> {
       .setLoader(`swc`, await this.resolve(`swc-loader`))
       .setItem(`swc`, {
         loader: bud.build.getLoader(`swc`),
+        options: () => this.options,
       })
 
     bud.hooks.on(`build.resolve.extensions`, (extensions = new Set()) =>
@@ -71,7 +72,7 @@ export default class BudSWC extends Extension<Options> {
   public override async configAfter(bud: Bud) {
     this.set(
       `jsc.experimental.cacheRoot` as any,
-      cacheRoot => cacheRoot ?? bud.path(bud.cache.cacheDirectory, `swc`),
+      (cacheRoot: string) => cacheRoot ?? bud.path(bud.cache.cacheDirectory, `swc`),
     )
     bud.build.getItem(`swc`).setOptions(this.options)
   }

--- a/sources/@roots/bud-terser/src/css-minimizer/extension.ts
+++ b/sources/@roots/bud-terser/src/css-minimizer/extension.ts
@@ -42,6 +42,7 @@ export class BudMinimizeCss extends Extension<BasePluginOptions, Plugin> {
 
     hooks.on(`build.optimization.minimizer`, (minimizer = []) => {
       minimizer.push(new Plugin(this.options))
+      this.logger.success(`css-minimizer added to minimizers`)
       return minimizer
     })
   }

--- a/sources/@roots/bud-terser/src/extension.test.ts
+++ b/sources/@roots/bud-terser/src/extension.test.ts
@@ -21,12 +21,13 @@ describe(`@roots/bud-terser`, () => {
   it(`has options prop`, () => {
     expect(bud.terser.options).toStrictEqual({
       extractComments: false,
-      exclude: /(node_modules|bower_components)/,
       parallel: true,
       terserOptions: {
         compress: {
           drop_console: false,
           drop_debugger: true,
+          defaults: true,
+          unused: true,
         },
         format: {
           ascii_only: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7212,8 +7212,6 @@ __metadata:
     "@swc/plugin-emotion": 2.5.40
     "@types/babel__core": 7.20.0
     "@types/node": 18.11.18
-    "@types/react": 18.0.26
-    react: 18.2.0
   peerDependencies:
     "@babel/core": 7.20.7
     "@emotion/babel-plugin": "*"
@@ -7221,9 +7219,6 @@ __metadata:
     "@emotion/react": "*"
     "@emotion/styled": "*"
     "@roots/bud": "*"
-    "@roots/bud-babel": "*"
-    "@roots/bud-swc": "*"
-    "@swc/plugin-emotion": "*"
   peerDependenciesMeta:
     "@babel/core":
       optional: true


### PR DESCRIPTION
- Fixes unrelated issue with swc tree shaking by temporarily removing swcMinify in favor of the standard Terser minifier.
- Fixes issue with emotion dependencies not being hoisted
- Adds test case to cover regressions

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
