### PR TITLE
✨ feat(@roots/bud): support tsconfig compilerOptions.paths

### DIFF
--- a/sources/@roots/bud-api/src/methods/alias/handleRecords.ts
+++ b/sources/@roots/bud-api/src/methods/alias/handleRecords.ts
@@ -11,10 +11,10 @@ export async function handleRecords(bud: Bud, input: Parameters) {
   const validation = await schema.records.safeParseAsync(input[0])
   if (!validation.success) handleTypeError(bud, `bud.alias`, validation)
 
-  const aliases = await bud.hooks.filterAsync(`build.resolve.alias`, {
-    '@src': bud.path(`@src`),
-  })
-  bud.hooks.async(`build.resolve.alias`, {...aliases, ...validation.data})
+  bud.hooks.async(`build.resolve.alias`, async (paths = {}) => ({
+    ...paths,
+    ...validation.data,
+  }))
 
   return bud
 }

--- a/sources/@roots/bud-api/src/methods/alias/handleSignifierValuePair.ts
+++ b/sources/@roots/bud-api/src/methods/alias/handleSignifierValuePair.ts
@@ -14,10 +14,10 @@ export async function handleSignifierValuePair(
   const signifier = await getParameter(bud, input, 0)
   const value = await getParameter(bud, input, 1)
 
-  const aliases = await bud.hooks.filterAsync(`build.resolve.alias`, {
-    '@src': bud.path(`@src`),
-  })
-  bud.hooks.async(`build.resolve.alias`, {...aliases, [signifier]: value})
+  bud.hooks.async(`build.resolve.alias`, async (paths = {}) => ({
+    ...paths,
+    [signifier]: value,
+  }))
 
   return bud
 }

--- a/sources/@roots/bud-api/src/methods/alias/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/alias/index.test.ts
@@ -28,14 +28,13 @@ describe(`bud.alias`, () => {
     const asyncSpy = vi.spyOn(bud.hooks, `async`)
     await alias({'@foo': bud.path(`@src`, `foo`)})
 
-    expect(asyncSpy).toHaveBeenCalledWith(`build.resolve.alias`, {
-      '@src': bud.path(`@src`),
-      '@foo': bud.path(`@src`, `foo`),
-    })
+    expect(asyncSpy).toHaveBeenCalledWith(
+      `build.resolve.alias`,
+      expect.any(Function),
+    )
 
     const value = await bud.hooks.filterAsync(`build.resolve.alias`)
     expect(value).toEqual({
-      '@src': bud.path(`@src`),
       '@foo': bud.path(`@src`, `foo`),
     })
   })
@@ -45,7 +44,7 @@ describe(`bud.alias`, () => {
     await alias('test', 'test')
     expect(asyncSpy).toHaveBeenCalledWith(
       `build.resolve.alias`,
-      expect.objectContaining({test: `test`}),
+      expect.any(Function),
     )
   })
 
@@ -54,7 +53,6 @@ describe(`bud.alias`, () => {
     const value = await bud.hooks.filterAsync(`build.resolve.alias`)
 
     expect(value).toEqual({
-      '@src': bud.path(`@src`),
       '@foo': bud.path(`@src/foo`),
     })
   })

