### PR TITLE
fix (@bud/prettier): bud format command

### DIFF
--- a/sources/@roots/bud-prettier/src/bud/commands/bud.prettier.command.tsx
+++ b/sources/@roots/bud-prettier/src/bud/commands/bud.prettier.command.tsx
@@ -19,15 +19,17 @@ export class BudPrettierCommand extends BudCommand {
     await this.makeBud(this)
     await this.bud.run()
 
-    const prettier = await this.bud.module.getDirectory(`prettier`)
-    const bin = join(prettier, `bin-prettier.js`)
+    const prettier = join(
+      await this.bud.module.getDirectory(`prettier`),
+      `bin-prettier.js`,
+    )
 
-    if (!this.options)
+    if (!this.options?.length)
       this.options = [
-        this.bud.path(`@src`, `**/*.{ts,tsx,js,jsx,css,scss,sass}`),
+        this.bud.path(`@src`, `**`, `*.{ts,tsx,js,jsx,css,scss,sass}`),
         `--write`,
       ]
 
-    await this.$(this.bin, [bin, ...(this.options ?? [])])
+    await this.$(this.bin, [prettier, ...this.options])
   }
 }


### PR DESCRIPTION
I'm having issues with `@roots/bud-prettier`. For a reason I didn't fully understand (maybe not exploding the full path? -> `**/*.js`), the `yarn bud format` failed printing prettier help: 

```
Usage: prettier [options] [file/dir/glob ...]

By default, output is written to stdout.
Stdin is read if it is piped to Prettier and no files are given.

...
```
Seems like options are not passed to the command. I borrowed and aligned the logic from `@roots/bud-eslint`. Seems to work again. 

## Type of change

**NONE: internal change**

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
