### PR TITLE
🩹 fix: postcss plugin api

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-postcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-postcss.mdx
@@ -69,7 +69,7 @@ bud.postcss
   /** Register the tailwindcss plugin and options */
   .setPlugin(`tailwindcss`)
   /** Specify which registered plugins you want to use, in the order they should be added */
-  .use([`import`, `nesting`, `tailwindcss`, `env`])
+  .use([`import`, `tailwindcss/nesting`, `tailwindcss`, `env`])
 ```
 
 ### Step 1. Registration

--- a/sources/@repo/docs/content/extensions/bud-postcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-postcss.mdx
@@ -22,40 +22,98 @@ By default, **@roots/bud-postcss** includes the following plugins, registered wi
 | 2.    | 'nesting' | [postcss-nested](https://github.com/postcss/postcss-nested) |
 | 3.    | 'env'     | [postcss-preset-env](https://preset-env.cssdb.org/)         |
 
-If this works for you, great! No need to keep reading. But, should you need something more specialized,
-you can configure it in your bud config file or a postcss.config.js file in your project's root directory.
+If this works for you, great! No need to keep reading.
 
-Any additional plugins you may want to add will be added between `nesting` and `env`.
-This is, generally, what you want, but there instructions included below for overriding this behavior.
+Should you need something more specialized, you can configure postcss in your bud config file or a
+standard postcss config file.
 
-## Add a plugin
+Note that by using a postcss config file you will be overriding the bud.js options API.
 
-You can add a plugin with **bud.postcss.setPlugin**. This function takes up to two parameters.
+## Overriding postcss options directly
 
-The first parameter is required. It is the name for the plugin.
-If it is the only parameter being passed, it should be the module signifier.
+You can set the postcss options directly using `bud.postcss.set`.
+
+PostCss options are contained in the `postcssOptions` key.
 
 ```typescript title=bud.config.js
-bud.postcss.setPlugin('example-postcss-plugin')
+bud.postcss.set(`postcssOptions`, {
+  parser: `sugarss`,
+  plugins: [`postcss-import`, `postcss-nested`, `postcss-preset-env`],
+})
 ```
 
-The second parameter is optional and multivariate.
+Doing it this way is quick and easy but you are fully overriding the default settings. It's best to use this method only
+if you are comfortable with postcss and know what you are doing.
 
-Use a string to specify the plugin's resolvable path:
+If you want to just change a single option you can use dot syntax:
+
+```typescript title=bud.config.js
+bud.postcss.set(`postcssOptions.parser`, `sugarss`)
+```
+
+This allows the default options to be merged with your new options.
+
+## Adding a plugin
+
+Adding a plugin with the API is a two step process:
+
+1. Register the plugin
+2. Add it to the plugin order
+
+Let's look at how this is done using `tailwindcss` as an example.
+
+```typescript title=bud.config.js
+bud.postcss
+  /** Register the tailwindcss/nesting plugin */
+  .setPlugin(`tailwindcss/nesting`)
+  /** Register the tailwindcss plugin and options */
+  .setPlugin(`tailwindcss`)
+  /** Specify which registered plugins you want to use, in the order they should be added */
+  .use([`import`, `nesting`, `tailwindcss`, `env`])
+```
+
+### Step 1. Registration
+
+```typescript title=bud.config.js
+bud.postcss.setPlugin(`example-postcss-plugin`)
+```
+
+If you want to be specific about how to resolve a plugin, you can pass a second parameter.
 
 ```typescript title=bud.config.js
 bud.postcss.setPlugin(
-  'example-postcss-plugin',
-  bud.path('./directory/example.js'),
+  `example-postcss-plugin`,
+  bud.path(`@modules/example-postcss-plugin/lib/index.js`),
 )
 ```
 
-Use an array to set any associated options alongside the resolvable path.
+If you want to pass along options with the plugin, you can do so by passing an array.
 
 ```typescript title=bud.config.js
