### PR TITLE
🩹 fix(create-bud-app): add typescript when using eslint/swc

### DIFF
--- a/sources/create-bud-app/src/commands/create.ts
+++ b/sources/create-bud-app/src/commands/create.ts
@@ -442,6 +442,10 @@ export default class CreateCommand extends Command {
 
     if (this.support.includes(`eslint`)) {
       this.devDependencies.push(`@roots/eslint-config`)
+
+      if (this.support.includes(`swc`)) {
+        this.devDependencies.push(`typescript`)
+      }
     }
 
     await writePackageJSONTask(this)

--- a/sources/create-bud-app/src/commands/create.ts
+++ b/sources/create-bud-app/src/commands/create.ts
@@ -443,7 +443,10 @@ export default class CreateCommand extends Command {
     if (this.support.includes(`eslint`)) {
       this.devDependencies.push(`@roots/eslint-config`)
 
-      if (this.support.includes(`swc`)) {
+      if (
+        this.support.includes(`swc`) &&
+        !this.support.includes(`typescript`)
+      ) {
         this.devDependencies.push(`typescript`)
       }
     }


### PR DESCRIPTION
When building a project with `eslint` and `swc` support we need to add `typescript` as a project devDependency. It is a required peer dependency of `@typescript-eslint/eslint-plugin`. 

Fixes errors like:

```
$ ./node_modules/.bin/bud build production

╭─ ✘ test-app ./dist [978f474f1b337ae9d71e]
│
├─ ✘  error
│
│  Failed to load plugin '@typescript-eslint' declared in 'CLIOptions »
@roots/eslint-config/typescript': Cannot find module 'typescript'
│ Require stack:
│ - ./node_modules/@typescript-eslint/eslint-plugin/dist/util/astUtils.js
│ - ./node_modules/@typescript-eslint/eslint-plugin/dist/util/index.js
│ - ./node_modules/@typescript-eslint/eslint-plugin/dist/rules/adjacent-overload
-signatures.js
│ - ./node_modules/@typescript-eslint/eslint-plugin/dist/rules/index.js
│ - ./node_modules/@typescript-eslint/eslint-plugin/dist/index.js
│ - ./node_modules/@eslint/eslintrc/dist/eslintrc.cjs
│ Referenced from: ./node_modules/@roots/eslint-config/typescript.cjs
│
├─ ✘  error
│
│  Child compilation failed:
│    Failed to load plugin '@typescript-eslint' declared in 'CLIOptions »
@roots/eslint-config/typescript': Cannot find module 'typescript'
│   Require stack:
│   - ./node_modules/@typescript-eslint/eslint-plugin/dist/util/astUtils.js
│   - ./node_modules/@typescript-eslint/eslint-plugin/dist/util/index.js
│   - ./node_modules/@typescript-eslint/eslint-plugin/dist/rules/adjacent-overload-signatures.js
│   - ./node_modules/@typescript-eslint/eslint-plugin/dist/rules/index.js
│   - ./node_modules/@typescript-eslint/eslint-plugin/dist/index.js
│   - ./node_modules/@eslint/eslintrc/dist/eslintrc.cjs
│   Referenced from: ./node_modules/@roots/eslint-config/typescript.cjs
│
│   - child-compiler.js:169
│     /lib/child-compiler.js:169:18
│
│   - Compiler.js:551 finalCallback
│     /lib/Compiler.js:551:5
│
│   - Compiler.js:577
│     /lib/Compiler.js:577:11
│
│   - Compiler.js:1199
│     /lib/Compiler.js:1199:17
│
│
│   - Hook.js:18 Hook.CALL_ASYNC_DELEGATE
│     /lib/Hook.js:18:14
│
│   - Compiler.js:1195
│     /lib/Compiler.js:1195:33
│
│   - Compilation.js:2789 finalCallback
│     /lib/Compilation.js:2789:11
│
│   - Compilation.js:3094
│     /lib/Compilation.js:3094:11
│
│
│
│
├─ entrypoints
│  └─ app
│     ├─ css/app.css  635 bytes
│     └─ js/app.js    142.09 kB
│
├─ assets
│  ├─ index.html     1.8 kB
│  └─ logo.svg      1.21 kB
│
╰─ compiled 23 modules (0 cached) in 2s 122ms

╭─ ✘ HtmlWebpackCompiler ./dist [081b6b119589d9322dc4]
│
╰─ compiled 7 modules (0 cached) in 386ms
```

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