--- a/sources/@roots/bud-build/src/config/index.test.ts
+++ b/sources/@roots/bud-build/src/config/index.test.ts
@@ -74,9 +74,6 @@ describe(`bud.build.config`, function () {
   it(`should have expected resolve.alias default`, async () => {
     expect(build.config.resolve?.alias).toEqual({
       '@src': bud.path(`@src`),
-      '@scripts': bud.path(`@src/scripts`),
-      '@styles': bud.path(`@src/styles`),
-      '@components': bud.path(`@src`, `scripts`, `components`),
     })
   })
 

--- a/sources/@roots/bud-build/src/config/resolve.ts
+++ b/sources/@roots/bud-build/src/config/resolve.ts
@@ -1,25 +1,24 @@
 import type {Factory} from './index.js'
 
 export const resolve: Factory<`resolve`> = async bud => {
-  const paths: Record<string, Array<string>> = {
-    ...(bud.context.files[`tsconfig.json`]?.module?.compilerOptions
-      ?.paths ?? {}),
-    ...(bud.context.files[`jsconfig.json`]?.module?.compilerOptions
-      ?.paths ?? {}),
-  }
+  const compilerOptions =
+    bud.context.files[`tsconfig.json`]?.module?.compilerOptions ??
+    bud.context.files[`jsconfig.json`]?.module?.compilerOptions
 
-  const aliases = Object.entries(paths).reduce(
-    (acc, [key, tsConfValue]): Record<string, string> => {
-      const value = tsConfValue[0]
-
-      if (key.includes(`*`) || value.includes(`*`)) {
-        return acc
-      }
-
-      return {...acc, [key]: bud.path(value)}
-    },
-    {'@src': bud.path(`@src`)},
-  )
+  const aliases = compilerOptions?.paths
+    ? Object.entries(compilerOptions.paths)
+        .map(([k, v]: [string, Array<string>]) => [k, v[0]])
+        .map(tuple => tuple.map((str: string) => str.replace(`/*`, ``)))
+        .reduce(
+          (acc, [key, value]): Record<string, string> => ({
+            ...(acc ?? {}),
+            [key]: compilerOptions.baseUrl
+              ? bud.path(compilerOptions.baseUrl, value)
+              : bud.path(value),
+          }),
+          {'@src': bud.path(`@src`)},
+        )
+    : {}
 
   return await bud.hooks.filterAsync(`build.resolve`, {
     alias: await bud.hooks.filterAsync(`build.resolve.alias`, aliases),

--- a/sources/@roots/bud-build/src/config/resolve.ts
+++ b/sources/@roots/bud-build/src/config/resolve.ts
@@ -1,27 +1,11 @@
 import type {Factory} from './index.js'
 
 export const resolve: Factory<`resolve`> = async bud => {
-  const compilerOptions =
-    bud.context.files[`tsconfig.json`]?.module?.compilerOptions ??
-    bud.context.files[`jsconfig.json`]?.module?.compilerOptions
-
-  const aliases = compilerOptions?.paths
-    ? Object.entries(compilerOptions.paths)
-        .map(([k, v]: [string, Array<string>]) => [k, v[0]])
-        .map(tuple => tuple.map((str: string) => str.replace(`/*`, ``)))
-        .reduce(
-          (acc, [key, value]): Record<string, string> => ({
-            ...(acc ?? {}),
-            [key]: compilerOptions.baseUrl
-              ? bud.path(compilerOptions.baseUrl, value)
-              : bud.path(value),
-          }),
-          {'@src': bud.path(`@src`)},
-        )
-    : {}
-
   return await bud.hooks.filterAsync(`build.resolve`, {
-    alias: await bud.hooks.filterAsync(`build.resolve.alias`, aliases),
+    alias: {
+      [`@src`]: bud.path(`@src`),
+      ...(await bud.hooks.filterAsync(`build.resolve.alias`, {})),
+    },
     extensionAlias: await bud.hooks.filterAsync(
       `build.resolve.extensionAlias`,
       {

--- a/sources/@roots/bud-extensions/src/extensions/index.ts
+++ b/sources/@roots/bud-extensions/src/extensions/index.ts
@@ -6,6 +6,7 @@ import BudFixStyleOnlyEntrypoints from './fix-style-only-entrypoints/index.js'
 import HtmlWebpackPlugin from './html-webpack-plugin/index.js'
 import InterpolateHtmlPlugin from './interpolate-html-webpack-plugin/index.js'
 import MiniCssExtractPlugin from './mini-css-extract-plugin/index.js'
+import BudTsConfigValues from './tsconfig-values/index.js'
 import WebpackDefinePlugin from './webpack-define-plugin/index.js'
 import WebpackHotModuleReplacementPlugin from './webpack-hot-module-replacement-plugin/index.js'
 import WebpackManifestPlugin from './webpack-manifest-plugin/index.js'
@@ -15,6 +16,7 @@ export {
   BudCDN,
   BudESM,
   BudFixStyleOnlyEntrypoints,
+  BudTsConfigValues,
   CleanWebpackPlugin,
   CopyWebpackPlugin,
   HtmlWebpackPlugin,

--- a/sources/@roots/bud-extensions/src/extensions/tsconfig-values/index.ts
+++ b/sources/@roots/bud-extensions/src/extensions/tsconfig-values/index.ts
@@ -1,0 +1,104 @@
+import {join} from 'node:path'
+
+import type {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+import {
+  disabled,
+  expose,
+  label,
+  options,
+} from '@roots/bud-framework/extension/decorators'
+import isString from '@roots/bud-support/lodash/isString'
+
+type Options = Record<string, any>
+
+/**
+ * Read tsconfig values and apply to bud.js
+ */
+@label(`@roots/bud-extensions/tsconfig-values`)
+@expose(`tsconfig`)
+@options<Options>({})
+@disabled
+export default class BudTsConfigValues extends Extension<Options> {
+  /**
+   * {@link Extension.register}
+   */
+  public override async register(bud: Bud) {
+    this.setOptions(
+      bud.context.files[`tsconfig.json`]?.module ??
+        bud.context.files[`jsconfig.json`]?.module ??
+        {},
+    )
+
+    if (this.get(`bud.useCompilerOptions`)) this.enable()
+  }
+
+  /**
+   * {@link Extension.buildBefore}
+   */
+  public override async configAfter(bud: Bud) {
+    if (!this.enabled) return
+
+    const baseDir =
+      this.get(`compilerOptions.rootDir`) ??
+      this.get(`compilerOptions.baseUrl`)
+
+    if (baseDir) {
+      this.logger.log(
+        `setting @src dir as specified in jsconfig/tsconfig: ${baseDir}`,
+      )
+      bud.setPath({'@src': baseDir})
+    }
+    const outDir = this.get(`compilerOptions.outDir`)
+    if (outDir) {
+      this.logger.log(
+        `setting @dist dir as specified in jsconfig/tsconfig: ${outDir}`,
+      )
+      bud.setPath({'@dist': outDir})
+    }
+
+    const tsConfigPaths = this.get(`compilerOptions.paths`)
+      ? Object.entries(this.get(`compilerOptions.paths`))
+          .map(([k, v]: [string, Array<string>]) => [k, v[0]])
+          .map(tuple => tuple.map((str: string) => str.replace(`/*`, ``)))
+          .reduce(
+            (acc, [key, value]): Record<string, string> => ({
+              ...(acc ?? {}),
+              [key]: baseDir
+                ? bud.path(join(baseDir, value))
+                : bud.path(value),
+            }),
+            {},
+          )
+      : {}
+
+    if (tsConfigPaths) {
+      ;[
+        bud.setPath,
+        // @ts-ignore
+        bud.alias,
+      ].forEach(fn => fn(tsConfigPaths))
+    }
+
+    const include: Array<string> = this.get(`include`)
+    const directories: Array<string> = (
+      await Promise.all(
+        include.map(async (path: string) => {
+          const type = await bud.fs.exists(path)
+          return type === `dir` && !path.match(/^\.?\/?config/)
+            ? path
+            : undefined
+        }),
+      )
+    ).filter(isString)
+
+    if (directories.length) {
+      this.logger.log(
+        `compiling paths as specified in jsconfig/tsconfig:`,
+        ...directories,
+      )
+      // @ts-ignore
+      bud.compilePaths(directories.map((path: string) => bud.path(path)))
+    }
+  }
+}

--- a/sources/@roots/bud-extensions/src/types.ts
+++ b/sources/@roots/bud-extensions/src/types.ts
@@ -1,5 +1,3 @@
-/// <reference types="@roots/bud-framework" />
-
 import type {PublicExtensionApi} from '@roots/bud-framework/extension'
 
 import type BudCDN from './extensions/cdn/index.js'
@@ -10,6 +8,7 @@ import type BudFixStyleOnlyEntrypoints from './extensions/fix-style-only-entrypo
 import type HtmlWebpackPlugin from './extensions/html-webpack-plugin/index.js'
 import type InterpolateHtmlPlugin from './extensions/interpolate-html-webpack-plugin/index.js'
 import type MiniCssExtractPlugin from './extensions/mini-css-extract-plugin/index.js'
+import type BudTsConfigValues from './extensions/tsconfig-values/index.js'
 import type WebpackDefinePlugin from './extensions/webpack-define-plugin/index.js'
 import type WebpackHotModuleReplacementPlugin from './extensions/webpack-hot-module-replacement-plugin/index.js'
 import type WebpackManifestPlugin from './extensions/webpack-manifest-plugin/index.js'
@@ -20,6 +19,7 @@ declare module '@roots/bud-framework' {
     cdn: Modules[`@roots/bud-extensions/cdn`]
     esm: Modules[`@roots/bud-extensions/esm`]
     manifest: PublicExtensionApi<WebpackManifestPlugin>
+    tsconfig: PublicExtensionApi
   }
 
   interface Modules {
@@ -31,6 +31,7 @@ declare module '@roots/bud-framework' {
     '@roots/bud-extensions/html-webpack-plugin': HtmlWebpackPlugin
     '@roots/bud-extensions/interpolate-html-webpack-plugin': InterpolateHtmlPlugin
     '@roots/bud-extensions/mini-css-extract-plugin': MiniCssExtractPlugin
+    '@roots/bud-extensions/tsconfig-values': BudTsConfigValues
     '@roots/bud-extensions/webpack-define-plugin': WebpackDefinePlugin
     '@roots/bud-extensions/webpack-hot-module-replacement-plugin': WebpackHotModuleReplacementPlugin
     '@roots/bud-extensions/webpack-manifest-plugin': WebpackManifestPlugin

--- a/sources/@roots/bud-extensions/test/service/__snapshots__/index.test.ts.snap
+++ b/sources/@roots/bud-extensions/test/service/__snapshots__/index.test.ts.snap
@@ -11,6 +11,7 @@ exports[`@roots/bud-extensions > bud.extensions.repository options should match 
   "@roots/bud-extensions/html-webpack-plugin",
   "@roots/bud-extensions/interpolate-html-webpack-plugin",
   "@roots/bud-extensions/mini-css-extract-plugin",
+  "@roots/bud-extensions/tsconfig-values",
   "@roots/bud-extensions/webpack-define-plugin",
   "@roots/bud-extensions/webpack-hot-module-replacement-plugin",
   "@roots/bud-extensions/webpack-manifest-plugin",

--- a/sources/@roots/bud-framework/src/extension/decorators/development.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/development.ts
@@ -5,7 +5,7 @@ export const development = <Type extends {new (...args: any[]): any}>(
   constructor: Type,
 ) =>
   class extends constructor {
-    public declare enabled: boolean
+    public enabled: boolean
 
     public constructor(...args: any[]) {
       super(...args)

--- a/sources/@roots/bud-framework/src/extension/decorators/when.test.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/when.test.ts
@@ -2,8 +2,8 @@ import {describe, expect, it} from 'vitest'
 
 import {when} from './when'
 
-@when(() => true)
 // @ts-ignore
+@when(() => true)
 class TestClass {}
 
 describe(`when`, () => {

--- a/sources/@roots/bud-framework/src/extension/decorators/when.ts
+++ b/sources/@roots/bud-framework/src/extension/decorators/when.ts
@@ -4,6 +4,8 @@ export const when =
   (when: Extension['when']) =>
   <Type extends {new (...args: any[]): any}>(constructor: Type) =>
     class extends constructor {
+      public when: Extension[`when`]
+
       public constructor(...args: any[]) {
         super(...args)
         this.when = `bind` in when ? when.bind(this) : when

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.test.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.test.ts
@@ -14,26 +14,26 @@ describe(`bud.setPath`, () => {
     setPath = subject.bind(bud)
   })
 
-  it(`is a function`, () => {
+  it(`should be a function`, () => {
     expect(setPath).toBeInstanceOf(Function)
   })
 
-  it(`returns Bud`, () => {
+  it(`should return Bud`, () => {
     expect(setPath(`@src`, `test`)).toBe(bud)
   })
 
-  it(`sets a path`, () => {
+  it(`should set a path`, () => {
     const hooksOnSpy = vi.spyOn(bud.hooks, `on`)
     setPath(`@src`, `test`)
     expect(hooksOnSpy).toHaveBeenCalled()
   })
 
-  it(`sets context when only a string is passed`, () => {
+  it(`should set context when only a string is passed`, () => {
     setPath(`/test`)
     expect(bud.context.basedir).toBe(`/test`)
   })
 
-  it(`throws when an invalid value is passed`, () => {
+  it(`should throw when an invalid value is passed`, () => {
     try {
       // @ts-ignore
       expect(setPath(`src`, `test-foo`)).toThrowError()
@@ -42,7 +42,7 @@ describe(`bud.setPath`, () => {
     }
   })
 
-  it(`throws when a path doesn't resolve correctly`, () => {
+  it(`should throw when a path doesn't resolve correctly`, () => {
     bud.path = vi.fn(() => `foo`)
     try {
       expect(setPath(`@src`, `test-foo`)).toThrowError()
@@ -51,7 +51,7 @@ describe(`bud.setPath`, () => {
     }
   })
 
-  it(`sets multiple paths`, () => {
+  it(`should set multiple paths`, () => {
     bud.relPath = vi.fn(() => `test-return`)
     const hooksOnSpy = vi.spyOn(bud.hooks, `on`)
 

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
@@ -86,7 +86,7 @@ const makeCallback =
   (bud: Bud) =>
   (pair: [string, string]): Bud => {
     const [key, value] = validate.stringPair(pair)
-    const normal = isAbsolute(value) ? bud.relPath(value) : value
+    const normal = !isAbsolute(value) ? bud.relPath(value) : value
 
     bud.hooks
       .on(`location.${key}` as keyof SyncRegistry, normal)

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
@@ -86,17 +86,12 @@ const makeCallback =
   (bud: Bud) =>
   (pair: [string, string]): Bud => {
     const [key, value] = validate.stringPair(pair)
-    const normal = !isAbsolute(value) ? bud.relPath(value) : value
-
-    bud.log({
-      key,
-      value,
-      normal,
-    })
+    const normal = isAbsolute(value) ? bud.relPath(value) : value
 
     bud.hooks
       .on(`location.${key}` as keyof SyncRegistry, normal)
       .log(`${key} set to ${normal}`)
+      .info({key, value, normal})
 
     return bud
   }

--- a/sources/@roots/bud-framework/src/methods/when.ts
+++ b/sources/@roots/bud-framework/src/methods/when.ts
@@ -14,7 +14,6 @@ export interface when {
       | Array<((app: Bud) => boolean) | boolean>,
     trueCase: ((app: Bud) => any) | Array<(app: Bud) => any>,
     falseCase?: ((app: Bud) => any) | Array<(app: Bud) => any>,
-    description?: string,
   ): Bud
 }
 
@@ -51,7 +50,6 @@ export function when(
     | Array<((app: Bud) => boolean) | boolean>,
   trueCase: ((app: Bud) => any) | Array<(app: Bud) => any>,
   falseCase?: ((app: Bud) => any) | Array<(app: Bud) => any>,
-  description: string = ``,
 ): Bud {
   const ctx = this as Bud
 

--- a/sources/@roots/bud/src/context/extensions.ts
+++ b/sources/@roots/bud/src/context/extensions.ts
@@ -36,6 +36,7 @@ const extensions: Extensions = {
     `@roots/bud-extensions/webpack-hot-module-replacement-plugin`,
     `@roots/bud-extensions/webpack-manifest-plugin`,
     `@roots/bud-extensions/webpack-provide-plugin`,
+    `@roots/bud-extensions/tsconfig-values`,
   ],
   discovered: [],
 }

--- a/sources/@roots/sage/src/sage/extension.ts
+++ b/sources/@roots/sage/src/sage/extension.ts
@@ -35,25 +35,6 @@ export class Sage extends Extension {
   public override async register(bud: Bud) {
     bud.hooks.on(`build.output.uniqueName`, `@roots/bud/sage/${bud.label}`)
 
-    const compilerOptions =
-      bud.context.files[`tsconfig.json`]?.module?.compilerOptions ??
-      bud.context.files[`jsconfig.json`]?.module?.compilerOptions
-
-    const aliases = compilerOptions?.paths
-      ? Object.entries(compilerOptions.paths)
-          .map(([k, v]: [string, Array<string>]) => [k, v[0]])
-          .map(tuple => tuple.map((str: string) => str.replace(`/*`, ``)))
-          .reduce(
-            (acc, [key, value]): Record<string, string> => ({
-              ...(acc ?? {}),
-              [key]: compilerOptions.baseUrl
-                ? bud.path(compilerOptions.baseUrl, value)
-                : bud.path(value),
-            }),
-            {},
-          )
-      : {}
-
     /* Set paths */
     bud.setPath({
       '@src': `resources`,
@@ -63,7 +44,6 @@ export class Sage extends Extension {
       '@styles': `@src/styles`,
       '@views': `@src/views`,
       '@dist': `public`,
-      ...aliases,
     })
 
     /* Set aliases */
@@ -73,7 +53,6 @@ export class Sage extends Extension {
       '@scripts': bud.path(`@scripts`),
       '@styles': bud.path(`@styles`),
       '@views': bud.path(`@views`),
-      ...aliases,
     })
 
     /* Set runtime single */

--- a/sources/@roots/sage/test/sage/extension.test.ts
+++ b/sources/@roots/sage/test/sage/extension.test.ts
@@ -1,3 +1,6 @@
+import {dirname} from 'node:path'
+import {fileURLToPath} from 'node:url'
+
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {Bud, factory} from '@repo/test-kit/bud'
 
@@ -8,7 +11,9 @@ describe(`@roots/sage`, async () => {
   let sage: Sage
 
   beforeEach(async () => {
-    bud = await factory()
+    bud = await factory({
+      basedir: dirname(fileURLToPath(import.meta.url)),
+    })
     sage = new Sage(bud)
   })
 
@@ -79,7 +84,6 @@ describe(`@roots/sage`, async () => {
       true,
       expect.any(Function),
       expect.any(Function),
-      `set minimize, hash, splitChunks in production and devtool in development (@roots\/sage)`,
     )
     expect(spy).toHaveBeenCalled()
   })
@@ -95,7 +99,6 @@ describe(`@roots/sage`, async () => {
       true,
       expect.any(Function),
       expect.any(Function),
-      `set minimize, hash, splitChunks in production and devtool in development (@roots\/sage)`,
     )
     expect(spy).toHaveBeenCalledWith(`single`)
   })
@@ -112,7 +115,6 @@ describe(`@roots/sage`, async () => {
       true,
       expect.any(Function),
       expect.any(Function),
-      `set minimize, hash, splitChunks in production and devtool in development (@roots\/sage)`,
     )
     expect(spy).toHaveBeenCalled()
     expect(devtoolSpy).not.toHaveBeenCalled()
@@ -129,7 +131,6 @@ describe(`@roots/sage`, async () => {
       false,
       expect.any(Function),
       expect.any(Function),
-      `set minimize, hash, splitChunks in production and devtool in development (@roots\/sage)`,
     )
     expect(devtoolSpy).toHaveBeenCalled()
     expect(splitChunksSpy).not.toHaveBeenCalled()

--- a/tests/util/project/tsconfig.json
+++ b/tests/util/project/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "@roots/bud/config/tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@scripts": ["./src/scripts"],
-      "@styles": ["./src/styles"],
-      "@components": ["./src/scripts/components"],
+      "@scripts/*": ["./src/scripts/*"],
+      "@styles/*": ["./src/styles/*"],
+      "@components/*": ["./src/scripts/components/*"],
     },
     "types": ["node", "webpack-env", "@roots/bud", "@roots/bud-swc", "@roots/bud-tailwindcss"]
   },

--- a/tests/util/project/tsconfig.json
+++ b/tests/util/project/tsconfig.json
@@ -1,13 +1,18 @@
 {
   "extends": "@roots/bud/config/tsconfig.json",
   "compilerOptions": {
+    "baseUrl": "./src",
+    "outDir": "./dist",
     "paths": {
-      "@scripts/*": ["./src/scripts/*"],
-      "@styles/*": ["./src/styles/*"],
-      "@components/*": ["./src/scripts/components/*"],
+      "@scripts/*": ["scripts/*"],
+      "@styles/*": ["styles/*"],
+      "@components/*": ["scripts/components/*"],
     },
     "types": ["node", "webpack-env", "@roots/bud", "@roots/bud-swc", "@roots/bud-tailwindcss"]
   },
-  "include": ["./src", "./config"],
-  "exclude": ["./node_modules"]
+  "files": ["./config/bud.config.ts", "./config/tailwind.config.ts"],
+  "include": ["./src"],
+  "bud": {
+    "useCompilerOptions": true
+  }
 }


### PR DESCRIPTION
## Enabling `tsconfig.json` integration

I want this to be default but I'm starting with it disabled. We'll wait for a major release to enable for all projects.

For now, to enable you can either:

**1. call bud.tsconfig.enable()**

```js
export default async bud => {
  bud.tsconfig.enable()
}
```

This returns `bud.tsconfig`, so don't try to chain off it.

**2. add `bud.useCompilerOptions` to `tsconfig.json` or `jsconfig.json`**

```json
{
  "extends": ["@roots/bud/config/tsconfig.json"],
  "compilerOptions": {},
  "bud": {
    "useCompilerOptions": true
  }
}
```

## What it does

Configures the `bud` instance based on `tsconfig.json` or `jsconfig.json`. For example:

```jsonc
{
  "extends": ["@roots/sage/config/tsconfig.json"],
  "compilerOptions": {
    /**
     * Source directory
     *
     * @remarks
     * This is the same as calling `bud.setPath(`@src`, `resources`)
     */
    "baseUrl": "resources",

    /**
     * Output directory
     *
     * @remarks
     * This is the same as calling `bud.setPath(`@dist`, `public`)
     */
    "outDir": "public",

    /**
     * Path aliases
     *
     * @remarks
     * This is the same as calling `bud.path()` and `bud.alias()`
     */
    "paths": {
      "@fonts/*": ["fonts/*"],
      "@images/*": ["images/*"],
      "@scripts/*": ["scripts/*"],
      "@styles/*": ["styles/*"]
    },

    /**
     * Include type definitions
     */
    "types": [
      "@roots/bud",
      "@roots/bud-react",
      "@roots/bud-postcss",
      "@roots/bud-preset-recommend",
      "@roots/sage",
    ]
  },

  /**
   * Compiler paths
   *
   * @remarks
   * This is the same as calling `bud.compilePaths`
   */
  "include": ["./bud.config.js", "./resources", "./node_modules/bootstrap"],

  /**
   * Allow bud to reference tsconfig/jsconfig values
   *
   * @remarks
   * Alternatively, call `bud.tsconfig.enable` in your project `bud.config`
   */
  "bud": {
    "useCompilerOptions": true
  }
}
```

Is the same way of expressing this intent:

```js
export default async bud => {
  bud
    .setPath({
      '@src': 'resources', // `compileOptions.baseUrl`
      '@dist': 'public', // `compileOptions.outDir`
    })
    
    .setAlias({
      '@fonts': bud.path(`@src/fonts`),
      '@images': bud.path(`@src/images`),
      '@scripts': bud.path(`@src/scripts`),
      '@styles': bud.path(`@src/styles`),
    }) // `compileOptions.paths`
    
    .compilePaths([
      bud.path(`@src`), bud.path(`@modules/bootstrap`)
    ]) // `include`
}
```

## Why?

The nice thing about supporting `tsconfig.json`/`jsconfig.json` configuration is that it is standard and cross-compatible with other tools. With the above `tsconfig.json` the lift to switch to `tsc` directly is very minimal.

Plus, if you have your IDE set up to update import paths you can just rename `resources` to `assets` and `tsconfig.json` updates the relevant values automatically. Dope!

## How?

With a new built-in extension: [`@roots/bud-extensions/tsconfig-values`](https://github.com/roots/bud/blob/64b73eb84eeb99a38ccf16452cd9b3bf53a2a22d/sources/%40roots/bud-extensions/src/extensions/tsconfig-values/index.ts) that, if enabled, runs on `configAfter` and makes bud.js API calls based on `tsconfig.json` or `jsconfig.json` (if present).

## Changes

- add support for `includes`, `excludes`, `compilerOptions.baseUrl`, `compilerOptions.rootDir`

## Type of change

**MINOR: feature**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