-bud.postcss.setPlugin('example-postcss-plugin', [
-  bud.path('./directory/example.js'),
+bud.postcss.setPlugin(`example-postcss-plugin`, [
+  `example-postcss-plugin`,
   {stage: 1},
+])
+```
+
+### Step 2. Add the plugin
+
+```typescript title=bud.config.js
+bud.postcss.use([
+  `import`,
+  `nesting`,
+  `example-postcss-plugin`, // our new plugin
+  'env',
+])
+```
+
+You can also use a callback:
+
+```typescript title=bud.config.js
+bud.postcss.use(plugins => [
+  ...plugins.splice(0, 2),
+  'example-postcss-plugin',
+  ...plugins,
 ])
 ```
 
@@ -69,7 +127,7 @@ The first parameter is the plugin key and the second is the options object.
 bud.postcss.setPluginOptions('example-postcss-plugin', {optimize: false})
 ```
 
-## Override plugin resolution
+## Override plugin path
 
 You can modify the path for a postcss plugin using **bud.postcss.setPluginPath**.
 
@@ -82,90 +140,14 @@ bud.postcss.setPluginPath(
 )
 ```
 
-## Add multiple plugins
-
-You can add multiple postcss plugins using **bud.postcss.setPlugins**.
-
-### Using an object
-
-```typescript title=bud.config.js
-bud.postcss.setPlugins({
-  ['tailwindcss']: await bud.module.resolve('tailwindcss'),
-  ['nesting']: await bud.module.resolve('tailwindcss/nesting/index.js'),
-})
-```
-
-### Using a Map
-
-```typescript title=bud.config.js
-bud.postcss.setPlugins(
-  new Map([])
-    .set('tailwindcss', await bud.module.resolve('tailwindcss'))
-    .set('nesting', [
-      await bud.module.resolve('tailwindcss/nesting/index.js'),
-    ]),
-)
-```
-
-### Using an array
-
-```typescript title=bud.config.js
-bud.postcss.setPlugins([
-  ['tailwindcss', await bud.module.resolve('tailwindcss')],
-  ['nesting', await bud.module.resolve('tailwindcss/nesting/index.js')],
-])
-```
-
 ## Remove a plugin
 
-You may remove a plugin with **bud.postcss.unsetPlugin**.
+You may remove a plugin by calling **bud.postcss.removePlugin** with the plugin key.
 
 ```typescript title=bud.config.js
-bud.postcss.unsetPlugin('import')
+bud.postcss.removePlugin(`import`)
 ```
 
-## Plugin ordering
+## Internals
 
-**@roots/bud-postcss** loosely attempts to enforce a particular plugin load order.
-
-It will always attempt to load plugins in this order:
-
-| Order | Description                     | Default              |
-| ----- | ------------------------------- | -------------------- |
-| 1     | `import` implementation         | `postcss-import`     |
-| 2     | `nesting` implementation        | `postcss-nested`     |
-| ...3  | all other plugins as registered | none                 |
-| 4     | `env` implementation            | `postcss-preset-env` |
-
-The reason bud.js gets so hands-on here is to provide a reasonable default which people can build on without needing to splice in their own plugins manually.
-If this is a problem for your project, the most direct way to override this is to hook a function to `postcss.plugins` which returns an array of plugin values:
-
-```typescript title=bud.config.js
-bud.hooks.on('postcss.plugins', () => {
-  return [
-    bud.postcss.get('import'),
-    // ... plugins, in the order you wish to load them
-  ]
-})
-```
-
-## Working with the plugin registry directly
-
-**@roots/bud-postcss** stores PostCSS plugins as a `Map`. You can work with this `Map` directly using **bud.postcss.plugins**.
-
-```typescript title=bud.config.js
-export default async bud => {
-  bud.postcss.plugins.set('import', [
-    await module.resolve('postcss-import'),
-    {...options},
-  ])
-
-  bud.postcss.plugins.get('import')
-
-  bud.postcss.plugins.delete('import')
-
-  bud.postcss.plugins.clear()
-}
-```
-
-When you `get` something, you can hopefully rely on it being a `tuple` with the plugin in the first position and the options in the second. The plugin might be a string (resolveable path) or a module.
+Most of these functions are just wrappers around the bud.js extensions options API with some added guard rails.

--- a/sources/@repo/docs/content/extensions/bud-postcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-postcss.mdx
@@ -14,7 +14,7 @@ import {Install} from '@site/src/docs/Install'
 
 ## Usage
 
-By default, **@roots/bud-postcss** includes the following plugins, registered with postcss in this order:
+By default, **@roots/bud-postcss** includes the following plugins, registered with PostCSS in this order:
 
 | Order | Key       | Plugin                                                      |
 | ----- | --------- | ----------------------------------------------------------- |
@@ -24,14 +24,14 @@ By default, **@roots/bud-postcss** includes the following plugins, registered wi
 
 If this works for you, great! No need to keep reading.
 
-Should you need something more specialized, you can configure postcss in your bud config file or a
-standard postcss config file.
+Should you need something more specialized, you can configure PostCSS in your bud config file or a
+standard PostCSS config file.
 
-Note that by using a postcss config file you will be overriding the bud.js options API.
+Note that by using a PostCSS config file you will be overriding the bud.js options API.
 
-## Overriding postcss options directly
+## Overriding PostCSS options directly
 
-You can set the postcss options directly using `bud.postcss.set`.
+You can set the PostCSS options directly using `bud.postcss.set`.
 
 PostCss options are contained in the `postcssOptions` key.
 
@@ -43,7 +43,7 @@ bud.postcss.set(`postcssOptions`, {
 ```
 
 Doing it this way is quick and easy but you are fully overriding the default settings. It's best to use this method only
-if you are comfortable with postcss and know what you are doing.
+if you are comfortable with PostCSS and know what you are doing.
 
 If you want to just change a single option you can use dot syntax:
 
@@ -110,11 +110,7 @@ bud.postcss.use([
 You can also use a callback:
 
 ```typescript title=bud.config.js
-bud.postcss.use(plugins => [
-  ...plugins.splice(0, 2),
-  'example-postcss-plugin',
-  ...plugins,
-])
+bud.postcss.use(plugins => [...plugins, 'example-postcss-plugin'])
 ```
 
 ## Override plugin options
@@ -129,7 +125,7 @@ bud.postcss.setPluginOptions('example-postcss-plugin', {optimize: false})
 
 ## Override plugin path
 
-You can modify the path for a postcss plugin using **bud.postcss.setPluginPath**.
+You can modify the path for a PostCSS plugin using **bud.postcss.setPluginPath**.
 
 The first parameter is the plugin key and the second is the new path to assign.
 
@@ -142,12 +138,8 @@ bud.postcss.setPluginPath(
 
 ## Remove a plugin
 
-You may remove a plugin by calling **bud.postcss.removePlugin** with the plugin key.
+You may remove a plugin by calling **bud.postcss.unsetPlugin** with the plugin key.
 
 ```typescript title=bud.config.js
-bud.postcss.removePlugin(`import`)
+bud.postcss.unsetPlugin(`import`)
 ```
-
-## Internals
-
-Most of these functions are just wrappers around the bud.js extensions options API with some added guard rails.

--- a/sources/@roots/bud-postcss/src/extension.test.ts
+++ b/sources/@roots/bud-postcss/src/extension.test.ts
@@ -1,7 +1,13 @@
-import {factory} from '@repo/test-kit/bud'
+import {Bud, factory} from '@repo/test-kit/bud'
 import {describe, expect, it} from 'vitest'
 
 import BudPostCss from './index.js'
+
+const resetPlugins = (bud: Bud) =>
+  bud.postcss
+    .set(`import`, undefined)
+    .set(`env`, undefined)
+    .set(`nesting`, undefined)
 
 describe(`@roots/bud-postcss`, () => {
   it(`label`, async () => {
@@ -11,42 +17,32 @@ describe(`@roots/bud-postcss`, () => {
     expect(bud.postcss.label).toBe(`@roots/bud-postcss`)
   })
 
-  it(`getPlugins`, async () => {
-    const bud = await factory()
-    await bud.extensions.add(BudPostCss)
-    expect(bud.postcss.getPlugins()).toBe(bud.postcss.plugins)
-  })
-
   it(`setPlugins from obj`, async () => {
     const bud = await factory()
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins({foo: [`bar`]})
 
-    expect(bud.postcss.getPlugins()).toStrictEqual(
-      new Map([[`foo`, [`bar`]]]),
-    )
+    expect(bud.postcss.get(`foo`)).toStrictEqual([`bar`])
   })
 
   it(`setPlugins from map`, async () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
 
-    expect(bud.postcss.getPlugins()).toStrictEqual(
-      new Map([[`bang`, [`bop`]]]),
-    )
+    expect(bud.postcss.get(`bang`)).toStrictEqual([`bop`])
   })
 
   it(`getPluginOptions`, async () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
 
@@ -54,23 +50,23 @@ describe(`@roots/bud-postcss`, () => {
     expect(options).toStrictEqual({})
   })
 
-  it(`setPluginOptions`, async () => {
+  it(`should have functioning setPluginOptions method`, async () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
 
     bud.postcss.setPluginOptions(`bang`, {})
-    expect(bud.postcss.plugins.get(`bang`)?.pop()).toStrictEqual({})
+    expect(bud.postcss.get(`bang`)).toStrictEqual([`bop`, {}])
   })
 
   it(`setPluginOptions (callback)`, async () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
     bud.postcss.setPluginOptions(`bang`, {foo: `bar`})
@@ -85,7 +81,7 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(new Map([[`bang`, [`setPluginPath test`]]]))
 
@@ -98,21 +94,19 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
     bud.postcss.setPluginPath(`bang`, `newPath`)
 
-    expect(bud.postcss.plugins.get(`bang`)?.shift()).toStrictEqual(
-      `newPath`,
-    )
+    expect(bud.postcss.get(`bang`)?.[0]).toStrictEqual(`newPath`)
   })
 
   it(`unsetPlugin`, async () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugins(
       new Map([
@@ -126,7 +120,7 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     const returnValue = bud.postcss.setPlugins(
       new Map([
@@ -142,7 +136,7 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     const returnValue = bud.postcss.setPlugins(
       new Map([
@@ -158,11 +152,11 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     bud.postcss.setPlugin(`boop`)
 
-    expect(bud.postcss.plugins.get(`boop`)).toEqual(
+    expect(bud.postcss.get(`boop`)).toEqual(
       expect.arrayContaining([expect.stringContaining(`boop`)]),
     )
   })
@@ -171,12 +165,12 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     const signifier = `postcss-preset-env`
     bud.postcss.setPlugin(`env`, signifier)
 
-    expect(bud.postcss.plugins.get(`env`)).toEqual(
+    expect(bud.postcss.get(`env`)).toEqual(
       expect.arrayContaining([expect.stringContaining(signifier)]),
     )
   })
@@ -185,12 +179,12 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     const signifier = `postcss-preset-env`
     bud.postcss.setPlugin(`env`, [signifier, {option: `value`}])
 
-    expect(bud.postcss.plugins.get(`env`)).toEqual(
+    expect(bud.postcss.get(`env`)).toEqual(
       expect.arrayContaining([
         expect.stringContaining(signifier),
         expect.objectContaining({option: `value`}),
@@ -203,7 +197,7 @@ describe(`@roots/bud-postcss`, () => {
 
     await bud.extensions.add(BudPostCss)
 
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     try {
       expect(bud.postcss.getPluginOptions(`no-exist`)).toThrow()
@@ -214,7 +208,7 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     expect(bud.build.loaders.postcss.getSrc()).toContain(`postcss-loader`)
   })
@@ -223,7 +217,7 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     expect(bud.build.items.postcss?.getLoader().getSrc()).toContain(
       `postcss-loader`,
@@ -234,8 +228,19 @@ describe(`@roots/bud-postcss`, () => {
     const bud = await factory()
 
     await bud.extensions.add(BudPostCss)
-    bud.postcss.plugins.clear()
+    resetPlugins(bud)
 
     expect(bud.build.rules.css?.getUse()).toContain(`postcss`)
+  })
+
+  it(`should set the order with bud.postcss.use`, async () => {
+    const bud = await factory()
+    await bud.extensions.add(BudPostCss)
+    resetPlugins(bud)
+    bud.postcss.use([`foo`, `bar`])
+    expect(bud.postcss.get(`order`)).toStrictEqual([`foo`, `bar`])
+
+    bud.postcss.use(plugins => plugins.map(plugin => `${plugin}!`))
+    expect(bud.postcss.get(`order`)).toStrictEqual([`foo!`, `bar!`])
   })
 })

--- a/sources/@roots/bud-postcss/src/extension.ts
+++ b/sources/@roots/bud-postcss/src/extension.ts
@@ -21,7 +21,6 @@ type Input =
 type InputList = Array<string | [string, any?]>
 type InputRecords = Record<string, Input>
 type InputMap = Map<string, Input>
-type Registry = Map<string, [string | Plugin | Processor, any?]>
 
 /**
  * PostCSS configuration options
@@ -34,6 +33,8 @@ interface Options {
     parser?: string
     plugins?: InputList
   }
+  plugins: InputRecords
+  order: Array<`${keyof InputRecords & string}`>
 }
 
 /**
@@ -48,31 +49,28 @@ interface Options {
 @expose(`postcss`)
 export class BudPostCss extends Extension<Options> {
   /**
-   * Boolean representing if project has a postcss config file
+   * Config file options
    */
-  public get overridenByProjectConfigFile() {
-    if (!this.app.context.files) return false
-
-    return Object.values(this.app.context.files).some(
-      file => file?.name?.includes(`postcss`) && file?.module,
-    )
-  }
-
-  /**
-   * PostCSS configuration options (if overridden by project config file)
-   */
-  public declare configFileOptions: Record<string, any> | undefined
+  protected configFileOptions: Options[`postcssOptions`]
 
   /**
    * {@link Extension.register}
    */
   @bind
   public override async register({build, context}: Bud): Promise<void> {
-    if (!this.overridenByProjectConfigFile) {
-      this.setPlugins({
-        import: await this.resolve(`postcss-import`, import.meta.url),
-        nesting: await this.resolve(`postcss-nested`, import.meta.url),
-        env: [
+    if (
+      !context.files ||
+      !Object.values(context.files).some(
+        file => file?.name?.includes(`postcss`) && file?.module,
+      )
+    ) {
+      this.set(`import`, [
+        await this.resolve(`postcss-import`, import.meta.url),
+      ])
+        .set(`nesting`, [
+          await this.resolve(`postcss-nested`, import.meta.url),
+        ])
+        .set(`env`, [
           await this.resolve(`postcss-preset-env`, import.meta.url).then(
             path => path.replace(`.mjs`, `.cjs`),
           ),
@@ -82,16 +80,16 @@ export class BudPostCss extends Extension<Options> {
               'focus-within-pseudo-class': false,
             },
           },
-        ],
-      })
+        ])
+        .set(`order`, [`import`, `nesting`, `env`])
     } else {
       this.logger.log(
         `PostCSS configuration is being overridden by project configuration file.`,
       )
-      const file = Object.values(context.files).find(
-        ({name, module}) => name.includes(`postcss`) && module,
-      )
-      this.configFileOptions = file?.module?.default ?? file?.module
+      this.set(`postcssOptions.config`, true)
+      this.configFileOptions = Object.values(this.app.context.files).find(
+        file => file?.name?.includes(`postcss`) && file?.module,
+      )?.module
     }
 
     build
@@ -102,7 +100,7 @@ export class BudPostCss extends Extension<Options> {
       .setItem(`postcss`, {
         loader: `postcss`,
         options: () => ({
-          postcssOptions: this.configFileOptions || this.postcssOptions,
+          postcssOptions: this.configFileOptions ?? this.postcssOptions,
           sourceMap: this.get(`sourceMap`),
         }),
       })
@@ -116,60 +114,40 @@ export class BudPostCss extends Extension<Options> {
    * @readonly
    */
   public get postcssOptions(): Options[`postcssOptions`] {
-    let plugins = []
+    const options: Options[`postcssOptions`] = this.get(
+      `postcssOptions`,
+    ) as Options[`postcssOptions`]
 
-    if (!this.plugins.size) return null
-
-    this.plugins.has(`import`) && plugins.push(this.plugins.get(`import`))
-
-    this.plugins.has(`nesting`) &&
-      plugins.push(this.plugins.get(`nesting`))
-
-    Array.from(this.plugins.entries())
-      .filter(([k]) => ![`import`, `nesting`, `env`].includes(k))
-      .forEach(([_k, v]: [string, any]) => plugins.push(v))
-
-    this.plugins.has(`env`) && plugins.push(this.plugins.get(`env`))
-
-    const options = {
-      config: this.get(`postcssOptions.config`),
-      syntax: this.get(`postcssOptions.syntax`),
-      parser: this.get(`postcssOptions.parser`),
-      plugins: plugins.filter(Boolean),
+    if (!options?.plugins?.length) {
+      options.plugins = this.get(`order`)
+        .map(name => this.get(name))
+        .filter(Boolean) as InputList
     }
 
-    this.logger.info(`postcss syntax`, options.syntax)
-    this.logger.info(`postcss parser`, options.parser)
-    this.logger.info(`postcss plugins`, options.plugins)
+    this.logger.info(`postcss options`, options)
 
-    return options as Options[`postcssOptions`]
+    return options
   }
 
   /**
-   * Plugins registry
+   * Use plugins
+   *
+   * @remarks
+   * Sets the plugin order
    */
-  protected readonly _plugins: Registry = new Map([])
-
-  /**
-   * PostCss plugins accessor
-   */
-  public get plugins() {
-    return this._plugins
-  }
-  /**
-   * Get plugins
-   */
-  @bind
-  public getPlugins() {
-    return this._plugins
+  public use(
+    order: Array<string> | ((plugins: Array<string>) => Array<string>),
+  ) {
+    this.set(`order`, order)
+    return this
   }
 
   /**
-   * Replaces all plugins with provided value
+   * Set plugins
    */
   @bind
   public setPlugins(plugins: InputRecords | InputMap | InputList): this {
-    if (this.overridenByProjectConfigFile) {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.setPlugins will not work as expected\n`,
@@ -181,23 +159,22 @@ export class BudPostCss extends Extension<Options> {
     const pluginMap = (plugin: string | [string, any?]): [string, any?] =>
       Array.isArray(plugin) ? plugin : [plugin]
 
-    const setPlugin = (plugin: [string, any?]): unknown =>
-      this._plugins.set(...plugin)
-
     if (Array.isArray(plugins)) {
-      plugins.map(pluginMap).forEach(setPlugin)
+      plugins.map(pluginMap).forEach(plugin => this.set(...plugin))
       return this
     }
 
     if (plugins instanceof Map) {
-      Array.from(plugins.entries()).forEach(([k, v]) => {
-        this.setPlugin(k, v)
+      Array.from(plugins.entries()).forEach(plugin => {
+        this.set(...plugin)
       })
 
       return this
     }
 
-    Object.entries(plugins).map(pluginMap).forEach(setPlugin)
+    Object.entries(plugins)
+      .map(pluginMap)
+      .forEach(plugin => this.set(...plugin))
 
     return this
   }
@@ -207,7 +184,7 @@ export class BudPostCss extends Extension<Options> {
    */
   @bind
   public setPlugin(name: string, plugin?: Input): this {
-    if (this.overridenByProjectConfigFile) {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.setPlugin will not work as expected\n`,
@@ -218,16 +195,16 @@ export class BudPostCss extends Extension<Options> {
     }
 
     if (isUndefined(plugin)) {
-      this._plugins.set(name, [name])
+      this.set(name, [name])
       return this
     }
 
     if (Array.isArray(plugin)) {
-      this._plugins.set(name, plugin)
+      this.set(name, plugin)
       return this
     }
 
-    this._plugins.set(name, [plugin])
+    this.set(name, [plugin])
     return this
   }
 
@@ -235,17 +212,17 @@ export class BudPostCss extends Extension<Options> {
    * Remove a plugin
    */
   @bind
-  public unsetPlugin(plugin: string) {
-    if (this.overridenByProjectConfigFile) {
+  public unsetPlugin(name: string) {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.unsetPlugin will not work as expected\n`,
         `tried to unset:`,
-        plugin,
+        name,
       )
     }
 
-    this.plugins.has(plugin) && this.plugins.delete(plugin)
+    this.set(name, undefined)
 
     return this
   }
@@ -254,19 +231,19 @@ export class BudPostCss extends Extension<Options> {
    * Get plugin options
    */
   @bind
-  public getPluginOptions(plugin: string): Record<string, any> {
-    if (this.overridenByProjectConfigFile) {
+  public getPluginOptions(name: string): Record<string, any> {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.getPluginOptions will not work as expected\n`,
-        `tried to get: ${plugin}`,
+        `tried to get:`,
+        name,
       )
     }
 
-    return this.plugins.get(plugin).length &&
-      this.plugins.get(plugin).length > 1
-      ? this.plugins.get(plugin).pop()
-      : {}
+    const plugin: any = this.get(name)
+    if (!plugin) throw new Error(`Plugin ${name} does not exist`)
+    return plugin.length && plugin.length > 1 ? plugin[1] : {}
   }
 
   /**
@@ -274,27 +251,27 @@ export class BudPostCss extends Extension<Options> {
    */
   @bind
   public setPluginOptions(
-    plugin: string,
+    name: string,
     options:
       | Record<string, any>
       | ((options: Record<string, any>) => Record<string, any>),
   ): this {
-    if (this.overridenByProjectConfigFile) {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.setPluginOptions will not work as expected`,
       )
     }
 
-    if (!this.plugins.has(plugin)) {
-      throw new InputError(`${plugin} does not exist`)
+    const plugin = this.get(name)
+
+    if (!plugin) {
+      throw new InputError(`${name} does not exist`)
     }
 
-    this.plugins.set(plugin, [
-      this.getPluginPath(plugin),
-      isFunction(options)
-        ? options(this.getPluginOptions(plugin))
-        : options,
+    this.set(name, [
+      this.getPluginPath(name),
+      isFunction(options) ? options(this.getPluginOptions(name)) : options,
     ])
 
     return this
@@ -304,35 +281,35 @@ export class BudPostCss extends Extension<Options> {
    * Get plugin path
    */
   @bind
-  public getPluginPath(plugin: string): string {
-    if (this.overridenByProjectConfigFile) {
+  public getPluginPath(name: string): string {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.getPluginPath will not work as expected`,
       )
     }
 
-    return this.plugins.has(plugin) && this.plugins.get(plugin)?.length
-      ? [...this.plugins.get(plugin)].shift()
-      : this.plugins.get(plugin)
+    const plugin: any = this.get(name)
+    return plugin && plugin?.length ? [...plugin][0] : plugin
   }
 
   /**
    * Set plugin path
    */
   @bind
-  public setPluginPath(plugin: string, path: string): this {
-    if (this.overridenByProjectConfigFile) {
+  public setPluginPath(name: string, path: string): this {
+    if (this.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration is being overridden by project configuration file.\n`,
         `bud.postcss.setPluginPath will not work as expected`,
       )
     }
 
-    const target = this.plugins.get(plugin)
-    const hasOptions = target.length && target.length > 1
+    const plugin: any = this.get(name)
+    if (!plugin) throw new Error(`Plugin ${name} does not exist`)
 
-    this.setPlugin(plugin, hasOptions ? [path, target.pop()] : [path])
+    const hasOptions = plugin.length && plugin.length > 1
+    this.set(name, hasOptions ? [path, plugin[1]] : [path])
 
     return this
   }

--- a/sources/@roots/bud-postcss/src/types.ts
+++ b/sources/@roots/bud-postcss/src/types.ts
@@ -8,16 +8,15 @@ import type {PublicExtensionApi} from '@roots/bud-framework/extension'
 import type {BudPostCss} from './extension.js'
 
 interface PublicPostCssApi extends PublicExtensionApi<BudPostCss> {
-  overridenByProjectConfigFile: BudPostCss[`overridenByProjectConfigFile`]
-  setPlugin: BudPostCss[`setPlugin`]
+  postcssOptions: BudPostCss[`postcssOptions`]
   getPluginPath: BudPostCss[`getPluginPath`]
   setPluginPath: BudPostCss[`setPluginPath`]
   getPluginOptions: BudPostCss[`getPluginOptions`]
   setPluginOptions: BudPostCss[`setPluginOptions`]
-  getPlugins: BudPostCss[`getPlugins`]
+  setPlugin: BudPostCss[`setPlugin`]
   setPlugins: BudPostCss[`setPlugins`]
   unsetPlugin: BudPostCss[`unsetPlugin`]
-  plugins: BudPostCss[`plugins`]
+  use: BudPostCss[`use`]
   getSyntax: BudPostCss[`getSyntax`]
   setSyntax: BudPostCss[`setSyntax`]
   getSourceMap: BudPostCss[`getSourceMap`]

--- a/sources/@roots/bud-postcss/src/types.ts
+++ b/sources/@roots/bud-postcss/src/types.ts
@@ -9,6 +9,7 @@ import type {BudPostCss} from './extension.js'
 
 interface PublicPostCssApi extends PublicExtensionApi<BudPostCss> {
   postcssOptions: BudPostCss[`postcssOptions`]
+  getPlugin: BudPostCss[`getPlugin`]
   getPluginPath: BudPostCss[`getPluginPath`]
   setPluginPath: BudPostCss[`setPluginPath`]
   getPluginOptions: BudPostCss[`getPluginOptions`]

--- a/sources/@roots/bud-postcss/test/extension.test.ts
+++ b/sources/@roots/bud-postcss/test/extension.test.ts
@@ -1,13 +1,9 @@
 import {Bud, factory} from '@repo/test-kit/bud'
 import {describe, expect, it} from 'vitest'
 
-import BudPostCss from './index.js'
+import BudPostCss from '../src/index.js'
 
-const resetPlugins = (bud: Bud) =>
-  bud.postcss
-    .set(`import`, undefined)
-    .set(`env`, undefined)
-    .set(`nesting`, undefined)
+const resetPlugins = (bud: Bud) => bud.postcss.set(`plugins`, {})
 
 describe(`@roots/bud-postcss`, () => {
   it(`label`, async () => {
@@ -24,7 +20,7 @@ describe(`@roots/bud-postcss`, () => {
 
     bud.postcss.setPlugins({foo: [`bar`]})
 
-    expect(bud.postcss.get(`foo`)).toStrictEqual([`bar`])
+    expect(bud.postcss.get(`plugins.foo`)).toStrictEqual([`bar`])
   })
 
   it(`setPlugins from map`, async () => {
@@ -35,7 +31,7 @@ describe(`@roots/bud-postcss`, () => {
 
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
 
-    expect(bud.postcss.get(`bang`)).toStrictEqual([`bop`])
+    expect(bud.postcss.get(`plugins.bang`)).toStrictEqual([`bop`])
   })
 
   it(`getPluginOptions`, async () => {
@@ -59,7 +55,7 @@ describe(`@roots/bud-postcss`, () => {
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
 
     bud.postcss.setPluginOptions(`bang`, {})
-    expect(bud.postcss.get(`bang`)).toStrictEqual([`bop`, {}])
+    expect(bud.postcss.get(`plugins.bang`)).toStrictEqual([`bop`, {}])
   })
 
   it(`setPluginOptions (callback)`, async () => {
@@ -99,7 +95,7 @@ describe(`@roots/bud-postcss`, () => {
     bud.postcss.setPlugins(new Map([[`bang`, [`bop`]]]))
     bud.postcss.setPluginPath(`bang`, `newPath`)
 
-    expect(bud.postcss.get(`bang`)?.[0]).toStrictEqual(`newPath`)
+    expect(bud.postcss.get(`plugins.bang`)?.[0]).toStrictEqual(`newPath`)
   })
 
   it(`unsetPlugin`, async () => {
@@ -156,7 +152,7 @@ describe(`@roots/bud-postcss`, () => {
 
     bud.postcss.setPlugin(`boop`)
 
-    expect(bud.postcss.get(`boop`)).toEqual(
+    expect(bud.postcss.get(`plugins.boop`)).toEqual(
       expect.arrayContaining([expect.stringContaining(`boop`)]),
     )
   })
@@ -170,7 +166,7 @@ describe(`@roots/bud-postcss`, () => {
     const signifier = `postcss-preset-env`
     bud.postcss.setPlugin(`env`, signifier)
 
-    expect(bud.postcss.get(`env`)).toEqual(
+    expect(bud.postcss.get(`plugins.env`)).toEqual(
       expect.arrayContaining([expect.stringContaining(signifier)]),
     )
   })
@@ -184,7 +180,7 @@ describe(`@roots/bud-postcss`, () => {
     const signifier = `postcss-preset-env`
     bud.postcss.setPlugin(`env`, [signifier, {option: `value`}])
 
-    expect(bud.postcss.get(`env`)).toEqual(
+    expect(bud.postcss.get(`plugins.env`)).toEqual(
       expect.arrayContaining([
         expect.stringContaining(signifier),
         expect.objectContaining({option: `value`}),

--- a/sources/@roots/bud-purgecss/src/api.ts
+++ b/sources/@roots/bud-purgecss/src/api.ts
@@ -84,8 +84,8 @@ export interface Extractors {
  */
 export const purgecss: purge = function (userOptions) {
   this.postcss
-    .set(`purgecss`, [`@fullhuman/postcss-purgecss`, userOptions])
-    .set(`order`, plugins => [...plugins, `purgecss`])
+    .setPlugin(`purgecss`, [`@fullhuman/postcss-purgecss`, userOptions])
+    .use(plugins => [...plugins, `purgecss`])
 
   return this
 }

--- a/sources/@roots/bud-purgecss/src/api.ts
+++ b/sources/@roots/bud-purgecss/src/api.ts
@@ -83,10 +83,9 @@ export interface Extractors {
  * ```
  */
 export const purgecss: purge = function (userOptions) {
-  this.postcss.setPlugin(`purgecss`, [
-    `@fullhuman/postcss-purgecss`,
-    userOptions,
-  ])
+  this.postcss
+    .set(`purgecss`, [`@fullhuman/postcss-purgecss`, userOptions])
+    .set(`order`, plugins => [...plugins, `purgecss`])
 
   return this
 }

--- a/sources/@roots/bud-purgecss/test/extension.test.ts
+++ b/sources/@roots/bud-purgecss/test/extension.test.ts
@@ -36,9 +36,8 @@ describe(`@roots/bud-purgecss`, () => {
 
   it(`should add plugin to the postcss plugins repository`, () => {
     purgecss.bind(bud)({content: [`**/*.html`]})
-    expect(bud.postcss.get(`purgecss`)).toStrictEqual([
-      `@fullhuman/postcss-purgecss`,
-      {content: [`**/*.html`]},
-    ])
+    expect(bud.postcss.getPluginOptions(`purgecss`)).toStrictEqual({
+      content: [`**/*.html`],
+    })
   })
 })

--- a/sources/@roots/bud-purgecss/test/extension.test.ts
+++ b/sources/@roots/bud-purgecss/test/extension.test.ts
@@ -1,3 +1,5 @@
+import '../src/index.js'
+
 import {Bud, factory} from '@repo/test-kit/bud'
 import postcss from '@roots/bud-postcss'
 import {beforeEach, describe, expect, it} from 'vitest'
@@ -34,6 +36,9 @@ describe(`@roots/bud-purgecss`, () => {
 
   it(`should add plugin to the postcss plugins repository`, () => {
     purgecss.bind(bud)({content: [`**/*.html`]})
-    expect(bud.postcss.plugins.has(`purgecss`)).toBe(true)
+    expect(bud.postcss.get(`purgecss`)).toStrictEqual([
+      `@fullhuman/postcss-purgecss`,
+      {content: [`**/*.html`]},
+    ])
   })
 })

--- a/sources/@roots/bud-tailwindcss/src/extension/index.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension/index.ts
@@ -159,16 +159,19 @@ export class BudTailwindCss extends Extension<Options> {
       )
     }
 
-    bud.postcss.setPlugins({
-      nesting: await this.resolve(
-        join(`tailwindcss`, `nesting`, `index.js`),
-        import.meta.url,
-      ),
-      tailwindcss: [
+    bud.postcss
+      .set(
+        `nesting`,
+        await this.resolve(
+          join(`tailwindcss`, `nesting`, `index.js`),
+          import.meta.url,
+        ),
+      )
+      .set(`tailwindcss`, [
         await this.resolve(`tailwindcss`, import.meta.url),
         this.file.module ?? this.file.path,
-      ],
-    })
+      ])
+      .set(`order`, [`import`, `nesting`, `tailwindcss`, `env`])
 
     this.logger.success(`postcss configured for tailwindcss`)
 
@@ -247,7 +250,7 @@ export class BudTailwindCss extends Extension<Options> {
   }
 
   public override async buildBefore() {
-    if (this.app.postcss.overridenByProjectConfigFile) {
+    if (this.app.postcss.get(`postcssOptions.config`)) {
       this.logger.warn(
         `PostCSS configuration overridden by project config file.`,
         `@roots/bud-tailwindcss configuration will not apply.`,

--- a/sources/@roots/bud-tailwindcss/src/extension/index.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension/index.ts
@@ -160,20 +160,19 @@ export class BudTailwindCss extends Extension<Options> {
     }
 
     bud.postcss
-      .set(
+      .setPlugin(
         `nesting`,
         await this.resolve(
           join(`tailwindcss`, `nesting`, `index.js`),
           import.meta.url,
         ),
       )
-      .set(`tailwindcss`, [
+      .setPlugin(`tailwindcss`, [
         await this.resolve(`tailwindcss`, import.meta.url),
         this.file.module ?? this.file.path,
       ])
-      .set(`order`, [`import`, `nesting`, `tailwindcss`, `env`])
-
-    this.logger.success(`postcss configured for tailwindcss`)
+      .use([`import`, `nesting`, `tailwindcss`, `env`])
+      .logger.success(`postcss configured for tailwindcss`)
 
     /**
      * Add tailwind config to webpack cache dependencies

--- a/sources/@roots/bud-tailwindcss/test/extension/index.test.ts
+++ b/sources/@roots/bud-tailwindcss/test/extension/index.test.ts
@@ -110,10 +110,10 @@ describe(`@roots/bud-tailwindcss extension`, () => {
   })
 
   it(`should call postcss.setPlugins`, async () => {
-    const setPluginsSpy = vi.spyOn(bud.postcss, `setPlugins`)
+    const setSpy = vi.spyOn(bud.postcss, `set`)
 
     await extension.boot(bud)
 
-    expect(setPluginsSpy).toHaveBeenCalled()
+    expect(setSpy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- fixes postcss plugin ordering api (the documented `postcss.plugins` hook was not valid).
- updates documentation

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
