### PR TITLE
🩹 fix(patch): register command type error after extension uninstall

### DIFF
--- a/sources/@roots/bud-eslint/src/bud/commands/bud.eslint.command.tsx
+++ b/sources/@roots/bud-eslint/src/bud/commands/bud.eslint.command.tsx
@@ -9,9 +9,9 @@ export class BudEslintCommand extends BudCommand {
   public static override paths = [[`lint`, `js`], [`eslint`]]
 
   public static override usage = BudCommand.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `eslint CLI passthrough`,
-    examples: [[`View eslint usage information`, `$0 eslint --help`]],
+    examples: [[`Run eslint on source files`, `$0 eslint`]],
   })
 
   public options = Option.Proxy({name: `eslint passthrough options`})

--- a/sources/@roots/bud-prettier/src/bud/commands/bud.prettier.command.tsx
+++ b/sources/@roots/bud-prettier/src/bud/commands/bud.prettier.command.tsx
@@ -8,7 +8,7 @@ import {dry} from '@roots/bud/cli/decorators/dry'
 export class BudPrettierCommand extends BudCommand {
   public static override paths = [[`format`], [`prettier`]]
   public static override usage = Command.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `Prettier CLI`,
     examples: [[`View prettier usage information`, `$0 prettier --help`]],
   })

--- a/sources/@roots/bud-stylelint/src/bud/commands/bud.stylelint.command.tsx
+++ b/sources/@roots/bud-stylelint/src/bud/commands/bud.stylelint.command.tsx
@@ -21,11 +21,10 @@ export class BudStylelintCommand extends BudCommand {
    * {@link BudCommand.usage}
    */
   public static override usage = Command.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `stylelint CLI passthrough`,
     examples: [
       [`Run stylelint on source files`, `$0 lint css`],
-      [`View stylelint usage information`, `$0 lint css --help`],
     ],
   })
 

--- a/sources/@roots/bud-tailwindcss/src/bud/commands/tailwindcss/index.tsx
+++ b/sources/@roots/bud-tailwindcss/src/bud/commands/tailwindcss/index.tsx
@@ -9,7 +9,7 @@ export class BudTailwindCommand extends BudCommand {
   public static override paths = [[`tailwindcss`], [`tw`]]
 
   public static override usage = BudCommand.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `tailwindcss CLI passthrough`,
     examples: [
       [`View tailwindcss usage information`, `$0 tailwindcss --help`],

--- a/sources/@roots/bud-typescript/src/bud/commands/bud.ts.check.command.tsx
+++ b/sources/@roots/bud-typescript/src/bud/commands/bud.ts.check.command.tsx
@@ -9,7 +9,7 @@ export class BudTSCheckCommand extends BudCommand {
   public static override paths = [[`ts`, `check`]]
 
   public static override usage = BudCommand.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `Typecheck source code`,
     details: `
       This command runs the \`tsc\` command with the \`--noEmit\` flag.

--- a/sources/@roots/bud-typescript/src/bud/commands/bud.tsc.command.tsx
+++ b/sources/@roots/bud-typescript/src/bud/commands/bud.tsc.command.tsx
@@ -9,7 +9,7 @@ export class BudTSCCommand extends BudCommand {
   public static override paths = [[`tsc`]]
 
   public static override usage = Command.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `TypeScript CLI passthrough`,
     examples: [[`View tsc usage information`, `$0 tsc --help`]],
   })

--- a/sources/@roots/bud/src/cli/commands/bud.build.development.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.build.development.tsx
@@ -27,23 +27,12 @@ export default class BuildDevelopmentCommand extends BuildCommand {
    */
   public static override usage = BuildCommand.Usage({
     category: `build`,
-    description: `Compiles source assets in \`development\` mode.`,
-    details: `\
-      \`bud build development\` compiles source assets in \`development\` mode.
-    `,
+    description: `Compile source assets in \`development\` mode.`,
+    details: `Compile source assets in \`development\` mode.`,
     examples: [
-      [`compile source and serve`, `$0 build development`],
       [
-        `open project in system default browser`,
-        `$0 build development --browser`,
-      ],
-      [
-        `do not force reload in the browser when encountering a fatal HMR error`,
-        `$0 build development --no-reload`,
-      ],
-      [
-        `do not display an error overlay when encountering errors in application code`,
-        `$0 build development --no-overlay`,
+        `Compile source assets in \`development\` mode.`,
+        `$0 build development`,
       ],
     ],
   })

--- a/sources/@roots/bud/src/cli/commands/bud.build.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.build.tsx
@@ -51,7 +51,6 @@ export default class BudBuildCommand extends BudCommand {
 
       If you run this command without a configuration file \`bud\` will look for an entrypoint at \`@src/index.js\`.
     `,
-    examples: [[`compile source assets`, `$0 build`]],
   })
 
   public [`cache`] = cache

