### PR TITLE
docs: `bud-vue` update syntax for `runtimeOnly`

### DIFF
--- a/sources/@roots/bud-vue/README.md
+++ b/sources/@roots/bud-vue/README.md
@@ -40,7 +40,7 @@ You can disable the `runtimeOnly` default by adding the following to your config
 
 ```js
 export default async (bud) => {
-  bud.vue.runtimeOnly(false);
+  bud.vue.set('runtimeOnly', false);
 };
 ```
 


### PR DESCRIPTION
`@roots/bud-vue` readme refers to the deprecated syntax to set `runtimeOnly`. Use of this old syntax (`bud.vue.runtimeOnly(false)`) triggers a deprecation warning as of at least Bud 6.11.x.

PR changes this to the suggested syntax of `bud.vue.set('runtimeOnly', false)`

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
