### PR TITLE
🩹 fix: when

### DIFF
--- a/sources/@roots/bud-api/src/methods/entry/index.test.ts
+++ b/sources/@roots/bud-api/src/methods/entry/index.test.ts
@@ -14,7 +14,7 @@ describe(`bud.entry`, function () {
   })
 
   it(`is a function`, () => {
-    expect(entry).toBeInstanceOf(Function)
+    expect(entryFn).toBeInstanceOf(Function)
   })
 
   it(`should return bud`, async () => {

--- a/sources/@roots/bud-framework/src/methods/maybeCall.ts
+++ b/sources/@roots/bud-framework/src/methods/maybeCall.ts
@@ -2,11 +2,26 @@ import isFunction from '@roots/bud-support/lodash/isFunction'
 
 import type {Bud} from '../index.js'
 
-export interface maybeCall {
-  <I = Bud>(maybeCallable: maybeCallable<I>, value?: I): I
+type Parameters = Array<undefined | unknown>
+
+export interface Callable<I = Bud> {
+  (...value: Parameters): I
 }
 
-export type maybeCallable<I = unknown> = ((param: Bud) => I) | I
+export type MaybeCallable<T extends unknown, P extends Parameters> =
+  | ((...params: P) => T)
+  | Exclude<T, CallableFunction>
+
+interface maybeCall {
+  <T extends unknown, P extends never>(
+    value: ((bud: T) => T) | Exclude<T, CallableFunction>,
+  ): T
+
+  <T extends unknown, P extends Parameters>(
+    value: ((...params: P) => T) | Exclude<T, CallableFunction>,
+    ...params: P
+  ): T
+}
 
 /**
  * Calls a given value if it is a function. The function will be bound to
@@ -16,13 +31,17 @@ export type maybeCallable<I = unknown> = ((param: Bud) => I) | I
  *
  * @typeParam I - Type of the value expected to be returned
  */
-export function maybeCall<
-  I = Bud,
-  Args extends Array<undefined | unknown> = [I],
->(this: Bud, value: maybeCallable, ...args: Args): I {
+const maybeCall: maybeCall = function <
+  T extends unknown,
+  P extends Parameters,
+>(value: T, ...params: P) {
+  if (!params.length) params.push(this)
+
   return isFunction(value)
     ? value.bind
-      ? value.bind(this)(...args)
-      : value(...args)
+      ? value.bind(this)(...params)
+      : value(...params)
     : value
 }
+
+export {maybeCall}

--- a/sources/@roots/bud-framework/test/methods/maybeCall.test.ts
+++ b/sources/@roots/bud-framework/test/methods/maybeCall.test.ts
@@ -1,0 +1,48 @@
+import {Bud, factory} from '@repo/test-kit'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {maybeCall as subject} from '../../src/methods/maybeCall.js'
+
+describe(
+  `bud.maybeCall`,
+  function () {
+    let maybeCall: subject
+    let bud: Bud
+
+    beforeEach(async () => {
+      bud = await factory()
+      maybeCall = subject.bind(bud)
+    })
+
+    it(`is a function`, () => {
+      expect(maybeCall).toBeInstanceOf(Function)
+    })
+
+    it(`should call function with bud when supplied with no parameters`, async () => {
+      const callback = vi.fn(value => value)
+      const value = maybeCall(callback)
+      expect(callback).toHaveBeenCalledWith(bud)
+      expect(value).toBe(bud)
+    })
+
+    it(`should call function with parameters when supplied with parameters`, async () => {
+      const callback = vi.fn(value => value)
+      const value = maybeCall(callback, `...foo`)
+      expect(callback).toHaveBeenCalledWith(`...foo`)
+      expect(value).toBe(`...foo`)
+    })
+
+    it(`should return value when supplied a non-callable value`, async () => {
+      const value = maybeCall(`...bar`)
+      expect(value).toBe(`...bar`)
+    })
+
+    it(`should call function with context when bindable`, async () => {
+      const value = maybeCall(function () {
+        return this
+      })
+      expect(value).toBe(bud)
+    })
+  },
+  {retry: 2},
+)

--- a/sources/@roots/bud-framework/test/methods/when.test.ts
+++ b/sources/@roots/bud-framework/test/methods/when.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {SpyInstance, beforeEach, describe, expect, it, vi} from 'vitest'
 import {Bud, factory} from '@repo/test-kit'
 import {when as source} from '../../src/methods/when'
 
@@ -6,11 +6,14 @@ describe(
   `bud.when`,
   () => {
     let bud: Bud
+    let globSpy: SpyInstance
     let when: source
 
     beforeEach(async () => {
       bud = await factory()
       when = source.bind(bud)
+      globSpy = vi.fn(() => true)
+      bud.set(`globSync`, globSpy as any)
     })
 
     it(`should be a function`, () => {
@@ -60,6 +63,7 @@ describe(
       const trueCase = vi.fn()
       const falseCase = vi.fn()
       when(true, trueCase, falseCase)
+
       expect(trueCase).toHaveBeenCalledTimes(1)
       expect(falseCase).not.toHaveBeenCalled()
     })
@@ -84,6 +88,14 @@ describe(
       const trueCase = vi.fn()
       const falseCase = vi.fn()
       when([true, () => true], trueCase, falseCase)
+      expect(trueCase).toHaveBeenCalledTimes(1)
+      expect(falseCase).not.toHaveBeenCalled()
+    })
+
+    it(`should pass bud along to the test case`, () => {
+      const trueCase = vi.fn()
+      const falseCase = vi.fn()
+      when([bud => bud.globSync(`./`) as any], trueCase, falseCase)
       expect(trueCase).toHaveBeenCalledTimes(1)
       expect(falseCase).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
- Fixes `bud.when` not being passed `bud`
- Adds test case targeting this problem
- Adds unit test for `bud.maybeCall` (source of this issue)

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
