### PR TITLE
✨ improve(@roots/bud): safer postinstall scripts

### DIFF
--- a/sources/@roots/browserslist-config/scripts/postinstall.mjs
+++ b/sources/@roots/browserslist-config/scripts/postinstall.mjs
@@ -5,16 +5,12 @@
 
 import {execaCommandSync} from 'execa'
 
-if (process.env.npm_package_version === `0.0.0`) {
-  process.exit(0)
-}
-
-execaCommandSync(`npx browserslist --update-db`, {
-  cwd: process.env.INIT_CWD ?? process.cwd(),
-  reject: false,
-  timeout: 10000,
-})
-
-process.exit(0)
+try {
+  execaCommandSync(`npx browserslist --update-db`, {
+    cwd: process.env.INIT_CWD ?? process.cwd(),
+    reject: false,
+    timeout: 10000,
+  })
+} catch (e) {}
 
 export {}

--- a/sources/@roots/bud-framework/scripts/postinstall.mjs
+++ b/sources/@roots/bud-framework/scripts/postinstall.mjs
@@ -1,47 +1,39 @@
 /* eslint-disable no-console */
 // @ts-check
 
-/* eslint-disable n/no-process-env */
-/* eslint-disable n/no-process-exit */
-
 import {writeFileSync} from 'node:fs'
 import {dirname, join, resolve} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
 import {execaCommandSync} from 'execa'
 
-console.log(`[bud-framework] platform:`, process.platform)
+try {
+  if (process.platform === `darwin`) {
+    const cwd = resolve(dirname(fileURLToPath(import.meta.url)), `..`)
+    console.log(`[bud-framework] cwd:`, cwd)
 
-if (process.platform === `darwin`) {
-  const cwd = resolve(dirname(fileURLToPath(import.meta.url)), `..`)
-  console.log(`[bud-framework] cwd:`, cwd)
+    const notifierPath = join(
+      cwd,
+      `vendor`,
+      `mac.no-index`,
+      `roots-notifier.app`,
+      `Contents`,
+      `MacOS`,
+      `roots-notifier`,
+    )
+    console.log(`[bud-framework] notifierPath:`, notifierPath)
 
-  const notifierPath = join(
-    cwd,
-    `vendor`,
-    `mac.no-index`,
-    `roots-notifier.app`,
-    `Contents`,
-    `MacOS`,
-    `roots-notifier`,
-  )
-  console.log(`[bud-framework] notifierPath:`, notifierPath)
+    const results = execaCommandSync(`chmod u+x ${notifierPath}`, {
+      cwd,
+      reject: false,
+      timeout: 10000,
+    })
 
-  const results = execaCommandSync(`chmod u+x ${notifierPath}`, {
-    cwd,
-    reject: false,
-    timeout: 10000,
-  })
-
-  if (results.exitCode !== 0) {
-    console.log(`[bud-framework] notifier permissions could not be set`)
-    writeFileSync(join(cwd, `install.stderr.log`), results.stderr, `utf8`)
-  } else {
-    console.log(`[bud-framework] notifier permissions set`)
-    writeFileSync(join(cwd, `install.stdout.log`), `notifier permissions set`, `utf8`)
+    if (results.exitCode !== 0) {
+      console.log(`[bud-framework] notifier permissions could not be set`)
+      writeFileSync(join(cwd, `install.stderr.log`), results.stderr, `utf8`)
+    }
   }
-}
-
-process.exit(0)
+} catch (e) {}
 
 export {}


### PR DESCRIPTION
just wrap these postinstall scripts in a try/catch since neither one is life or death.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
