### PR TITLE
🩹 fix: config.after

### DIFF
--- a/sources/@roots/bud-build/src/config/resolve.ts
+++ b/sources/@roots/bud-build/src/config/resolve.ts
@@ -1,3 +1,5 @@
+import isString from '@roots/bud-support/lodash/isString'
+
 import type {Factory} from './index.js'
 
 export const resolve: Factory<`resolve`> = async bud => {
@@ -6,6 +8,7 @@ export const resolve: Factory<`resolve`> = async bud => {
       [`@src`]: bud.path(`@src`),
       ...(await bud.hooks.filterAsync(`build.resolve.alias`, {})),
     },
+
     extensionAlias: await bud.hooks.filterAsync(
       `build.resolve.extensionAlias`,
       {
@@ -13,22 +16,25 @@ export const resolve: Factory<`resolve`> = async bud => {
         [`.mjs`]: [`.mts`, `.mtx`, `.mjs`],
       },
     ),
+
     extensions: Array.from(
       bud.hooks.filter(
         `build.resolve.extensions`,
         new Set([`.js`, `.mjs`, `.jsx`, `.css`]),
       ),
     ),
-    modules: await bud.hooks.filterAsync(`build.resolve.modules`, [
-      bud.hooks.filter(`location.@src`),
-      bud.hooks.filter(`location.@modules`),
-    ]),
+
+    modules: await bud.hooks.filterAsync(
+      `build.resolve.modules`,
+      [
+        bud.hooks.filter(`location.@src`),
+        bud.hooks.filter(`location.@modules`),
+      ].filter(v => isString(v) && v.length > 0),
+    ),
+
     /**
      * Leave `undefined` to use webpack default (true in dev, false in production)
      */
-    unsafeCache: bud.hooks.filter(
-      `build.module.unsafeCache`,
-      bud.isDevelopment,
-    ),
+    unsafeCache: bud.hooks.filter(`build.module.unsafeCache`, undefined),
   })
 }

--- a/sources/@roots/bud-extensions/src/tsconfig-values/index.ts
+++ b/sources/@roots/bud-extensions/src/tsconfig-values/index.ts
@@ -141,6 +141,8 @@ export default class BudTsConfigValues
    * {@link Extension.configAfter}
    */
   public override async configAfter(bud: Bud) {
+    if (!this.isEnabled()) return
+
     // If a base directory has been defined in the tsconfig.json (either as rootDir or baseUrl),
     // it is set as the @src path in the bud.js application.
     if (this.derivedBaseDir) {

--- a/sources/@roots/bud-framework/src/bootstrap.ts
+++ b/sources/@roots/bud-framework/src/bootstrap.ts
@@ -164,6 +164,23 @@ export const bootstrap = async function (this: Bud) {
 
   this.hooks
     .fromMap({
+      'location.@dist':
+        isString(this.context.output) && this.context.output !== ``
+          ? this.context.output
+          : `dist`,
+      'location.@modules': isString(this.context.modules)
+        ? this.context.modules
+        : `node_modules`,
+      'location.@os-cache': this.context.paths[`os-cache`],
+      'location.@os-config': this.context.paths[`os-config`],
+      'location.@os-data': this.context.paths[`os-data`],
+      'location.@os-log': this.context.paths[`os-log`],
+      'location.@os-temp': this.context.paths[`os-temp`],
+      'location.@src':
+        isString(this.context.input) && this.context.input !== ``
+          ? this.context.input
+          : `src`,
+      'location.@storage': this.context.paths.storage,
       'pattern.css': /(?!.*\.module)\.css$/,
       'pattern.cssModule': /\.module\.css$/,
       'pattern.csv': /\.(csv|tsv)$/,
@@ -184,23 +201,6 @@ export const bootstrap = async function (this: Bud) {
       'pattern.webp': /\.webp$/,
       'pattern.xml': /\.xml$/,
       'pattern.yml': /\.ya?ml$/,
-    })
-    .hooks.fromMap({
-      'location.@dist': isString(this.context.output)
-        ? this.context.output
-        : `dist`,
-      'location.@modules': isString(this.context.modules)
-        ? this.context.modules
-        : `node_modules`,
-      'location.@os-cache': this.context.paths[`os-cache`],
-      'location.@os-config': this.context.paths[`os-config`],
-      'location.@os-data': this.context.paths[`os-data`],
-      'location.@os-log': this.context.paths[`os-log`],
-      'location.@os-temp': this.context.paths[`os-temp`],
-      'location.@src': isString(this.context.input)
-        ? this.context.input
-        : `src`,
-      'location.@storage': this.context.paths.storage,
     })
     .when(this.isDevelopment, ({hooks}) =>
       hooks.fromMap({

--- a/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
+++ b/sources/@roots/bud-framework/src/methods/setPath/setPath.ts
@@ -91,8 +91,7 @@ const makeCallback =
 
     bud.hooks
       .on(`location.${key}` as keyof SyncRegistry, normal)
-      .log(`${key} set to ${normal}`)
-      .info({key, normal, value})
+      .log(key, `set to`, normal)
 
     bud.hooks.async(`build.resolve.alias`, async (paths = {}) => ({
       ...paths,

--- a/sources/@roots/bud-react/src/react-refresh/extension.ts
+++ b/sources/@roots/bud-react/src/react-refresh/extension.ts
@@ -40,6 +40,7 @@ export default class BudReactRefresh extends Extension<
    */
   @bind
   public override async configAfter(bud: Bud) {
+    if (!this.isEnabled()) return
     if (bud.context.mode !== `development`) return
     if (bud.context.hot === false) return
 


### PR DESCRIPTION
- 🩹 fix: check if extension is `enabled` before proceeding with `configAfter` callback (applies to _most_ extensions)

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
