### PR TITLE
🩹 fix(@roots/bud-swc): #2116

### DIFF
--- a/sources/@roots/bud-swc/src/extension/index.ts
+++ b/sources/@roots/bud-swc/src/extension/index.ts
@@ -45,6 +45,20 @@ export default class BudSWC extends Extension<Options> {
         loader: bud.build.getLoader(`swc`),
         options: () => this.options,
       })
+      .setItem(`swc-js`, {
+        loader: bud.build.getLoader(`swc`),
+        options: () => ({
+          ...this.options,
+          jsc: {
+            ...(this.options.jsc ?? {}),
+            parser: {
+              ...(this.options.jsc?.parser ?? {}),
+              syntax: `ecmascript`,
+              jsx: true,
+            },
+          },
+        }),
+      })
 
     bud.hooks.on(`build.resolve.extensions`, (extensions = new Set()) =>
       extensions.add(`.ts`).add(`.tsx`).add(`.jsx`),
@@ -62,7 +76,7 @@ export default class BudSWC extends Extension<Options> {
       use: [`swc`],
     })
 
-    build.getRule(`js`).setUse(() => [`swc`])
+    build.getRule(`js`).setUse(() => [`swc-js`])
   }
 
   /**

--- a/sources/@roots/bud-swc/src/types/index.ts
+++ b/sources/@roots/bud-swc/src/types/index.ts
@@ -19,6 +19,7 @@ declare module '@roots/bud-framework' {
 
   interface Items {
     swc: Build.Item
+    'swc-js': Build.Item
   }
 
   interface Rules {

--- a/tests/reproductions/issue-2116.test.ts
+++ b/tests/reproductions/issue-2116.test.ts
@@ -1,0 +1,30 @@
+import {join} from 'node:path'
+import {paths} from '@repo/constants'
+import execa from '@roots/bud-support/execa'
+import {describe, expect, it} from 'vitest'
+import {readFile} from '@roots/bud-support/fs'
+
+describe('issue-2116', () => {
+  it('should generate app.js', async () => {
+    await execa(`yarn`, [`bud`, `clean`, `@dist`], {
+      cwd: join(paths.tests, `reproductions`, `issue-2116`),
+    })
+
+    await execa(`yarn`, [`bud`, `build`, `--force`, `--minimize`], {
+      cwd: join(paths.tests, `reproductions`, `issue-2116`),
+    })
+
+    const file = await readFile(
+      join(
+        paths.tests,
+        `reproductions`,
+        `issue-2116`,
+        `dist`,
+        `js`,
+        `main.js`,
+      ),
+      `utf-8`,
+    )
+    expect(file).not.toMatch(/\srequire\(/)
+  }, 300000)
+})

--- a/tests/reproductions/issue-2116/package.json
+++ b/tests/reproductions/issue-2116/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@tests/swc-js",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@roots/bud": "workspace:sources/@roots/bud",
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc",
+    "lodash": "^4.17.21"
+  }
+}

--- a/tests/reproductions/issue-2116/package.json
+++ b/tests/reproductions/issue-2116/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "@roots/bud": "workspace:sources/@roots/bud",
     "@roots/bud-swc": "workspace:sources/@roots/bud-swc",
-    "lodash": "^4.17.21"
+    "lodash": "4.17.21"
   }
 }

--- a/tests/reproductions/issue-2116/src/index.js
+++ b/tests/reproductions/issue-2116/src/index.js
@@ -1,0 +1,1 @@
+import './test.js'

--- a/tests/reproductions/issue-2116/src/test.js
+++ b/tests/reproductions/issue-2116/src/test.js
@@ -1,0 +1,7 @@
+import {get} from 'lodash'
+
+const foo = {
+  bar: 42,
+}
+
+console.log(get(foo, `bar`))

--- a/tests/reproductions/issue-2116/tsconfig.json
+++ b/tests/reproductions/issue-2116/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@roots/bud/config/tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "@roots/bud", "@roots/bud-swc"]
+  },
+  "include": ["./src"],
+  "exclude": ["./node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9153,7 +9153,7 @@ __metadata:
   dependencies:
     "@roots/bud": "workspace:sources/@roots/bud"
     "@roots/bud-swc": "workspace:sources/@roots/bud-swc"
-    lodash: ^4.17.21
+    lodash: 4.17.21
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9147,6 +9147,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@tests/swc-js@workspace:tests/reproductions/issue-2116":
+  version: 0.0.0-use.local
+  resolution: "@tests/swc-js@workspace:tests/reproductions/issue-2116"
+  dependencies:
+    "@roots/bud": "workspace:sources/@roots/bud"
+    "@roots/bud-swc": "workspace:sources/@roots/bud-swc"
+    lodash: ^4.17.21
+  languageName: unknown
+  linkType: soft
+
 "@tests/tailwind-integration@workspace:sources/@roots/bud-tailwindcss/test/implementation":
   version: 0.0.0-use.local
   resolution: "@tests/tailwind-integration@workspace:sources/@roots/bud-tailwindcss/test/implementation"


### PR DESCRIPTION
Fixes #2116 by setting `jsc.parser.syntax` to `ecmascript` and `jsx` to `true` for `.js` matches when using swc.

refers:

- #2116

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
