### PR TITLE
🔧 bud.js.org: Disable trailing slash

### DIFF
--- a/sources/@repo/docs/config/index.cjs
+++ b/sources/@repo/docs/config/index.cjs
@@ -17,6 +17,7 @@ module.exports = {
   tagline: config.description,
   url: config.url.docs,
   baseUrl: `/`,
+  trailingSlash: false,
   onBrokenLinks: `warn`,
   onBrokenMarkdownLinks: `warn`,
   favicon: config.organization.favicon,


### PR DESCRIPTION
Ref https://docusaurus.io/docs/api/docusaurus-config#trailingSlash
Ref https://docusaurus.io/docs/deployment#trailing-slashes

I cannot confirm whether this works or not from the local dev server, but the desired behavior is:

`https://bud.js.org/guides/getting-started/`  ➡️  `https://bud.js.org/guides/getting-started`

The canonical is at least already properly set, but we need the server to enforce the trailing slash properly for analytics purposes