### PR TITLE
✨ improve(@roots/bud): set process.cwd if --cwd flag is used

### DIFF
--- a/sources/@roots/bud-support/src/utilities/filesystem.ts
+++ b/sources/@roots/bud-support/src/utilities/filesystem.ts
@@ -1,5 +1,8 @@
+import {isMainThread} from 'node:worker_threads'
+
 import {BudError} from '../errors/errors.js'
 import {Filesystem} from '../filesystem/index.js'
+import {paths} from './paths.js'
 
 let filesystem: Filesystem
 
@@ -14,10 +17,14 @@ export const get = (basedir?: string) => {
   filesystem = new Filesystem(basedir)
 
   /**
-   * change directory to basedir
-   * for process.cwd() to work as expected
+   * change directory to basedir for process.cwd() to work as expected
+   *
+   * @remarks
+   * - no need to do this if the basedir is the same as the cwd
+   * - workers don't support process.chdir
    */
-  process.chdir(basedir)
+  const modifiedBaseDirectory = paths.basedir !== process.cwd()
+  if (isMainThread && modifiedBaseDirectory) process.chdir(basedir)
 
   return filesystem
 }

--- a/sources/@roots/bud-support/src/utilities/filesystem.ts
+++ b/sources/@roots/bud-support/src/utilities/filesystem.ts
@@ -13,6 +13,12 @@ export const get = (basedir?: string) => {
 
   filesystem = new Filesystem(basedir)
 
+  /**
+   * change directory to basedir
+   * for process.cwd() to work as expected
+   */
+  process.chdir(basedir)
+
   return filesystem
 }
 

--- a/sources/@roots/bud-support/src/utilities/paths.ts
+++ b/sources/@roots/bud-support/src/utilities/paths.ts
@@ -102,4 +102,4 @@ This is most likely a problem with the internals of bud.js.`,
   return paths
 }
 
-export {get}
+export {get, paths}


### PR DESCRIPTION
tools like `tailwindcss` use `process.cwd()` for pathing. This change sets the `process.cwd()` using `process.chdir` if the `--cwd` flag is used.

This causes errors if run in a worker thread so we check that we aren't in one before executing. This matters for us internally because vitest is threaded. Thankfully this change isn't needed for any of our tests to pass.

Without this change:

```
❯ yarn bud build --cwd examples/tailwindcss 

[@examples/tailwindcss] › ✖  warn - No utility classes were detected in your source files. If this is unexpected, double-check the `content` option in your Tailwind CSS configuration.
[@examples/tailwindcss] › ✖  warn - https://tailwindcss.com/docs/content-configuration

[stderr] warn - No utility classes were detected in your source files. If this is unexpected, double-check the `content` option in your
Tailwind CSS configuration.
[stderr] warn - https://tailwindcss.com/docs/content-configuration

╭─ @examples/tailwindcss ./dist [deb12d010346cc2dc6b1]
│
├─ entrypoints
│  └─ app
│     ├─ css/app.css    5.23 kB
│     └─ js/app.js     69 bytes
│
├─ assets
│  └─ index.html  389 bytes
│
╰─ compiled 11 modules (0 cached) in 1s 718ms

╭─ HtmlWebpackCompiler ./dist [41b35a5af5068146a6ea]
│
╰─ compiled 5 modules (0 cached) in 46ms
```

With it:

```
❯ yarn bud build --cwd examples/tailwindcss 

╭─ @examples/tailwindcss ./dist [4bfbbebc9bac287cfe34]
│
├─ entrypoints
│  └─ app
│     ├─ css/app.css    5.53 kB
│     └─ js/app.js     69 bytes
│
├─ assets
│  └─ index.html  389 bytes
│
╰─ compiled 4 modules (4 cached) in 234ms

╭─ HtmlWebpackCompiler ./dist [41b35a5af5068146a6ea]
│
╰─ compiled 5 modules (5 cached) in 147ms
```

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
