### PR TITLE
🩹 fix(@roots/entrypoints-webpack-plugin): stale caching

### DIFF
--- a/sources/@repo/docs/config/docusaurus.theme.cjs
+++ b/sources/@repo/docs/config/docusaurus.theme.cjs
@@ -125,7 +125,8 @@ const navbar = {
     },
     {
       items: [
-        {label: `latest`, to: `/releases/tags/6-13`},
+        {label: `latest`, to: `/releases/tags/6-14`},
+        {label: `6.13`, to: `/releases/tags/6-13`},
         {label: `6.12`, to: `/releases/tags/6-12`},
         {label: `6.11`, to: `/releases/tags/6-11`},
         {label: `6.9`, to: `/releases/tags/6-9`},

--- a/sources/@repo/docs/content/guides/general-use/node-api.mdx
+++ b/sources/@repo/docs/content/guides/general-use/node-api.mdx
@@ -4,7 +4,7 @@ description: Overview of instantiating bud.js directly from Node
 sidebar_label: Node API
 ---
 
-import NodeAPI from '!!raw-loader!@site/../../../examples/node-api/01-simple.js'
+import NodeAPI from '!!raw-loader!@site/../../../examples/node-api/node-script.js'
 import Code from '@theme/CodeBlock'
 
 :::note Work-in-progress
@@ -15,6 +15,6 @@ These docs are incomplete. Check out the [examples directory](https://github.com
 
 **bud.js** can be imported and instantiated directly.
 
-<Code language="typescript" title="examples/node-api/01-simple.js">
+<Code language="typescript" title="examples/node-api/node-script.js">
   {NodeAPI}
 </Code>

--- a/sources/@roots/entrypoints-webpack-plugin/src/webpack.plugin.ts
+++ b/sources/@roots/entrypoints-webpack-plugin/src/webpack.plugin.ts
@@ -119,30 +119,16 @@ export class EntrypointsWebpackPlugin {
               EntrypointsWebpackPlugin.getCompilationHooks(compilation)
             hooks.compilation.call(compilation)
 
-            const cache = compilation.getCache(this.constructor.name)
-            this.entrypoints = await cache.getPromise<Entrypoints>(
-              `entrypoints`,
-              null,
-            )
+            this.entrypoints = new Map()
 
-            if (!this.entrypoints) {
-              this.entrypoints = new Map()
+            for (const entry of compilation.entrypoints.values()) {
+              this.getChunkedFiles(entry.chunks).map(({file}) => {
+                const ident = entry.name
+                const path = this.options.publicPath.concat(file)
+                const type = path.split(`.`).pop()
 
-              for (const entry of compilation.entrypoints.values()) {
-                this.getChunkedFiles(entry.chunks).map(({file}) => {
-                  const ident = entry.name
-                  const path = this.options.publicPath.concat(file)
-                  const type = path.split(`.`).pop()
-
-                  this.addToManifest({ident, path, type})
-                })
-              }
-
-              await cache.storePromise(
-                `entrypoints`,
-                null,
-                this.entrypoints,
-              )
+                this.addToManifest({ident, path, type})
+              })
             }
 
             this.entrypoints = hooks.entrypoints.call(this.entrypoints)


### PR DESCRIPTION
- 🩹 fix(@roots/entrypoints-webpack-plugin): entrypoints.json artifact could become stale

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
