### PR TITLE
🩹 fix: bud.run

### DIFF
--- a/sources/@roots/bud-framework/src/methods/run.ts
+++ b/sources/@roots/bud-framework/src/methods/run.ts
@@ -8,8 +8,9 @@ export interface run {
 }
 
 export const run: run = async function (this: Bud) {
+  const compilation = await this.compiler.compile()
+
   if (this.isProduction) {
-    const compilation = await this.compiler.compile()
     if (!compilation) return
 
     compilation.run(async (error, stats) => {


### PR DESCRIPTION
- compiler should always be instantiated but is not in dev.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
