### PR TITLE
📕 docs: Install component

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
@@ -10,7 +10,7 @@ import {Install} from '@site/src/docs/Install'
 
 ## Installation
 
-<Install packages="@roots/bud-tailwindcss --dev" />
+<Install packages="@roots/bud-tailwindcss" />
 
 ## Using tailwind values in JS files
 


### PR DESCRIPTION
Remove ` --dev`from packages attribute on `<Install />` component, since it currently adds `--dev` by default.

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
