### PR TITLE
🩹 fix(@roots/bud): fix mixed magic paths

### DIFF
--- a/sources/@roots/bud-framework/src/methods/path/path.test.ts
+++ b/sources/@roots/bud-framework/src/methods/path/path.test.ts
@@ -51,8 +51,9 @@ describe(`bud.path`, () => {
   })
   it(`resolves @hash to empty string when disabled`, async () => {
     bud.hooks.on(`feature.hash`, false)
-    expect(path(`@hash`)).toEqual(``)
+    expect(path(`@hash`)).toEqual(`[contenthash:6]`)
   })
+
   it(`resolves @ext`, async () => {
     expect(path(`@ext`)).toEqual(`[ext]`)
   })

--- a/sources/@roots/bud-framework/src/methods/path/path.test.ts
+++ b/sources/@roots/bud-framework/src/methods/path/path.test.ts
@@ -57,4 +57,7 @@ describe(`bud.path`, () => {
   it(`resolves @ext`, async () => {
     expect(path(`@ext`)).toEqual(`[ext]`)
   })
+
+  it(`resolves @dist/@name`, () =>
+    expect(path(`@dist/@name`)).toMatch(/dist\/\[name\]/))
 })

--- a/sources/@roots/bud-framework/src/methods/path/path.ts
+++ b/sources/@roots/bud-framework/src/methods/path/path.ts
@@ -75,16 +75,21 @@ export const path: path = function (base, ...segments) {
         `@name`,
         app.hooks.filter(`feature.hash`) ? `${name}.@hash` : name,
       )
-      .replace(`@hash`, app.hooks.filter(`feature.hash`) ? hash : ``)
+      .replace(`@hash`, hash)
       .replace(`@path`, `[path]`)
       .replace(`@ext`, `[ext]`)
 
-  if (
-    [`@file`, `@base`, `@name`, `@path`, `@ext`, `@hash`].some(
-      magicString => base?.includes(magicString),
-    )
+  const isMagic = [
+    `@file`,
+    `@base`,
+    `@name`,
+    `@path`,
+    `@ext`,
+    `@hash`,
+  ].some(
+    magicString =>
+      base?.includes(magicString) || segments?.includes(magicString),
   )
-    return transformMagicString(base)
 
   base = transformMagicString(base)
 
@@ -92,6 +97,9 @@ export const path: path = function (base, ...segments) {
 
   /* Parse `@` aliases. Should return an absolute path */
   if (base.startsWith(`@`)) base = parseAlias(app, base)
+
+  /* If magic string return it */
+  if (isMagic) return join(base, ...segments)
 
   /* Resolve any base path that isn't already absolute */
   if (!base.startsWith(sep)) base = resolve(app.context.basedir, base)


### PR DESCRIPTION
Paths like `@dist/@name` or `@dist/@file` don't resolve the path alias.

There is basically no reason to do this but it's unexpected behavior so I'm fixing it.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
