### PR TITLE
🩹 fix(@roots/bud): paths

### DIFF
--- a/sources/@roots/bud-framework/src/methods/relPath.ts
+++ b/sources/@roots/bud-framework/src/methods/relPath.ts
@@ -1,9 +1,21 @@
-import {relative} from 'node:path'
+import {isAbsolute, relative} from 'node:path'
 
+import type {Bud} from '../bud.js'
+
+/**
+ * ## bud.relPath
+ */
 export interface relPath {
-  (...parts: Array<string>): string
+  (...segments: Array<string>): string
 }
 
-export const relPath: relPath = function (...parts): string {
-  return relative(this.path(), this.path(...parts))
+export const relPath: relPath = function (...segments) {
+  const app = this as Bud
+
+  /* Exit early with context.basedir if no path was passed */
+  if (!segments?.length) return ``
+
+  const value = app.path(...segments)
+
+  return isAbsolute(value) ? relative(app.context.basedir, value) : value
 }

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
@@ -1,4 +1,4 @@
-import {normalize} from 'node:path'
+import {isAbsolute} from 'node:path'
 
 import type {Bud} from '../../bud.js'
 import type {SyncRegistry} from '../../types/registry/index.js'
@@ -38,7 +38,7 @@ export const setPath: setPath = function (this: Bud, ...parameters) {
   /* Set basedir */
   if (isType.baseDir(parameters)) {
     const basedir = validate.baseDir(parameters)
-    this.context.basedir = normalize(basedir)
+    this.context.basedir = basedir
     this.log(`basedir set to ${basedir}`)
 
     return this
@@ -73,11 +73,17 @@ const makeCallback =
   (bud: Bud) =>
   (pair: [string, string]): Bud => {
     const [key, value] = validate.stringPair(pair)
-    const relativePath = bud.relPath(value)
+    const normal = !isAbsolute(value) ? bud.relPath(value) : value
+
+    bud.log({
+      key,
+      value,
+      normal,
+    })
 
     bud.hooks
-      .on(`location.${key}` as keyof SyncRegistry, relativePath)
-      .log(`${key} set to ${relativePath}`)
+      .on(`location.${key}` as keyof SyncRegistry, normal)
+      .log(`${key} set to ${normal}`)
 
     return bud
   }


### PR DESCRIPTION
Generally just makes paths more lenient so stuff like doesn't cause problems:

```js
bud.setPath('@src', bud.path('src'))
```

It would still be better to just set the path relatively:

```js
bud.setPath('@src', 'src')
```

Or, use the `bud.relPath` wrapper if you prefer wrapping multipart paths:

```js
bud.setPath('@js', bud.relPath('sources', 'js'))
```

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