--- a/sources/@roots/bud/src/cli/commands/bud.clean.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.clean.tsx
@@ -14,7 +14,7 @@ export default class BudCleanCommand extends BudCommand {
   public static override paths = [[`clean`]]
 
   public static override usage = Command.Usage({
-    category: `tasks`,
+    category: `task`,
     description: `Clean project artifacts and caches`,
     details: `
       \`bud clean\` empties the \`@dist\` and \`@storage\` directories.
@@ -23,9 +23,9 @@ export default class BudCleanCommand extends BudCommand {
       \`bud clean cache\` empties the \`@storage/cache\` directory.
 `,
     examples: [
-      [`Clean artifacts/caches`, `$0 clean`],
-      [`Clean dist`, `$0 clean @dist`],
-      [`Clean storage`, `$0 clean @storage`],
+      [`Clean all`, `$0 clean`],
+      [`Clean dist`, `$0 clean output`],
+      [`Clean storage`, `$0 clean storage`],
     ],
   })
 
@@ -40,6 +40,9 @@ export default class BudCleanCommand extends BudCommand {
   public storagePositional = Option.Boolean(`@storage,storage`, false, {
     description: `empty @storage`,
   })
+
+  @bind
+  public override async catch(error: Error) {}
 
   @bind
   public async cleanCache() {

--- a/sources/@roots/bud/src/cli/commands/bud.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.tsx
@@ -47,11 +47,28 @@ export default class BudCommand extends Command<CLIContext> {
   public static override usage = Command.Usage({
     description: `Run \`bud --help\` for usage information`,
     details: `\
-      \`bud build production\` compiles source assets in \`production\` mode. Run \`bud build production --help\` for usage.
+      Documentation for this command is available at https://bud.js.org/.
 
-      \`bud build development\` compiles source assets in \`development\` mode and serves updated modules. Run \`bud build development --help\` for usage.
+      Any flags which accept a boolean can be negated with the \`--no-\` prefix. For example, \`--no-color\` will disable color output.
+
+      Any command can be exited with \`esc\` or \`ctrl+c\`.
+
+      Run this command with no arguments for an interactive menu of available subcommands.
+
+      Common tasks:
+
+        - \`bud build production\` compiles source assets in \`production\` mode.
+        - \`bud build development\` compiles source assets in \`development\` mode and updates modules in the browser.
+        - \`bud doctor\` checks your system and project for common configuration issues. Try this before making an issue in the bud.js repo.
+
+      Helpful flags:
+
+        - \`--help\` can be appened to any command for usage information.
+        - \`--basedir\` sets the working directory for bud and will be treated as project root.
+        - \`--storage\` sets the storage directory. Defaults to the system tmp dir.
+        - \`--log\` enables logging. Use \`--log\` in tandem with \`--verbose\` for more detailed output.
+        - \`--debug\` enables debug mode. It is very noisy in the terminal but also produces useful output files in the storage directory.
     `,
-    examples: [[`compile source assets`, `$0 build`]],
   })
 
   public basedir = basedir

--- a/sources/@roots/bud/src/cli/commands/bud.upgrade.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.upgrade.tsx
@@ -20,7 +20,7 @@ export default class BudUpgradeCommand extends BudCommand {
    * {@link Command.usage}
    */
   public static override usage = Command.Usage({
-    category: `tasks`,
+    category: `task`,
     description: `Set bud.js version`,
     details: `
       This command will upgrade your bud.js installation to the latest stable version.
@@ -34,12 +34,7 @@ export default class BudUpgradeCommand extends BudCommand {
       This command is a passthrough to the package manager you are using.
     `,
     examples: [
-      [`Upgrade dependencies to latest`, `$0 upgrade`],
-      [`Upgrade dependencies to specific version`, `$0 upgrade 6.6.6`],
-      [
-        `Upgrade through a private registry`,
-        `$0 upgrade --registry http://localhost:4873`,
-      ],
+      [`Upgrade all bud dependencies to latest version`, `$0 upgrade`],
     ],
   })
 

--- a/sources/@roots/bud/src/cli/commands/bud.view.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.view.tsx
@@ -13,11 +13,9 @@ export default class BudViewCommand extends BudCommand {
   public static override paths = [[`view`]]
 
   public static override usage = Command.Usage({
+    category: `debug`,
     description: `Explore bud object`,
-    examples: [
-      [`view compiled config`, `$0 view`],
-      [`view`, `$0 view env store`],
-    ],
+    examples: [[`view compiled config`, `$0 view build.config`]],
   })
 
   public indent = indent
@@ -47,7 +45,7 @@ export default class BudViewCommand extends BudCommand {
     if (this.color) value = highlight(value)
 
     BudViewCommand.renderStatic(
-      <Box>
+      <Box flexDirection="column">
         <Text color="magenta">{this.subject ?? `build.config`}</Text>
         <Text>{` `}</Text>
         <Text>{value}</Text>

--- a/sources/@roots/bud/src/cli/commands/bud.webpack.tsx
+++ b/sources/@roots/bud/src/cli/commands/bud.webpack.tsx
@@ -18,9 +18,9 @@ export default class BudWebpackCommand extends BudCommand {
    * {@link Command.usage}
    */
   public static override usage = Command.Usage({
-    category: `tools`,
+    category: `tool`,
     description: `Webpack CLI passthrough`,
-    examples: [[`View webpack usage information`, `$0 webpack --help`]],
+    examples: [[`Run webpack`, `$0 webpack`]],
   })
 
   public options = Option.Proxy({name: `webpack passthrough options`})

--- a/sources/@roots/bud/src/cli/commands/doctor/index.tsx
+++ b/sources/@roots/bud/src/cli/commands/doctor/index.tsx
@@ -24,6 +24,7 @@ export default class DoctorCommand extends BudCommand {
   public static override paths = [[`doctor`]]
 
   public static override usage = Command.Usage({
+    category: `debug`,
     description: `Check project for common errors`,
     details: `\
 The \`bud doctor\` command will:
@@ -39,7 +40,7 @@ In general, \`bud.js\` dependencies should be kept at the same version. This scr
 for a lot of edge cases so it might return a false positive.
 `,
     examples: [
-      [`Check compiled configuration against webpack`, `$0 doctor`],
+      [`Check project for common configuration issues`, `$0 doctor`],
     ],
   })
 

--- a/sources/@roots/bud/src/cli/commands/repl/index.tsx
+++ b/sources/@roots/bud/src/cli/commands/repl/index.tsx
@@ -18,6 +18,7 @@ export default class BudReplCommand extends BudCommand {
    * {@link BudCommand.usage}
    */
   public static override usage = Command.Usage({
+    category: `debug`,
     description: `Use bud in a repl`,
     examples: [[`repl`, `$0 repl`]],
   })

--- a/sources/@roots/bud/src/cli/components/Menu.tsx
+++ b/sources/@roots/bud/src/cli/components/Menu.tsx
@@ -1,3 +1,5 @@
+import {exit} from 'node:process'
+
 import figures from '@roots/bud-support/figures'
 import {
   Box,
@@ -9,75 +11,66 @@ import {
 
 import type BudCommand from '../commands/bud.js'
 
-const options: Array<[string, string, Array<string>]> = [
-  [
-    `build production`,
-    `build application for production`,
-    [`build`, `production`],
-  ],
-  [
-    `build development`,
-    `start development server`,
-    [`build`, `development`],
-  ],
-  [
-    `doctor`,
-    `check bud.js configuration for common errors and issues`,
-    [`doctor`],
-  ],
-  [
-    `repl`,
-    `open a repl to explore bud just prior to compilation`,
-    [`repl`],
-  ],
-  [
-    `upgrade`,
-    `upgrade bud.js and extensions to the latest stable version`,
-    [`upgrade`],
-  ],
-]
-
 export const Menu = ({cli}: {cli: BudCommand[`cli`]}) => {
+  const [defined] = useState(cli.definitions())
   const [selected, setSelected] = useState(0)
   const [running, setRunning] = useState(false)
+  const [items, setItems] = useState([])
+
+  useEffect(() => {
+    setItems(
+      defined.reduce((acc, cmd, id) => {
+        return [
+          ...acc,
+          ...(cmd.examples ?? []).map(([description, path]) => {
+            return {cmd, description, id, path}
+          }),
+        ]
+      }, []),
+    )
+  }, [defined])
 
   useInput((key, input) => {
+    if (input.escape) {
+      // eslint-disable-next-line n/no-process-exit
+      exit()
+    }
+
     if (running) return
 
     input[`downArrow`] && setSelected(selected + 1)
     input[`upArrow`] && setSelected(selected - 1)
 
-    if (input.escape) {
-      // eslint-disable-next-line n/no-process-exit
-      process.exit(0)
-    }
-
     if (input.return) {
       setRunning(true)
-      cli.run(options[selected][2])
+      cli.run(items[selected].path.split(` `).slice(1))
     }
   })
 
   useEffect(() => {
-    if (selected > options.length - 1) setSelected(0)
-    if (selected < 0) setSelected(options.length - 1)
-  }, [selected])
+    if (selected > items.length - 1) setSelected(0)
+    if (selected < 0) setSelected(items.length - 1)
+  }, [items, selected])
 
   return (
-    <Box flexDirection="column" marginTop={1}>
-      {options.map(([option, description, command], index) => {
-        return (
-          <Text color={selected === index ? `blue` : `white`} key={index}>
-            {selected === index ? figures.radioOn : figures.radioOff}
-            {`  `}
-            {option}
-            <Text color="white" dimColor>
+    <Box flexDirection="column" gap={1} marginTop={1}>
+      <Text bold>bud.js (v{cli.binaryVersion})</Text>
+      <Box flexDirection="column" gap={0}>
+        {items.map(({cmd, description, path}, id) => {
+          return (
+            <Text color={selected === id ? `blue` : `white`} key={id}>
+              {selected === id ? figures.radioOn : figures.radioOff}
               {` `}
-              {description}
+              {path.trim()}
+
+              <Text color="white" dimColor>
+                {` `}
+                {description.trim()}
+              </Text>
             </Text>
-          </Text>
-        )
-      })}
+          )
+        })}
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
Fixes type error after uninstalling extension which registers commands.

Without this change users would need to run `yarn bud clean storage` in order to clean out the stale entry.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
