### PR TITLE
docs: `options.serve`: point to `mkcert` for local SSL workflow

### DIFF
--- a/sources/@roots/bud-api/docs/serve/setting-options.md
+++ b/sources/@roots/bud-api/docs/serve/setting-options.md
@@ -27,8 +27,8 @@ bud.serve(`https://dev.example.test`, {
 | port     | `number`                                                    | [URL['port']](https://developer.mozilla.org/en-US/docs/Web/API/URL/port)         |
 | url      | [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) | [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL)                      |
 | ssl      | `boolean`                                                   | Is the server `https` enabled?                                                   |
-| cert     | `string`                                                    | The ssl certificate path                                                         |
-| key      | `string`                                                    | The ssl key path                                                                 |
+| cert     | `string`                                                    | The SSL certificate path                                                         |
+| key      | `string`                                                    | The SSL key path                                                                 |
 | options  | [`Https.ServerOptions`](https://nodejs.org/api/https.html)  | Direct access to the server options                                              |
 
 ### Setting the origin
@@ -63,9 +63,40 @@ bud.serve({
 })
 ```
 
-Note in the example above that the `cert` and `key` are paths. This is different than [the Node API](https://nodejs.org/api/https.html), which both expect a [Buffer](https://nodejs.org/api/buffer.html).
+Note in the example above that the `cert` and `key` are paths. This is different than [the Node API](https://nodejs.org/api/https.html), which both expect a [Buffer](https://nodejs.org/api/buffer.html). If you don't already have a certificate and key available (likely the case in local development), see the section on the subject below.
 
 You don't need to include `ssl` if you are using the `url` property. It will be inferred from the URL's protocol.
+
+#### Generating an SSL certificate and key for local development
+
+You can use [`mkcert`][mkcert-repo] to quickly (yes, quickly!) generate an SSL cert and key (for local development only).
+
+In short, that might look something like this if you're on macOS and want to use the default `0.0.0.0` aka `localhost` setting:
+
+```sh
+brew install mkcert
+mkcert -install 
+mkcert localhost
+```
+
+The above commands should result in the creation of two `.pem` files in your current directory -- **make sure to add `*.pem` to your `.gitignore` if it's not already there!**
+
+Then you can specify those files in your config:
+
+```ts title='bud.config.js'
+bud.serve({
+  ssl: true,
+  host: 'localhost',
+  port: 3000,
+  cert: bud.path('localhost.pem'),
+  key: bud.path('localhost-key.pem'),
+})
+```
+
+For more info, check out the "How to use HTTPS for local development" [tutorial from the Google Chrome Developer Relations team on `web.dev`][mkcert-guide]. 
+
+[mkcert-repo]: https://github.com/FiloSottile/mkcert
+[mkcert-guide]: https://web.dev/how-to-use-local-https/
 
 ### Using the Node API
 


### PR DESCRIPTION
<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

refers:

- none

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

This PR includes breaking changes to the following core packages:

- none

This PR includes breaking changes to the follow extensions:

- none

## Dependencies

### Adds

- none

### Removes

- none
