### PR TITLE
✨ improve(@roots/bud): add bud.copyFile and bud.copyDir

### DIFF
--- a/sources/@roots/bud-api/src/api/__snapshots__/service.test.ts.snap
+++ b/sources/@roots/bud-api/src/api/__snapshots__/service.test.ts.snap
@@ -8,6 +8,8 @@ exports[`@roots/bud-api > should add methods when bootstrapped 1`] = `
   "compilePaths": [Function],
   "config": [Function],
   "copy": [Function],
+  "copyDir": [Function],
+  "copyFile": [Function],
   "define": [Function],
   "devtool": [Function],
   "entry": [Function],

--- a/sources/@roots/bud-api/src/methods/assets/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/assets/index.test.ts
@@ -34,9 +34,7 @@ describe(`bud.assets`, () => {
       expect.arrayContaining([
         expect.objectContaining({
           from: expect.stringContaining(`images`),
-          to: expect.stringMatching(
-            /dist\/images\/\[path\]\[name\]\[ext\]$/,
-          ),
+          to: expect.stringMatching(/images\/\[path\]\[name\]\[ext\]$/),
           context: expect.stringContaining(`src`),
           toType: `template`,
           noErrorOnMissing: true,

--- a/sources/@roots/bud-api/src/methods/assets/index.ts
+++ b/sources/@roots/bud-api/src/methods/assets/index.ts
@@ -82,7 +82,7 @@ export const fromStringFactory =
     from: isAbsolute(from) ? from : app.path(`@src`, from),
     to: isAbsolute(from)
       ? relative(app.path(`@src`), from)
-      : app.path(`@dist`, from, `@file`),
+      : app.path(from, `@file`),
     context: app.path(`@src`),
     filter: filterDotFiles,
     noErrorOnMissing: true,

--- a/sources/@roots/bud-api/src/methods/copyDir/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/copyDir/index.test.ts
@@ -1,0 +1,59 @@
+import {factory} from '@repo/test-kit/bud'
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {copyDir as copyDirFn} from './index.js'
+
+describe(`bud.copyDir`, () => {
+  let bud
+  let copyDir: typeof copyDirFn
+
+  beforeEach(async () => {
+    bud = await factory()
+    copyDir = copyDirFn.bind(bud)
+    bud.extensions
+      .get(`@roots/bud-extensions/copy-webpack-plugin`)
+      .setOption(`patterns`, [])
+  })
+
+  it(`should be a function`, () => {
+    expect(copyDir).toBeInstanceOf(Function)
+  })
+
+  it(`should have copy-webpack-plugin available`, () => {
+    expect(
+      bud.extensions.has(`@roots/bud-extensions/copy-webpack-plugin`),
+    ).toBeTruthy()
+  })
+
+  it(`should add job when passed a string`, async () => {
+    await copyDir(bud.path(`@src/images`))
+    expect(
+      bud.extensions.get(`@roots/bud-extensions/copy-webpack-plugin`)
+        .options.patterns,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: `**/*`,
+          to: bud.path(`@file`),
+          context: bud.path(`@src/images`),
+        }),
+      ]),
+    )
+  })
+
+  it(`should add jobs when passed a tuple`, async () => {
+    await copyDir([bud.path(`@src/images`), `images`])
+
+    const [patterna] = bud.extensions.get(
+      `@roots/bud-extensions/copy-webpack-plugin`,
+    ).options.patterns as any
+
+    expect(patterna).toEqual(
+      expect.objectContaining({
+        from: `**/*`,
+        to: `images/[name][ext]`,
+        context: bud.path(`@src/images`),
+      }),
+    )
+  })
+})

--- a/sources/@roots/bud-api/src/methods/copyDir/index.ts
+++ b/sources/@roots/bud-api/src/methods/copyDir/index.ts
@@ -1,0 +1,69 @@
+import type {Bud} from '@roots/bud-framework'
+import type {Plugin as CopyPlugin} from '@roots/bud-support/copy-webpack-plugin'
+import {isAbsolute, join} from 'path'
+
+type FromToTuple = [CopyPlugin.StringPattern, CopyPlugin.StringPattern]
+
+export type Parameters = [
+  CopyPlugin.StringPattern | FromToTuple,
+  Partial<CopyPlugin.ObjectPattern>?,
+]
+
+export interface copyDir {
+  (...parameters: Parameters): Promise<Bud>
+}
+
+export const copyDir: copyDir = async function copyDir(
+  this: Bud,
+  request,
+  overrides = {},
+) {
+  const app = this as Bud
+
+  const makePatternObjectFromString = fromStringFactory(app, overrides)
+  const makePatternObjectFromTuple = fromTupleFactory(app, overrides)
+
+  const result =
+    typeof request === `string`
+      ? makePatternObjectFromString(request)
+      : makePatternObjectFromTuple(request)
+
+  app.extensions
+    .get(`@roots/bud-extensions/copy-webpack-plugin`)
+    .setOptions(options => ({
+      ...(options ?? {}),
+      patterns: [...(options?.patterns ?? []), result],
+    }))
+
+  app.api.logger.success(`bud.copyDir: asset pattern added`)
+
+  return app
+}
+
+/**
+ * Take an input string and return a {@link CopyPlugin.ObjectPattern}
+ *
+ * @internal
+ */
+export const fromStringFactory =
+  (app: Bud, overrides: Partial<CopyPlugin.ObjectPattern>) =>
+  (from: string): CopyPlugin.ObjectPattern => ({
+    from: join(`**`, `*`),
+    to: app.path(`@file`),
+    context: isAbsolute(from) ? from : app.path(from),
+    ...overrides,
+  })
+
+/**
+ * Take an input [from,to] tuple and return a {@link CopyPlugin.ObjectPattern}
+ *
+ * @internal
+ */
+export const fromTupleFactory =
+  (app: Bud, overrides: Partial<CopyPlugin.ObjectPattern>) =>
+  ([from, to]: [string, string]): CopyPlugin.ObjectPattern => ({
+    from: join(`**`, `*`),
+    to: join(to, app.path(`@base`)),
+    context: isAbsolute(from) ? from : app.path(from),
+    ...overrides,
+  })

--- a/sources/@roots/bud-api/src/methods/copyFile/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/copyFile/index.test.ts
@@ -1,0 +1,63 @@
+import {factory} from '@repo/test-kit/bud'
+import {beforeEach, describe, expect, it} from 'vitest'
+
+import {copyFile as copyFileFn} from './index.js'
+
+describe(`bud.copyFile`, () => {
+  let bud
+  let copyFile: typeof copyFileFn
+
+  beforeEach(async () => {
+    bud = await factory()
+    copyFile = copyFileFn.bind(bud)
+    bud.extensions
+      .get(`@roots/bud-extensions/copy-webpack-plugin`)
+      .setOption(`patterns`, [])
+  })
+
+  it(`should be a function`, () => {
+    expect(copyFile).toBeInstanceOf(Function)
+  })
+
+  it(`should have copy-webpack-plugin available`, () => {
+    expect(
+      bud.extensions.has(`@roots/bud-extensions/copy-webpack-plugin`),
+    ).toBeTruthy()
+  })
+
+  it(`should add job when passed an array of strings`, async () => {
+    await copyFile(bud.path(`@src/images/image.jpeg`))
+    expect(
+      bud.extensions.get(`@roots/bud-extensions/copy-webpack-plugin`)
+        .options.patterns,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: bud.path(`@src/images/image.jpeg`),
+          to: expect.stringMatching(/\[name\]\[ext\]$/),
+          context: expect.stringMatching(
+            /tests\/util\/project\/src\/images$/,
+          ),
+        }),
+      ]),
+    )
+  })
+
+  it(`should add jobs when passed tuple`, async () => {
+    await copyFile([bud.path(`@src/images/image.jpeg`), `foo`])
+
+    const [pattern] = bud.extensions.get(
+      `@roots/bud-extensions/copy-webpack-plugin`,
+    ).options.patterns as any
+
+    expect(pattern).toEqual(
+      expect.objectContaining({
+        from: bud.path(`@src/images/image.jpeg`),
+        to: expect.stringMatching(/foo\/\[name\]\[ext\]$/),
+        context: expect.stringMatching(
+          /tests\/util\/project\/src\/images$/,
+        ),
+      }),
+    )
+  })
+})

--- a/sources/@roots/bud-api/src/methods/copyFile/index.ts
+++ b/sources/@roots/bud-api/src/methods/copyFile/index.ts
@@ -1,0 +1,69 @@
+import type {Bud} from '@roots/bud-framework'
+import type {Plugin as CopyPlugin} from '@roots/bud-support/copy-webpack-plugin'
+import {dirname} from 'path'
+
+type FromToTuple = [CopyPlugin.StringPattern, CopyPlugin.StringPattern]
+
+export type Parameters = [
+  CopyPlugin.StringPattern | FromToTuple,
+  Partial<CopyPlugin.ObjectPattern>?,
+]
+
+export interface copyFile {
+  (...parameters: Parameters): Promise<Bud>
+}
+
+export const copyFile: copyFile = async function copyFile(
+  this: Bud,
+  request,
+  overrides = {},
+) {
+  const app = this as Bud
+
+  const makePatternObjectFromString = fromStringFactory(app, overrides)
+  const makePatternObjectFromTuple = fromTupleFactory(app, overrides)
+
+  const result =
+    typeof request === `string`
+      ? makePatternObjectFromString(request)
+      : makePatternObjectFromTuple(request)
+
+  app.extensions
+    .get(`@roots/bud-extensions/copy-webpack-plugin`)
+    .setOptions(options => ({
+      ...(options ?? {}),
+      patterns: [...(options?.patterns ?? []), result],
+    }))
+
+  app.api.logger.success(`bud.copyDir: asset pattern added`)
+
+  return app
+}
+
+/**
+ * Take an input string and return a {@link CopyPlugin.ObjectPattern}
+ *
+ * @internal
+ */
+export const fromStringFactory =
+  (app: Bud, overrides: Partial<CopyPlugin.ObjectPattern>) =>
+  (from: string): CopyPlugin.ObjectPattern => ({
+    from,
+    to: app.path(`@base`),
+    context: dirname(from),
+    ...overrides,
+  })
+
+/**
+ * Take an input [from,to] tuple and return a {@link CopyPlugin.ObjectPattern}
+ *
+ * @internal
+ */
+export const fromTupleFactory =
+  (app: Bud, overrides: Partial<CopyPlugin.ObjectPattern>) =>
+  ([from, to]: [string, string]): CopyPlugin.ObjectPattern => ({
+    from,
+    to: app.path(to, `@base`),
+    context: dirname(from),
+    ...overrides,
+  })

--- a/sources/@roots/bud-api/src/methods/index.ts
+++ b/sources/@roots/bud-api/src/methods/index.ts
@@ -6,6 +6,8 @@ export {
   config as webpackConfig,
   config as override,
 } from './config/index.js'
+export {copyDir} from './copyDir/index.js'
+export {copyFile} from './copyFile/index.js'
 export {define} from './define/index.js'
 export {devtool} from './devtool/index.js'
 export {entry} from './entry/index.js'

--- a/sources/@roots/bud-api/src/repository.ts
+++ b/sources/@roots/bud-api/src/repository.ts
@@ -5,6 +5,8 @@ import type * as Assets from './methods/assets/index.js'
 import type * as Bundle from './methods/bundle/index.js'
 import type * as CompilePaths from './methods/compilePaths/index.js'
 import type * as Config from './methods/config/index.js'
+import type * as CopyDir from './methods/copyDir/index.js'
+import type * as CopyFile from './methods/copyFile/index.js'
 import type * as Define from './methods/define/index.js'
 import type * as Devtool from './methods/devtool/index.js'
 import type * as Entry from './methods/entry/index.js'
@@ -70,6 +72,20 @@ export interface Repository {
    * {@link https://bud.js.org/docs/bud.config 📕 Documentation}
    */
   config(...params: Config.Parameters): Bud
+
+  /**
+   * ## bud.copyFile
+   *
+   * {@link https://bud.js.org/docs/bud.copyDir 📕 Documentation}
+   */
+  copyDir(...params: CopyDir.Parameters): Bud
+
+  /**
+   * ## bud.copyFile
+   *
+   * {@link https://bud.js.org/docs/bud.copyFile 📕 Documentation}
+   */
+  copyFile(...params: CopyFile.Parameters): Bud
 
   /**
    * ## bud.override

--- a/sources/@roots/bud-dashboard/src/dashboard/chunk/asset.component.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/chunk/asset.component.tsx
@@ -30,13 +30,9 @@ const Asset = ({
         <Ink.Text color={color.dim}>{name}</Ink.Text>
       </Ink.Box>
 
-      {size && size > 0 ? (
-        <Ink.Box minWidth={10} justifyContent="flex-end">
-          <Ink.Text color={color.dim} dimColor>
-            {(formatSize(size) as string).trim()}
-          </Ink.Text>
-        </Ink.Box>
-      ) : null}
+      <Ink.Box minWidth={10} justifyContent="flex-end">
+        <Ink.Text dimColor>{(formatSize(size) as string).trim()}</Ink.Text>
+      </Ink.Box>
     </Title>
   )
 }

--- a/sources/@roots/bud-dashboard/src/dashboard/compilation/compilation.component.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/compilation/compilation.component.tsx
@@ -35,7 +35,9 @@ interface AssetGroup extends StatsChunkGroup {
 }
 
 const onlyNotHot = ({name}: StatsAsset) => !name?.includes(`hot-update`)
-const onlyStatic = ({info}: StatsAsset) => info?.copied
+const onlyStatic = ({name}: StatsAsset) =>
+  ![`.css`, `.js`].some(ext => name?.includes(ext))
+
 const makeAssetGroupCallback =
   (assets?: {name: string}[]) =>
   (asset: Partial<StatsAsset>): Partial<StatsAsset> => {


### PR DESCRIPTION
Add `bud.copyFile` and `bud.copyDir` for people who don't want to muck around with `copy-webpack-plugin` settings but also need to copy from a location outside of `@src` (the context for bud.assets).

Unlike `bud.assets`, these functions only allow for specifying a single copy task. If you have multiple tasks you can call it multiple times.

Like `bud.assets`, these functions handle file hashing if it is enabled.

## bud.copyFile

Copy `./images/image.jpeg` to `./dist/image.jpeg`:

```ts
bud.copyFile(
  bud.path(`images/image.jpeg`),
)
```

Copy `./images/image.jpeg` to `./dist/new-directory/image.jpeg`. 

```ts
bud.copyFile([
 bud.path(`images/image.jpeg`),
 `new-directory`,
])
```

## bud.copyDir

Copy `./images/**/*` to `./dist/**/*`:

```ts
bud.copyDir(
  bud.path(`images`),
)
```

Copy `./images/**/*` to `./dist/new-directory/**/*`. 

```ts
bud.copyDir([
 bud.path(`images`),
 `new-directory`,
])
```

For copying from `@src/*` paths, bud.assets is probably still preferable.

Copy from `src/images/**/*` to `dist/images/**/*`:

```ts
bud.assets('images')
```

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
