### PR TITLE
🩹 fix(none): readme generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <h1 align="center"><strong>bud.js</strong></h1>
 
 <p align="center">
-  Frontend build tools combining the best parts of Symfony Encore and Laravel Mix
+  Configurable, extensible build tools for modern single and multi-page web applications
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bud",
   "private": true,
-  "description": "⚡️ Lightning fast frontend build tools combining the best parts of Symfony Encore and Laravel Mix",
+  "description": "Configurable, extensible build tools for modern single and multi-page web applications",
   "engines": {
     "node": "18.16.1",
     "yarn": "1.22.19",

--- a/sources/@repo/docs/package.json
+++ b/sources/@repo/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@repo/docs",
   "private": true,
-  "description": "A frontend build tooling framework combining the best parts of Symfony Encore and Laravel Mix",
+  "description": "Configurable, extensible build tools for modern single and multi-page web applications",
   "engines": {
     "node": "^16.3.0"
   },

--- a/sources/@repo/markdown-kit/readme/renderer/handlebars.ts
+++ b/sources/@repo/markdown-kit/readme/renderer/handlebars.ts
@@ -27,8 +27,8 @@ handlebars.registerHelper(`dotPath`, function (context, options) {
   return `${options.fn(this).replace(/\./, options.data.root.name)}`
 })
 
-handlebars.registerHelper(`raw`, function (options) {
-  return options.fn(this)
+handlebars.registerHelper(`raw`, function (context) {
+  return context.fn(this)
 })
 
 export {handlebars, Handlebars}

--- a/sources/@repo/yarn-plugin-bud/sources/command/docs.build.ts
+++ b/sources/@repo/yarn-plugin-bud/sources/command/docs.build.ts
@@ -52,6 +52,7 @@ export class Docs extends Command {
           `compiled/cli-examples/index.js`,
         ])
         .catch(this.catch),
+
       this.cli
         .run([
           `workspace`,
@@ -61,6 +62,7 @@ export class Docs extends Command {
           `compiled/releases/index.js`,
         ])
         .catch(this.catch),
+
       this.cli
         .run([
           `workspace`,

--- a/sources/@roots/bud-support/src/logger/index.ts
+++ b/sources/@roots/bud-support/src/logger/index.ts
@@ -27,25 +27,34 @@ class Logger {
   /**
    * Class constructor
    */
-  public constructor(public options: SignaleOptions) {
-    if (args.log === false) this.options.disabled = true
-    options.logLevel = args.verbose ? `info` : args.log ? `log` : `warn`
+  public constructor(public options: SignaleOptions = {}) {
+    if (args.log === false || options?.disabled === true)
+      this.options.disabled = true
 
     if (process.env) {
-      this.options.secrets = Object.entries(process.env)
-        .filter(
-          (
-            entry: [string, string | undefined],
-          ): entry is [string, string] =>
-            !isUndefined(entry[1]) && entry[0].includes(`SECRET`),
-        )
-        .map(([k, v]): string => v)
+      this.options.secrets =
+        options?.secrets ??
+        Object.entries(process.env)
+          .filter(
+            (
+              entry: [string, string | undefined],
+            ): entry is [string, string] =>
+              !isUndefined(entry[1]) && entry[0].includes(`SECRET`),
+          )
+          .map(([k, v]): string => v)
     }
 
     this.instance = new Signale.Signale(this.options)
     this.instance.config({displayLabel: false})
-    if (args.verbose) this.verbose = true
-    if (args.log) this.enabled = true
+
+    if (args.verbose || this.options.logLevel === `info`)
+      this.verbose = true
+    if (
+      args.log ||
+      (this.options.logLevel &&
+        [`info`, `log`].includes(this.options.logLevel))
+    )
+      this.enabled = true
     if (args.silent) this.enabled = false
   }
 

--- a/sources/@roots/bud-wordpress-theme-json/README.md
+++ b/sources/@roots/bud-wordpress-theme-json/README.md
@@ -61,7 +61,7 @@ bud.wptheme
     theme
       .set("typography.customFontSizes", true)
       .set("typography.fontWeight", false)
-      .merge("spacing.units", ["px", "%", "em"])
+      .merge("spacing.units", ["px", "%", "em"]),
   )
   .enable();
 ```

--- a/sources/@roots/bud/README.md
+++ b/sources/@roots/bud/README.md
@@ -9,7 +9,7 @@
 <h1 align="center"><strong>@roots/bud</strong></h1>
 
 <p align="center">
-  Frontend build tools combining the best parts of Symfony Encore and Laravel Mix
+  Configurable, extensible build tools for modern single and multi-page web applications
 </p>
 
 ---

--- a/sources/@roots/bud/package.json
+++ b/sources/@roots/bud/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roots/bud",
   "version": "0.0.0",
-  "description": "Frontend build tools combining the best parts of Symfony Encore and Laravel Mix",
+  "description": "Configurable, extensible build tools for modern single and multi-page web applications",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/sources/create-bud-app/src/tasks/write.bud.config.ts
+++ b/sources/create-bud-app/src/tasks/write.bud.config.ts
@@ -40,7 +40,7 @@ export default async function writeConfigTask(command: CreateCommand) {
 
     await command.fs.write(
       `bud.config.ts`,
-      formatSource(result, {parser: `typescript`}),
+      await formatSource(result, {parser: `typescript`}),
     )
 
     spinner.succeed()

--- a/sources/create-bud-app/src/tasks/write.eslint.config.ts
+++ b/sources/create-bud-app/src/tasks/write.eslint.config.ts
@@ -19,36 +19,36 @@ export default async function writeStylelintConfigTask(
     )
   }
 
+  const configExtends = [`@roots/eslint-config`]
+
+  /** babel syntax */
+  command.support.includes(`babel`) &&
+    configExtends.push(`@roots/eslint-config/babel`)
+
+  /** ts syntax */
+  ;(command.support.includes(`typescript`) ||
+    command.support.includes(`swc`)) &&
+    configExtends.push(`@roots/eslint-config/typescript`)
+
+  /** react syntax */
+  command.support.includes(`react`) &&
+    configExtends.push(`@roots/eslint-config/react`)
+
+  /** wordpress rules */
+  command.support.includes(`wordpress`) &&
+    configExtends.push(`@roots/eslint-config/wordpress`)
+
+  const source = await command.fs.read(
+    join(command.createRoot, `templates`, `eslint.config.js.hbs`),
+    `utf8`,
+  )
+
   try {
-    const configExtends = [`@roots/eslint-config`]
-
-    /** babel syntax */
-    command.support.includes(`babel`) &&
-      configExtends.push(`@roots/eslint-config/babel`)
-
-    /** ts syntax */
-    ;(command.support.includes(`typescript`) ||
-      command.support.includes(`swc`)) &&
-      configExtends.push(`@roots/eslint-config/typescript`)
-
-    /** react syntax */
-    command.support.includes(`react`) &&
-      configExtends.push(`@roots/eslint-config/react`)
-
-    /** wordpress rules */
-    command.support.includes(`wordpress`) &&
-      configExtends.push(`@roots/eslint-config/wordpress`)
-
-    const source = await command.fs.read(
-      join(command.createRoot, `templates`, `eslint.config.js.hbs`),
-      `utf8`,
-    )
-
     const template = templateEngine.compile(source)
 
     const result = template({extends: configExtends})
 
-    await command.fs.write(`eslint.config.js`, formatSource(result))
+    await command.fs.write(`eslint.config.js`, await formatSource(result))
   } catch (error) {
     spinner.fail()
     throw error

--- a/sources/create-bud-app/src/tasks/write.prettier.config.ts
+++ b/sources/create-bud-app/src/tasks/write.prettier.config.ts
@@ -29,7 +29,7 @@ export default async function writeStylelintConfigTask(
   const result = template({})
 
   try {
-    await command.fs.write(`.prettierrc.cjs`, formatSource(result))
+    await command.fs.write(`.prettierrc.cjs`, await formatSource(result))
   } catch (error) {
     spinner.fail()
     throw error

--- a/sources/create-bud-app/src/tasks/write.stylelint.config.ts
+++ b/sources/create-bud-app/src/tasks/write.stylelint.config.ts
@@ -45,7 +45,10 @@ export default async function writeStylelintConfigTask(
 
     const result = template({extends: configExtends})
 
-    await command.fs.write(`stylelint.config.cjs`, formatSource(result))
+    await command.fs.write(
+      `stylelint.config.cjs`,
+      await formatSource(result),
+    )
   } catch (error) {
     spinner.fail()
     throw error

--- a/sources/create-bud-app/src/tasks/write.tsconfig.ts
+++ b/sources/create-bud-app/src/tasks/write.tsconfig.ts
@@ -51,7 +51,7 @@ export default async function writeTsConfig(command: CreateCommand) {
 
     await command.fs.write(
       `tsconfig.json`,
-      formatSource(source, {parser: `json`}),
+      await formatSource(source, {parser: `json`}),
     )
   } catch (error) {
     spinner.fail()

--- a/sources/create-bud-app/src/utilities/formatSource.ts
+++ b/sources/create-bud-app/src/utilities/formatSource.ts
@@ -2,8 +2,8 @@ import type {Options} from 'prettier'
 
 import {format} from 'prettier'
 
-export default (code: string, options: Partial<Options> = {}) => {
-  return format(code, {
+export default async (code: string, options: Partial<Options> = {}) => {
+  return await format(code, {
     bracketSpacing: false,
     parser: `babel`,
     printWidth: 75,


### PR DESCRIPTION
prettier@3.0.0 broke readme gen and create-bud-app because the `format` export is now async.



## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
