### PR TITLE
🩹 fix(cli): ink static renderer

### DIFF
--- a/sources/@roots/bud-dashboard/src/service.tsx
+++ b/sources/@roots/bud-dashboard/src/service.tsx
@@ -47,14 +47,14 @@ export class Dashboard extends Service implements Contract {
     }
 
     if (!this.app.isCLI() || this.app.context.args.ci === true) {
-      await this.renderString(stats)
+      this.renderString(stats)
       return this
     }
 
     try {
       await this.render(stats.toJson(this.app.hooks.filter(`build.stats`)))
     } catch (error) {
-      await this.renderString(stats)
+      this.renderString(stats)
     }
 
     return this
@@ -114,13 +114,13 @@ export class Dashboard extends Service implements Contract {
    * Render stats as a simple string
    */
   @bind
-  public async renderString(stats: MultiStats) {
+  public renderString(stats: MultiStats) {
     const stringCompilation = stats.toString({
       preset: `minimal`,
       colors: true,
     })
 
-    await process.stdout.write(stringCompilation)
+    process.stdout.write(stringCompilation)
   }
 
   /**

--- a/sources/@roots/bud-framework/src/types/services/dashboard/index.ts
+++ b/sources/@roots/bud-framework/src/types/services/dashboard/index.ts
@@ -20,5 +20,5 @@ export interface Service extends Contract {
    */
   render: any
 
-  renderString(stats: MultiStats): Promise<void>
+  renderString(stats: MultiStats): void
 }

--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -174,6 +174,7 @@
     "@roots/bud-terser": "workspace:sources/@roots/bud-terser",
     "chalk": "5.2.0",
     "ink": "4.0.0",
+    "ink-spinner": "5.0.0",
     "ink-text-input": "5.0.0",
     "react": "18.2.0",
     "tslib": "2.5.0"

--- a/sources/@roots/bud/src/cli/app.ts
+++ b/sources/@roots/bud/src/cli/app.ts
@@ -3,8 +3,6 @@ import BudBuildCommand from '@roots/bud/cli/commands/bud.build'
 import BudBuildDevelopmentCommand from '@roots/bud/cli/commands/bud.build.development'
 import BudBuildProductionCommand from '@roots/bud/cli/commands/bud.build.production'
 import BudCleanCommand from '@roots/bud/cli/commands/bud.clean'
-import BudDoctorCommand from '@roots/bud/cli/commands/bud.doctor'
-import BudReplCommand from '@roots/bud/cli/commands/bud.repl'
 import BudUpgradeCommand from '@roots/bud/cli/commands/bud.upgrade'
 import BudViewCommand from '@roots/bud/cli/commands/bud.view'
 import BudWebpackCommand from '@roots/bud/cli/commands/bud.webpack'
@@ -12,12 +10,11 @@ import {Commands} from '@roots/bud/cli/finder'
 import getContext from '@roots/bud/context'
 import {Builtins, Cli, CommandClass} from '@roots/bud-support/clipanion'
 import * as args from '@roots/bud-support/utilities/args'
-import * as paths from '@roots/bud-support/utilities/paths'
 
-const {basedir} = paths.get(process.cwd())
+import BudDoctorCommand from './commands/doctor/index.js'
+import BudReplCommand from './commands/repl/index.js'
 
 const context = await getContext({
-  basedir,
   stdin: process.stdin,
   stdout: process.stdout,
   stderr: process.stderr,

--- a/sources/@roots/bud/src/cli/commands/bud.clean.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.clean.tsx
@@ -77,7 +77,7 @@ export default class BudCleanCommand extends BudCommand {
             .map(async child => {
               try {
                 await remove(child.path(`@dist`))
-                this.renderOnce(
+                this.renderStatic(
                   <Ink.Box>
                     <Ink.Text color="green">
                       ✔ emptied {child.path(`@dist`)}
@@ -92,7 +92,7 @@ export default class BudCleanCommand extends BudCommand {
       }
 
       await remove(this.bud.path(`@dist`))
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.path(`@dist`)}
@@ -114,7 +114,7 @@ export default class BudCleanCommand extends BudCommand {
             .map(async child => {
               try {
                 await remove(child.cache.cacheDirectory)
-                this.renderOnce(
+                this.renderStatic(
                   <Ink.Box>
                     <Ink.Text color="green">
                       ✔ emptied {child.cache.cacheDirectory}
@@ -129,7 +129,7 @@ export default class BudCleanCommand extends BudCommand {
       }
 
       await remove(this.bud.cache.cacheDirectory)
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.cache.cacheDirectory}
@@ -150,7 +150,7 @@ export default class BudCleanCommand extends BudCommand {
           .map(async child => {
             try {
               await remove(child.path(`@dist`))
-              this.renderOnce(
+              this.renderStatic(
                 <Ink.Box>
                   <Ink.Text color="green">
                     ✔ emptied {child.path(`@storage`)}
@@ -167,7 +167,7 @@ export default class BudCleanCommand extends BudCommand {
     try {
       await ensureDir(this.bud.path(`@storage`))
       await remove(this.bud.path(`@storage`))
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.path(`@storage`)}

--- a/sources/@roots/bud/src/cli/commands/bud.clean.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.clean.tsx
@@ -77,7 +77,7 @@ export default class BudCleanCommand extends BudCommand {
             .map(async child => {
               try {
                 await remove(child.path(`@dist`))
-                await this.renderOnce(
+                this.renderOnce(
                   <Ink.Box>
                     <Ink.Text color="green">
                       ✔ emptied {child.path(`@dist`)}
@@ -92,7 +92,7 @@ export default class BudCleanCommand extends BudCommand {
       }
 
       await remove(this.bud.path(`@dist`))
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.path(`@dist`)}
@@ -114,7 +114,7 @@ export default class BudCleanCommand extends BudCommand {
             .map(async child => {
               try {
                 await remove(child.cache.cacheDirectory)
-                await this.renderOnce(
+                this.renderOnce(
                   <Ink.Box>
                     <Ink.Text color="green">
                       ✔ emptied {child.cache.cacheDirectory}
@@ -129,7 +129,7 @@ export default class BudCleanCommand extends BudCommand {
       }
 
       await remove(this.bud.cache.cacheDirectory)
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.cache.cacheDirectory}
@@ -150,7 +150,7 @@ export default class BudCleanCommand extends BudCommand {
           .map(async child => {
             try {
               await remove(child.path(`@dist`))
-              await this.renderOnce(
+              this.renderOnce(
                 <Ink.Box>
                   <Ink.Text color="green">
                     ✔ emptied {child.path(`@storage`)}
@@ -167,7 +167,7 @@ export default class BudCleanCommand extends BudCommand {
     try {
       await ensureDir(this.bud.path(`@storage`))
       await remove(this.bud.path(`@storage`))
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.path(`@storage`)}

--- a/sources/@roots/bud/src/cli/commands/bud.clean.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.clean.tsx
@@ -77,7 +77,7 @@ export default class BudCleanCommand extends BudCommand {
             .map(async child => {
               try {
                 await remove(child.path(`@dist`))
-                this.renderStatic(
+                await this.renderStatic(
                   <Ink.Box>
                     <Ink.Text color="green">
                       ✔ emptied {child.path(`@dist`)}
@@ -92,7 +92,7 @@ export default class BudCleanCommand extends BudCommand {
       }
 
       await remove(this.bud.path(`@dist`))
-      this.renderStatic(
+      await this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.path(`@dist`)}
@@ -114,7 +114,7 @@ export default class BudCleanCommand extends BudCommand {
             .map(async child => {
               try {
                 await remove(child.cache.cacheDirectory)
-                this.renderStatic(
+                await this.renderStatic(
                   <Ink.Box>
                     <Ink.Text color="green">
                       ✔ emptied {child.cache.cacheDirectory}
@@ -129,7 +129,7 @@ export default class BudCleanCommand extends BudCommand {
       }
 
       await remove(this.bud.cache.cacheDirectory)
-      this.renderStatic(
+      await this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.cache.cacheDirectory}
@@ -150,7 +150,7 @@ export default class BudCleanCommand extends BudCommand {
           .map(async child => {
             try {
               await remove(child.path(`@dist`))
-              this.renderStatic(
+              await this.renderStatic(
                 <Ink.Box>
                   <Ink.Text color="green">
                     ✔ emptied {child.path(`@storage`)}
@@ -167,7 +167,7 @@ export default class BudCleanCommand extends BudCommand {
     try {
       await ensureDir(this.bud.path(`@storage`))
       await remove(this.bud.path(`@storage`))
-      this.renderStatic(
+      await this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             ✔ emptied {this.bud.path(`@storage`)}

--- a/sources/@roots/bud/src/cli/commands/bud.doctor.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.doctor.tsx
@@ -75,10 +75,10 @@ for a lot of edge cases so it might return a false positive.
     }
 
     if (isWindows()) {
-      await this.renderOnce(<WinError />)
+      this.renderOnce(<WinError />)
     }
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box marginTop={1}>
         <Ink.Text underline>
           {`Diagnosis for `}
@@ -89,7 +89,7 @@ for a lot of edge cases so it might return a false positive.
       </Ink.Box>,
     )
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Text color={`dimWhite`}>
         Completed a dry run of your project's build (executed in{` `}
         {this.timings.build} seconds). If the information provided by this
@@ -99,7 +99,7 @@ for a lot of edge cases so it might return a false positive.
     )
 
     if (await this.bud.fs.exists(this.bud.cache.cacheDirectory)) {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box flexDirection="column">
           <Ink.Text color="yellow">
             {figures.info} Detected compilation cache
@@ -123,7 +123,7 @@ for a lot of edge cases so it might return a false positive.
       )
     }
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">
           Checking system requirements{`\n`}
@@ -145,7 +145,7 @@ for a lot of edge cases so it might return a false positive.
     )
 
     if (!process.version.match(/v1[6|7|8|9]/)) {
-      await this.renderOnce(
+      this.renderOnce(
         <Error
           name="Node version not supported"
           message={`Please upgrade to Node v18 for long-term support. You are running node ${process.version}.`}
@@ -154,7 +154,7 @@ for a lot of edge cases so it might return a false positive.
     }
 
     if (this.bud.hasChildren) {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Child compilers{`\n`}</Ink.Text>
           {Object.values(this.bud.children).map((child, i) => (
@@ -173,7 +173,7 @@ for a lot of edge cases so it might return a false positive.
       )
     }
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">Project paths</Ink.Text>
         <Ink.Text>{` `}</Ink.Text>
@@ -197,7 +197,7 @@ for a lot of edge cases so it might return a false positive.
       </Ink.Box>,
     )
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">
           Checking versions of core packages
@@ -259,7 +259,7 @@ for a lot of edge cases so it might return a false positive.
       )
     } catch (e) {}
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">
           Checking installed package compatibility{`\n`}
@@ -270,7 +270,7 @@ for a lot of edge cases so it might return a false positive.
       </Ink.Box>,
     )
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">Mode</Ink.Text>
         <Ink.Text>{this.bud.mode}</Ink.Text>
@@ -281,7 +281,7 @@ for a lot of edge cases so it might return a false positive.
       this.bud.context.files ? Object.values(this.bud.context.files) : []
     ).filter(({bud}) => bud)
     if (configFiles.length) {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Bud configuration files{`\n`}</Ink.Text>
           {configFiles.map(({name, path}, i) => (
@@ -298,7 +298,7 @@ for a lot of edge cases so it might return a false positive.
         </Ink.Box>,
       )
     } else {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Registered configurations{`\n`}</Ink.Text>
           <Ink.Text dimColor>
@@ -309,7 +309,7 @@ for a lot of edge cases so it might return a false positive.
     }
 
     try {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Config API calls{`\n`}</Ink.Text>
           <Ink.Text></Ink.Text>
@@ -331,7 +331,7 @@ for a lot of edge cases so it might return a false positive.
         </Ink.Box>,
       )
     } catch (error) {
-      await this.renderOnce(
+      this.renderOnce(
         <Error
           name="Error analyzing called functions"
           message={error.message ?? error}
@@ -356,7 +356,7 @@ for a lot of edge cases so it might return a false positive.
         ),
       )
     } catch (error) {
-      await this.renderOnce(
+      this.renderOnce(
         <Error
           name={error.name ?? `Configuration error`}
           message={error.message ?? error}
@@ -366,7 +366,7 @@ for a lot of edge cases so it might return a false positive.
 
     if (this.bud.env) {
       try {
-        await this.renderOnce(
+        this.renderOnce(
           <Ink.Box flexDirection="column">
             <Ink.Text color="blue">Environment{`\n`}</Ink.Text>
             {this.bud.env.getEntries().map(([key, value]) => {
@@ -387,7 +387,7 @@ for a lot of edge cases so it might return a false positive.
           </Ink.Box>,
         )
       } catch (error) {
-        await this.renderOnce(
+        this.renderOnce(
           <Error name="Environment error" message={error.message} />,
         )
       }
@@ -395,20 +395,20 @@ for a lot of edge cases so it might return a false positive.
 
     if (this.enabledExtensions) {
       try {
-        await this.renderOnce(
+        this.renderOnce(
           <Ink.Box flexDirection="column">
             <Ink.Text color="blue">Enabled extensions{`\n`}</Ink.Text>
             {this.mapExtensions(this.enabledExtensions)}
           </Ink.Box>,
         )
-        await this.renderOnce(
+        this.renderOnce(
           <Ink.Box flexDirection="column">
             <Ink.Text color="blue">Disabled extensions{`\n`}</Ink.Text>
             {this.mapExtensions(this.disabledExtensions)}
           </Ink.Box>,
         )
       } catch (error) {
-        await this.renderOnce(
+        this.renderOnce(
           <Error name="Extensions" message={error.message ?? error} />,
         )
       }
@@ -421,7 +421,7 @@ for a lot of edge cases so it might return a false positive.
       this.entrypoints[0][1].import[0] === `index` &&
       !(await this.bud.fs.exists(this.bud.path(`@src/index.js`)))
     ) {
-      await this.renderOnce(
+      this.renderOnce(
         <Error
           name="Can't resolve application entrypoint"
           message={`No entrypoint was specified and there is also no file resolvable at \`${this.bud.relPath(
@@ -434,7 +434,7 @@ for a lot of edge cases so it might return a false positive.
     }
 
     if (this.mode === `development`) {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Development server</Ink.Text>
           <Ink.Box flexDirection="row">
@@ -479,7 +479,7 @@ for a lot of edge cases so it might return a false positive.
     try {
       webpack.validate(this.configuration)
 
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box>
           <Ink.Text color="green">
             {figures.tick} webpack validated configuration
@@ -487,7 +487,7 @@ for a lot of edge cases so it might return a false positive.
         </Ink.Box>,
       )
     } catch (error) {
-      await this.renderOnce(
+      this.renderOnce(
         <Ink.Box>
           <Ink.Text color="red">❌ {error?.message ?? error}</Ink.Text>
         </Ink.Box>,

--- a/sources/@roots/bud/src/cli/commands/bud.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.tsx
@@ -133,7 +133,7 @@ export default class BudCommand extends Command<CommandContext> {
     Ink?.render(children)
   }
 
-  public renderOnce(...children: Array<React.ReactElement>) {
+  public renderStatic(...children: Array<React.ReactElement>) {
     Ink?.render(
       <Ink.Static items={children}>
         {(child, id) => <Ink.Box key={id}>{child}</Ink.Box>}
@@ -427,7 +427,7 @@ export default class BudCommand extends Command<CommandContext> {
     }
 
     try {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Display.Error name={error.name} message={error.message} />
           {isWindows() ? <WinError /> : null}

--- a/sources/@roots/bud/src/cli/commands/bud.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.tsx
@@ -133,8 +133,8 @@ export default class BudCommand extends Command<CommandContext> {
     Ink?.render(children)
   }
 
-  public renderStatic(...children: Array<React.ReactElement>) {
-    Ink?.render(
+  public async renderStatic(...children: Array<React.ReactElement>) {
+    return Ink?.render(
       <Ink.Static items={children}>
         {(child, id) => <Ink.Box key={id}>{child}</Ink.Box>}
       </Ink.Static>,
@@ -195,6 +195,8 @@ export default class BudCommand extends Command<CommandContext> {
 
     if (this.withBud) await this.withBud(this.bud)
     await this.bud.processConfigs()
+
+    return this.bud
   }
 
   @bind
@@ -427,7 +429,7 @@ export default class BudCommand extends Command<CommandContext> {
     }
 
     try {
-      this.renderStatic(
+      await this.renderStatic(
         <Ink.Box flexDirection="column">
           <Display.Error name={error.name} message={error.message} />
           {isWindows() ? <WinError /> : null}

--- a/sources/@roots/bud/src/cli/commands/bud.view.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.view.tsx
@@ -59,7 +59,7 @@ export default class BudViewCommand extends BudCommand {
 
     if (this.color) value = highlight(value)
 
-    this.renderStatic(
+    await this.renderStatic(
       <Ink.Box>
         <Ink.Text color="magenta">
           {this.subject ?? `build.config`}

--- a/sources/@roots/bud/src/cli/commands/bud.view.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.view.tsx
@@ -59,7 +59,7 @@ export default class BudViewCommand extends BudCommand {
 
     if (this.color) value = highlight(value)
 
-    await this.renderOnce(
+    this.renderOnce(
       <Ink.Box>
         <Ink.Text color="magenta">
           {this.subject ?? `build.config`}

--- a/sources/@roots/bud/src/cli/commands/bud.view.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.view.tsx
@@ -59,7 +59,7 @@ export default class BudViewCommand extends BudCommand {
 
     if (this.color) value = highlight(value)
 
-    this.renderOnce(
+    this.renderStatic(
       <Ink.Box>
         <Ink.Text color="magenta">
           {this.subject ?? `build.config`}

--- a/sources/@roots/bud/src/cli/commands/doctor/Doctor.tsx
+++ b/sources/@roots/bud/src/cli/commands/doctor/Doctor.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable react/no-unescaped-entities */
+import figures from '@roots/bud-support/figures'
+import * as Ink from 'ink'
+
+import {Error} from '../../components/Error.js'
+import {isWindows} from '../../helpers/isWindows.js'
+
+export const Doctor = ({name, timings}) => {
+  return (
+    <Ink.Box flexDirection="column" marginTop={1}>
+      <Ink.Text underline>{`Diagnosis for ${name}\n`}</Ink.Text>
+      <Ink.Text dimColor>
+        Completed a dry run of your project's build (executed in{` `}
+        {timings.build} seconds). If the information provided by this
+        command doesn't yield a solution consider running `yarn bud repl`
+        and exploring the finalized config (`bud.build.config`).
+      </Ink.Text>
+      <Process />
+    </Ink.Box>
+  )
+}
+
+const Process = () => {
+  return (
+    <Ink.Box marginTop={1} flexDirection="column">
+      <Ink.Text color="blue">Checking system requirements{`\n`}</Ink.Text>
+
+      <Ink.Box flexDirection="column">
+        <Ink.Text>
+          {process.version.match(/v1[6|7|8|9]/)
+            ? figures.tick
+            : figures.cross}
+          {` `}
+          node: {process.version}
+        </Ink.Text>
+
+        <Ink.Text>
+          {isWindows() ? figures.cross : figures.tick} os:{` `}
+          {process.platform}
+        </Ink.Text>
+
+        {!process.version.match(/v1[6|7|8|9]/) && (
+          <Error
+            name="Node version not supported"
+            message={`Please upgrade to Node v18 for long-term support. You are running node ${process.version}.`}
+          />
+        )}
+      </Ink.Box>
+    </Ink.Box>
+  )
+}

--- a/sources/@roots/bud/src/cli/commands/doctor/index.tsx
+++ b/sources/@roots/bud/src/cli/commands/doctor/index.tsx
@@ -10,13 +10,13 @@ import webpack from '@roots/bud-support/webpack'
 import type {InspectTreeResult} from 'fs-jetpack/types.js'
 import * as Ink from 'ink'
 
-import {Error} from '../components/Error.js'
-import {WinError} from '../components/WinError.js'
-import {dry} from '../decorators/command.dry.js'
-import {isWindows} from '../helpers/isWindows.js'
+import {Error} from '../../components/Error.js'
+import {WinError} from '../../components/WinError.js'
+import {dry} from '../../decorators/command.dry.js'
+import {isWindows} from '../../helpers/isWindows.js'
 
 /**
- * `bud doctor` command
+ * bud doctor command
  */
 @dry
 export default class BudDoctorCommand extends BudCommand {
@@ -65,6 +65,8 @@ for a lot of edge cases so it might return a false positive.
    * Execute command
    */
   public override async execute() {
+    const {Doctor} = await import(`./Doctor.js`)
+
     try {
       const buildTimer = this.makeTimer()
       await this.makeBud(this)
@@ -75,31 +77,17 @@ for a lot of edge cases so it might return a false positive.
     }
 
     if (isWindows()) {
-      this.renderOnce(<WinError />)
+      this.renderStatic(<WinError />)
     }
 
-    this.renderOnce(
-      <Ink.Box marginTop={1}>
-        <Ink.Text underline>
-          {`Diagnosis for `}
-          {this.bud.context.manifest.name
-            ? this.bud.context.manifest.name
-            : this.bud.path()}
-        </Ink.Text>
-      </Ink.Box>,
-    )
+    const name = this.bud.context.manifest.name
+      ? this.bud.context.manifest.name
+      : this.bud.path()
 
-    this.renderOnce(
-      <Ink.Text color={`dimWhite`}>
-        Completed a dry run of your project's build (executed in{` `}
-        {this.timings.build} seconds). If the information provided by this
-        command doesn't yield a solution consider running `yarn bud repl`
-        and exploring the finalized config (`bud.build.config`).
-      </Ink.Text>,
-    )
+    this.renderStatic(<Doctor name={name} timings={this.timings} />)
 
     if (await this.bud.fs.exists(this.bud.cache.cacheDirectory)) {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Ink.Text color="yellow">
             {figures.info} Detected compilation cache
@@ -123,38 +111,8 @@ for a lot of edge cases so it might return a false positive.
       )
     }
 
-    this.renderOnce(
-      <Ink.Box flexDirection="column">
-        <Ink.Text color="blue">
-          Checking system requirements{`\n`}
-        </Ink.Text>
-        <Ink.Box flexDirection="column">
-          <Ink.Text>
-            {process.version.match(/v1[6|7|8|9]/)
-              ? figures.tick
-              : figures.cross}
-            {` `}
-            node: {process.version}
-          </Ink.Text>
-          <Ink.Text>
-            {isWindows() ? figures.cross : figures.tick} os:{` `}
-            {process.platform}
-          </Ink.Text>
-        </Ink.Box>
-      </Ink.Box>,
-    )
-
-    if (!process.version.match(/v1[6|7|8|9]/)) {
-      this.renderOnce(
-        <Error
-          name="Node version not supported"
-          message={`Please upgrade to Node v18 for long-term support. You are running node ${process.version}.`}
-        />,
-      )
-    }
-
     if (this.bud.hasChildren) {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Child compilers{`\n`}</Ink.Text>
           {Object.values(this.bud.children).map((child, i) => (
@@ -173,7 +131,7 @@ for a lot of edge cases so it might return a false positive.
       )
     }
 
-    this.renderOnce(
+    this.renderStatic(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">Project paths</Ink.Text>
         <Ink.Text>{` `}</Ink.Text>
@@ -197,7 +155,7 @@ for a lot of edge cases so it might return a false positive.
       </Ink.Box>,
     )
 
-    this.renderOnce(
+    this.renderStatic(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">
           Checking versions of core packages
@@ -259,7 +217,7 @@ for a lot of edge cases so it might return a false positive.
       )
     } catch (e) {}
 
-    this.renderOnce(
+    this.renderStatic(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">
           Checking installed package compatibility{`\n`}
@@ -270,7 +228,7 @@ for a lot of edge cases so it might return a false positive.
       </Ink.Box>,
     )
 
-    this.renderOnce(
+    this.renderStatic(
       <Ink.Box flexDirection="column">
         <Ink.Text color="blue">Mode</Ink.Text>
         <Ink.Text>{this.bud.mode}</Ink.Text>
@@ -281,7 +239,7 @@ for a lot of edge cases so it might return a false positive.
       this.bud.context.files ? Object.values(this.bud.context.files) : []
     ).filter(({bud}) => bud)
     if (configFiles.length) {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Bud configuration files{`\n`}</Ink.Text>
           {configFiles.map(({name, path}, i) => (
@@ -298,7 +256,7 @@ for a lot of edge cases so it might return a false positive.
         </Ink.Box>,
       )
     } else {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Registered configurations{`\n`}</Ink.Text>
           <Ink.Text dimColor>
@@ -309,7 +267,7 @@ for a lot of edge cases so it might return a false positive.
     }
 
     try {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Config API calls{`\n`}</Ink.Text>
           <Ink.Text></Ink.Text>
@@ -331,7 +289,7 @@ for a lot of edge cases so it might return a false positive.
         </Ink.Box>,
       )
     } catch (error) {
-      this.renderOnce(
+      this.renderStatic(
         <Error
           name="Error analyzing called functions"
           message={error.message ?? error}
@@ -356,7 +314,7 @@ for a lot of edge cases so it might return a false positive.
         ),
       )
     } catch (error) {
-      this.renderOnce(
+      this.renderStatic(
         <Error
           name={error.name ?? `Configuration error`}
           message={error.message ?? error}
@@ -366,7 +324,7 @@ for a lot of edge cases so it might return a false positive.
 
     if (this.bud.env) {
       try {
-        this.renderOnce(
+        this.renderStatic(
           <Ink.Box flexDirection="column">
             <Ink.Text color="blue">Environment{`\n`}</Ink.Text>
             {this.bud.env.getEntries().map(([key, value]) => {
@@ -387,7 +345,7 @@ for a lot of edge cases so it might return a false positive.
           </Ink.Box>,
         )
       } catch (error) {
-        this.renderOnce(
+        this.renderStatic(
           <Error name="Environment error" message={error.message} />,
         )
       }
@@ -395,20 +353,20 @@ for a lot of edge cases so it might return a false positive.
 
     if (this.enabledExtensions) {
       try {
-        this.renderOnce(
+        this.renderStatic(
           <Ink.Box flexDirection="column">
             <Ink.Text color="blue">Enabled extensions{`\n`}</Ink.Text>
             {this.mapExtensions(this.enabledExtensions)}
           </Ink.Box>,
         )
-        this.renderOnce(
+        this.renderStatic(
           <Ink.Box flexDirection="column">
             <Ink.Text color="blue">Disabled extensions{`\n`}</Ink.Text>
             {this.mapExtensions(this.disabledExtensions)}
           </Ink.Box>,
         )
       } catch (error) {
-        this.renderOnce(
+        this.renderStatic(
           <Error name="Extensions" message={error.message ?? error} />,
         )
       }
@@ -421,7 +379,7 @@ for a lot of edge cases so it might return a false positive.
       this.entrypoints[0][1].import[0] === `index` &&
       !(await this.bud.fs.exists(this.bud.path(`@src/index.js`)))
     ) {
-      this.renderOnce(
+      this.renderStatic(
         <Error
           name="Can't resolve application entrypoint"
           message={`No entrypoint was specified and there is also no file resolvable at \`${this.bud.relPath(
@@ -434,7 +392,7 @@ for a lot of edge cases so it might return a false positive.
     }
 
     if (this.mode === `development`) {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box flexDirection="column">
           <Ink.Text color="blue">Development server</Ink.Text>
           <Ink.Box flexDirection="row">
@@ -479,7 +437,7 @@ for a lot of edge cases so it might return a false positive.
     try {
       webpack.validate(this.configuration)
 
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box>
           <Ink.Text color="green">
             {figures.tick} webpack validated configuration
@@ -487,7 +445,7 @@ for a lot of edge cases so it might return a false positive.
         </Ink.Box>,
       )
     } catch (error) {
-      this.renderOnce(
+      this.renderStatic(
         <Ink.Box>
           <Ink.Text color="red">❌ {error?.message ?? error}</Ink.Text>
         </Ink.Box>,

--- a/sources/@roots/bud/src/cli/commands/repl/Repl.tsx
+++ b/sources/@roots/bud/src/cli/commands/repl/Repl.tsx
@@ -1,7 +1,4 @@
-import {dry} from '@roots/bud/cli/decorators'
 import type {Bud} from '@roots/bud-framework'
-import {bind} from '@roots/bud-framework/extension/decorators'
-import {Command, Option} from '@roots/bud-support/clipanion'
 import {highlight} from '@roots/bud-support/highlight'
 import chunk from '@roots/bud-support/lodash/chunk'
 import format from '@roots/bud-support/pretty-format'
@@ -9,55 +6,13 @@ import * as Ink from 'ink'
 import TextInput from 'ink-text-input'
 import {useEffect, useState} from 'react'
 
-import BudCommand, {ArgsModifier} from './bud.js'
-
-/**
- * `bud repl`
- */
-@dry
-export default class BudReplCommand extends BudCommand {
-  public static override paths = [[`repl`]]
-  public static override usage = Command.Usage({
-    description: `Use bud in a repl`,
-    examples: [[`repl`, `$0 repl`]],
-  })
-  public override withArguments = ArgsModifier({dry: true})
-
-  public color = Option.Boolean(`--color,-c`, true, {
-    description: `use syntax highlighting`,
-  })
-
-  public indent = Option.String(`--indent,-i`, `1`, {
-    description: `indentation level`,
-    tolerateBoolean: false,
-  })
-
-  public depth = Option.String(`--depth,-d`, `1`, {
-    description: `recursion depth`,
-    tolerateBoolean: false,
-  })
-
-  /**
-   * Execute command
-   */
-  @bind
-  public override async execute() {
-    await this.makeBud(this)
-    await this.bud.run()
-
-    await this.render(
-      <Repl app={this.bud} indent={this.indent} depth={this.depth} />,
-    )
-  }
-}
-
 interface ReplProps {
   app: Bud
   indent: string
   depth: string
 }
 
-const Repl = ({app, indent, depth}: ReplProps) => {
+export const Repl = ({app, indent, depth}: ReplProps) => {
   const [search, setSearch] = useState(``)
   const [result, setResult] = useState(``)
   const [paged, setPaged] = useState([])

--- a/sources/@roots/bud/src/cli/commands/repl/index.tsx
+++ b/sources/@roots/bud/src/cli/commands/repl/index.tsx
@@ -1,0 +1,62 @@
+import {dry} from '@roots/bud/cli/decorators'
+import {bind} from '@roots/bud-framework/extension/decorators'
+import {Command, Option} from '@roots/bud-support/clipanion'
+
+import BudCommand from '../bud.js'
+
+/**
+ * bud repl command
+ */
+@dry
+export default class BudReplCommand extends BudCommand {
+  /**
+   * Command paths
+   */
+  public static override paths = [[`repl`]]
+
+  /**
+   * Command usage
+   */
+  public static override usage = Command.Usage({
+    description: `Use bud in a repl`,
+    examples: [[`repl`, `$0 repl`]],
+  })
+
+  /**
+   * `--color`
+   */
+  public color = Option.Boolean(`--color,-c`, true, {
+    description: `use syntax highlighting`,
+  })
+
+  /**
+   * `--indent`
+   */
+  public indent = Option.String(`--indent,-i`, `1`, {
+    description: `indentation level`,
+    tolerateBoolean: false,
+  })
+
+  /**
+   * `--depth`
+   */
+  public depth = Option.String(`--depth,-d`, `1`, {
+    description: `recursion depth`,
+    tolerateBoolean: false,
+  })
+
+  /**
+   * Execute command
+   */
+  @bind
+  public override async execute() {
+    await this.makeBud(this)
+    await this.bud.run()
+
+    const {Repl} = await import(`./Repl.js`)
+
+    this.render(
+      <Repl app={this.bud} indent={this.indent} depth={this.depth} />,
+    )
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8305,6 +8305,7 @@ __metadata:
     "@types/react": 18.0.28
     chalk: 5.2.0
     ink: 4.0.0
+    ink-spinner: 5.0.0
     ink-text-input: 5.0.0
     react: 18.2.0
     tslib: 2.5.0
@@ -14833,7 +14834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.6.1":
+"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.6.1, cli-spinners@npm:^2.7.0":
   version: 2.7.0
   resolution: "cli-spinners@npm:2.7.0"
   checksum: a9afaf73f58d1f951fb23742f503631b3cf513f43f4c7acb1b640100eb76bfa16efbcd1994d149ffc6603a6d75dd3d4a516a76f125f90dce437de9b16fd0ee6f
@@ -21743,6 +21744,18 @@ __metadata:
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
+  languageName: node
+  linkType: hard
+
+"ink-spinner@npm:5.0.0":
+  version: 5.0.0
+  resolution: "ink-spinner@npm:5.0.0"
+  dependencies:
+    cli-spinners: ^2.7.0
+  peerDependencies:
+    ink: ">=4.0.0"
+    react: ">=18.0.0"
+  checksum: 88e547ff56ac8ee31239daef43b03ca2797eb20cc338ad25aba8e8fbe2cb322ea212494f8c545f327d345051be50542e1a27fdee3758a32a1b4a5db5308cad63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Ink static renderer has to be handed differently since we jettisoned the Ink@v3 code.

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
