### PR TITLE
🩹 fix(@roots/browserslist-config) no update in ci

### DIFF
--- a/sources/@roots/browserslist-config/scripts/postinstall.mjs
+++ b/sources/@roots/browserslist-config/scripts/postinstall.mjs
@@ -5,12 +5,14 @@
 
 import {execaCommandSync} from 'execa'
 
-try {
-  execaCommandSync(`npx browserslist --update-db`, {
-    cwd: process.env.INIT_CWD ?? process.cwd(),
-    reject: false,
-    timeout: 10000,
-  })
-} catch (e) {}
+if (!process.env.CI) {
+  try {
+    execaCommandSync(`npx browserslist --update-db`, {
+      cwd: process.env.INIT_CWD ?? process.cwd(),
+      reject: false,
+      timeout: 10000,
+    })
+  } catch (e) {}
+}
 
 export {}

--- a/sources/@roots/bud-framework/scripts/postinstall.mjs
+++ b/sources/@roots/bud-framework/scripts/postinstall.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-process-env */
 /* eslint-disable no-console */
 // @ts-check
 
@@ -8,7 +9,7 @@ import {fileURLToPath} from 'node:url'
 import {execaCommandSync} from 'execa'
 
 try {
-  if (process.platform === `darwin`) {
+  if (process.platform === `darwin` && !process.env.CI) {
     const cwd = resolve(dirname(fileURLToPath(import.meta.url)), `..`)
     console.log(`[bud-framework] cwd:`, cwd)
 
@@ -31,7 +32,11 @@ try {
 
     if (results.exitCode !== 0) {
       console.log(`[bud-framework] notifier permissions could not be set`)
-      writeFileSync(join(cwd, `install.stderr.log`), results.stderr, `utf8`)
+      writeFileSync(
+        join(cwd, `install.stderr.log`),
+        results.stderr,
+        `utf8`,
+      )
     }
   }
 } catch (e) {}


### PR DESCRIPTION
- don't run postinstall scripts in ci

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
