### PR TITLE
✨ improve(@roots/bud): show cached module count

### DIFF
--- a/sources/@roots/bud-dashboard/src/dashboard/compilation/compilation.component.tsx
+++ b/sources/@roots/bud-dashboard/src/dashboard/compilation/compilation.component.tsx
@@ -74,6 +74,10 @@ const Compilation = ({
     0,
   )
 
+  const uncachedModuleCount = compilation.modules?.filter(
+    module => !module.cached,
+  )?.length
+
   return (
     <Ink.Box flexDirection="column">
       <Ink.Box flexDirection="row">
@@ -199,7 +203,9 @@ const Compilation = ({
 
       <Title final finalFigure={figures.lineUpRightArc}>
         <Ink.Text dimColor>
-          compiled {compilation.modules?.length} modules in{` `}
+          compiled {compilation.modules?.length} modules (
+          {compilation.modules?.length - uncachedModuleCount} cached) in
+          {` `}
           {duration(compilation.time) as string}
         </Ink.Text>
       </Title>

--- a/sources/@roots/bud-vue/src/extension.ts
+++ b/sources/@roots/bud-vue/src/extension.ts
@@ -57,15 +57,12 @@ export default class Vue extends Extension<
   public override async register(bud: Bud) {
     bud.build
       .setLoader(`vue`, await this.resolve(`vue-loader`, import.meta.url))
-      .setItem(`vue`, {ident: `vue`, loader: `vue`})
       .setLoader(
         `vue-style`,
         await this.resolve(`vue-style-loader`, import.meta.url),
       )
-      .setItem(`vue-style`, {
-        ident: `vue-style`,
-        loader: `vue-style`,
-      })
+      .setItem(`vue`, {ident: `vue`, loader: `vue`})
+      .setItem(`vue-style`, {ident: `vue-style`, loader: `vue-style`})
   }
 
   /**
@@ -98,7 +95,8 @@ export default class Vue extends Extension<
       config.module.rules = [
         {
           test: bud.hooks.filter(`pattern.vue`),
-          include: [bud.path(`@src`)],
+          include: [bud.path(`@src`), bud.path(`@modules`)],
+          exclude: [/node_modules/],
           use: [bud.build.items.vue.toWebpack()],
         },
         ...config.module.rules.flatMap(rule =>


### PR DESCRIPTION
show cached module count in terminal dashboard

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
