### PR TITLE
✨ feat: extension done method

### DIFF
--- a/sources/@roots/bud-extensions/src/extensions/webpack-lifecycle-plugin/index.ts
+++ b/sources/@roots/bud-extensions/src/extensions/webpack-lifecycle-plugin/index.ts
@@ -1,14 +1,10 @@
-import type {
-  Compilation,
-  Compiler,
-  StatsCompilation,
-} from '@roots/bud-framework/config'
+import type {Compilation, Compiler} from '@roots/bud-framework/config'
 
 import {Extension} from '@roots/bud-framework/extension'
 import {bind, label} from '@roots/bud-framework/extension/decorators'
 
 /**
- * Webpack provide plugin configuration
+ * Webpack lifecycle plugin
  */
 @label(`@roots/bud-extensions/webpack-lifecycle-plugin`)
 export default class BudWebpackLifecyclePlugin extends Extension {
@@ -60,7 +56,6 @@ export default class BudWebpackLifecyclePlugin extends Extension {
       `beforeCompile`,
       `beforeRun`,
       `emit`,
-      `done`,
       `run`,
     ]
       .filter(k => compiler.hooks[k])
@@ -108,11 +103,6 @@ export default class BudWebpackLifecyclePlugin extends Extension {
 
   @bind
   public compile(...compilationParams: any[]) {}
-
-  @bind
-  public async done(stats: StatsCompilation) {
-    this.logger.info(`done`)
-  }
 
   @bind
   public async emit(compilation: Compilation) {

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -389,6 +389,14 @@ export class Extension<
   }
 
   /**
+   * Return to bud instance from extension
+   */
+  @bind
+  public done(): Bud {
+    return this.app
+  }
+
+  /**
    * Enable extension
    */
   @bind

--- a/sources/@roots/bud-framework/test/extension/done.test.ts
+++ b/sources/@roots/bud-framework/test/extension/done.test.ts
@@ -1,0 +1,16 @@
+import type {Bud} from '@roots/bud-framework'
+import {Extension} from '@roots/bud-framework/extension'
+
+import {beforeAll, describe, test} from 'vitest'
+
+describe(`@roots/bud-framework/extension`, () => {
+  let extension: Extension
+  let bud: Bud = {} as Bud
+
+  beforeAll(async () => {
+    extension = new (class extends Extension {})(bud)
+  })
+  test(`done`, async ({expect}) => {
+    expect(extension.done()).toBe(bud)
+  })
+})


### PR DESCRIPTION
- easier way to return to `bud` context from extension when finished configuring

```ts
bud
  .react
    .set(`foo`, `bar`)
    .done()
  .eslint
    .setFix(true)
    .done()
  .stylelint
    .setFix(true)
    .done()
```
  
## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
