### PR TITLE
✨ improve(@roots/bud-support): resolve esbuild-wasm

### DIFF
--- a/sources/@roots/bud-framework/src/extension/decorators/index.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/index.ts
@@ -1,4 +1,4 @@
-import {bind, once} from '@roots/bud-support/decorators'
+import {bind} from '@roots/bud-support/decorators'
 
 import {dependsOn} from './dependsOn.js'
 import {dependsOnOptional} from './dependsOnOptional.js'
@@ -19,7 +19,6 @@ export {
   disabled,
   expose,
   label,
-  once,
   options,
   plugin,
   production,

--- a/sources/@roots/bud-support/package.json
+++ b/sources/@roots/bud-support/package.json
@@ -141,7 +141,6 @@
     "file-loader": "^6.2.0",
     "get-port": "6.1.2",
     "globby": "13.1.3",
-    "helpful-decorators": "2.1.0",
     "highlight.js": "11.7.0",
     "html-loader": "^4.2.0",
     "html-webpack-plugin": "5.5.0",

--- a/sources/@roots/bud-support/src/decorators/bind.ts
+++ b/sources/@roots/bud-support/src/decorators/bind.ts
@@ -1,0 +1,54 @@
+/**
+ * Credit: https://github.com/andreypopp/autobind-decorator/blob/master/src/index.js
+ * Return a descriptor removing the value and returning a getter
+ * The getter will return a .bind version of the function
+ * and memoize the result against a symbol on the instance
+ */
+export function bind(target: any, key: any, descriptor: any) {
+  let fn = descriptor.value
+
+  if (typeof fn !== `function`) {
+    throw new Error(
+      `@autobind decorator can only be applied to methods not: ${typeof fn}`,
+    )
+  } // In IE11 calling Object.defineProperty has a side-effect of evaluating the
+  // getter for the property which is being replaced. This causes infinite
+  // recursion and an "Out of stack space" error.
+
+  let definingProperty = false
+  return {
+    configurable: true,
+
+    get() {
+      if (
+        definingProperty ||
+        this === target.prototype ||
+        this.hasOwnProperty(key) ||
+        typeof fn !== `function`
+      ) {
+        return fn
+      }
+
+      let boundFn = fn.bind(this)
+      definingProperty = true
+      Object.defineProperty(this, key, {
+        configurable: true,
+
+        get() {
+          return boundFn
+        },
+
+        set(value) {
+          fn = value
+          delete this[key]
+        },
+      })
+      definingProperty = false
+      return boundFn
+    },
+
+    set(value: any) {
+      fn = value
+    },
+  }
+}

--- a/sources/@roots/bud-support/src/decorators/index.ts
+++ b/sources/@roots/bud-support/src/decorators/index.ts
@@ -1,2 +1,2 @@
 export {deprecated} from './deprecated.js'
-export * from 'helpful-decorators'
+export {bind} from './bind.js'

--- a/sources/@roots/bud-support/src/esbuild/index.ts
+++ b/sources/@roots/bud-support/src/esbuild/index.ts
@@ -1,12 +1,44 @@
-let esbuild: typeof import('esbuild-wasm')
+import {resolve} from 'import-meta-resolve'
 
-export const getImplementation = async () => {
-  if (esbuild) return esbuild
-  try {
-    esbuild = await import(`esbuild`)
-  } catch (err) {
-    esbuild = await import(`esbuild-wasm`)
+import logger from '../logger/index.js'
+
+let path: string
+
+let transformer: typeof import('esbuild-wasm')
+
+export const getImplementation = async (context: string) => {
+  if (transformer) return transformer
+
+  const sources: Array<[string, string]> = [
+    [`esbuild`, context],
+    [`esbuild`, import.meta.url],
+    [`esbuild-wasm`, context],
+    [`esbuild-wasm`, import.meta.url],
+  ]
+
+  await sources.reduce(async (promised, props) => {
+    await promised
+    if (transformer) return
+    await trySource(...props)
+  }, Promise.resolve())
+
+  if (!transformer) {
+    throw new Error(`Neither esbuild nor esbuild-wasm could be found.`)
   }
 
-  return esbuild
+  return transformer
+}
+
+async function trySource(signifier: string, context: any) {
+  try {
+    path = await resolve(signifier, context)
+    logger.log(
+      `using transformer:`,
+      path,
+      `resolved from context:`,
+      context,
+    )
+    transformer = await import(path)
+    return transformer
+  } catch (err) {}
 }

--- a/sources/@roots/bud-support/src/utilities/files.ts
+++ b/sources/@roots/bud-support/src/utilities/files.ts
@@ -241,9 +241,10 @@ async function transformConfig({
   cachePath: string
 }): Promise<any> {
   logger.time(`compiling ${file.name}`)
+
   if (!transformer) {
     transformer = await import(`../esbuild/index.js`).then(
-      async ({getImplementation}) => await getImplementation(),
+      async ({getImplementation}) => await getImplementation(file.path),
     )
   }
 

--- a/sources/@roots/bud-support/src/utilities/logger.ts
+++ b/sources/@roots/bud-support/src/utilities/logger.ts
@@ -1,7 +1,7 @@
 /* eslint-disable n/no-process-env */
-import {bind} from 'helpful-decorators'
 import Signale, {SignaleOptions} from 'signale'
 
+import {bind} from '../decorators/index.js'
 import isUndefined from '../lodash/isUndefined/index.js'
 import args from './args.js'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8099,7 +8099,6 @@ __metadata:
     file-loader: ^6.2.0
     get-port: 6.1.2
     globby: 13.1.3
-    helpful-decorators: 2.1.0
     highlight.js: 11.7.0
     html-loader: ^4.2.0
     html-webpack-plugin: 5.5.0
@@ -15278,9 +15277,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001400, caniuse-lite@npm:^1.0.30001407, caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001464":
-  version: 1.0.30001473
-  resolution: "caniuse-lite@npm:1.0.30001473"
-  checksum: 007ad17463612d38080fc59b5fa115ccb1016a1aff8daab92199a7cf8eb91cf987e85e7015cb0bca830ee2ef45f252a016c29a98a6497b334cceb038526b73f1
+  version: 1.0.30001481
+  resolution: "caniuse-lite@npm:1.0.30001481"
+  checksum: 8200a043c191b4fd4fe0beda37a58fd61869c895ab93f87bdd0420e5927453f48434d716ce9da8552ff6c3ecc4dcd1366354cda3a134f3cc844af741574a7cab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Improve resolution of `esbuild`/`esbuild-wasm` to prevent duplicate modules in the tree
- Vendor `bind` from `helpful-decorators` to reduce overall import cost (this module is used in a lot of places)

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
