### PR TITLE
fix <alpha-value> Tailwind placeholder

### DIFF
--- a/sources/@roots/bud-tailwindcss-theme-json/src/tailwind/palette.ts
+++ b/sources/@roots/bud-tailwindcss-theme-json/src/tailwind/palette.ts
@@ -34,7 +34,7 @@ export interface transformEntry {
   (slug: Array<string>, color: string): WordPressColors[any]
 }
 export const transformEntry: transformEntry = (slug, color) => ({
-  color: color.toLowerCase().replace(/\/ <alpha-value>/g, '/ 1'),
+  color: color.toLowerCase().replace(/<alpha-value>/g, `1`),
   name: name(slug),
   slug: slug.join(`-`).toLowerCase(),
 })

--- a/sources/@roots/bud-tailwindcss-theme-json/src/tailwind/palette.ts
+++ b/sources/@roots/bud-tailwindcss-theme-json/src/tailwind/palette.ts
@@ -34,7 +34,7 @@ export interface transformEntry {
   (slug: Array<string>, color: string): WordPressColors[any]
 }
 export const transformEntry: transformEntry = (slug, color) => ({
-  color: color.toLowerCase(),
+  color: color.toLowerCase().replace(/\/ <alpha-value>/g, '/ 1'),
   name: name(slug),
   slug: slug.join(`-`).toLowerCase(),
 })


### PR DESCRIPTION
Replace the special <alpha-value> placeholder. Tailwind CSS uses this placeholder to inject the alpha value when using an opacity modifier. The placeholder has been replaced with the default value of 1. Currently, the color value is copied as is, leading to broken colors such as --wp-preset-color--primary: rgba(0 0 0 / <alpha-value>). This fix ensures that the value is replaced with --wp-preset-color--primary: rgba(0 0 0 / 1).

<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
