### PR TITLE
docs: `bud-tailwindcss` - fix tailwind website URL

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
@@ -6,7 +6,7 @@ import {Install} from '@site/src/docs/Install'
 
 # @roots/bud-tailwindcss
 
-[TailwindCSS](https://tailwindcss.org) support can be added by installing the [@roots/bud-tailwindcss](/extensions/bud-tailwindcss) extension.
+[TailwindCSS](https://tailwindcss.com) support can be added by installing the [@roots/bud-tailwindcss](/extensions/bud-tailwindcss) extension.
 
 ## Installation
 


### PR DESCRIPTION
`bud-tailwindcss` documentation links to the wrong URL for the Tailwind site.

refers:

- none

## Type of change

**NONE: internal change**

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
