### PR TITLE
✨ improve(minor): no split chunks (@roots/sage)

### DIFF
--- a/sources/@roots/sage/src/sage/index.ts
+++ b/sources/@roots/sage/src/sage/index.ts
@@ -47,7 +47,7 @@ class Sage extends Extension {
       })
       .when(
         bud.isProduction,
-        () => bud.minimize().hash().splitChunks(),
+        () => bud.hash(),
         () => bud.devtool(),
       )
       .hooks.on(`build.output.uniqueName`, `@roots/bud/sage/${bud.label}`)

--- a/sources/@roots/sage/test/sage/extension.test.ts
+++ b/sources/@roots/sage/test/sage/extension.test.ts
@@ -63,35 +63,20 @@ describe(`@roots/sage`, async () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  it(`should call bud.minimize in production`, async () => {
+  it(`should call bud.hash in production`, async () => {
     const bud = await factory({mode: `production`})
     expect(bud.isProduction).toBe(true)
 
     const whenSpy = vi.spyOn(bud, `when`)
-    const spy = vi.spyOn(bud, `minimize`)
-    await sage.register(bud)
-    expect(whenSpy).toHaveBeenCalledWith(
-      true,
-      expect.any(Function),
-      expect.any(Function),
-    )
-    expect(spy).toHaveBeenCalled()
-  })
-
-  it(`should call bud.splitChunks in production`, async () => {
-    const bud = await factory({mode: `production`})
-    expect(bud.isProduction).toBe(true)
-
-    const whenSpy = vi.spyOn(bud, `when`)
-    const spy = vi.spyOn(bud, `splitChunks`)
     const devtoolSpy = vi.spyOn(bud, `devtool`)
+    const hashSpy = vi.spyOn(bud, `hash`)
     await sage.register(bud)
     expect(whenSpy).toHaveBeenCalledWith(
       true,
       expect.any(Function),
       expect.any(Function),
     )
-    expect(spy).toHaveBeenCalled()
+    expect(hashSpy).toHaveBeenCalled()
     expect(devtoolSpy).not.toHaveBeenCalled()
   })
 
@@ -100,7 +85,7 @@ describe(`@roots/sage`, async () => {
     expect(bud.isProduction).toBe(false)
     const whenSpy = vi.spyOn(bud, `when`)
     const devtoolSpy = vi.spyOn(bud, `devtool`)
-    const splitChunksSpy = vi.spyOn(bud, `splitChunks`)
+    const hashSpy = vi.spyOn(bud, `hash`)
     await sage.register(bud)
     expect(whenSpy).toHaveBeenCalledWith(
       false,
@@ -108,6 +93,6 @@ describe(`@roots/sage`, async () => {
       expect.any(Function),
     )
     expect(devtoolSpy).toHaveBeenCalled()
-    expect(splitChunksSpy).not.toHaveBeenCalled()
+    expect(hashSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/reproductions/issue-2126.test.ts
+++ b/tests/reproductions/issue-2126.test.ts
@@ -29,8 +29,7 @@ describe(`issue-2126`, () => {
       ),
       `utf8`,
     )
-    expect(js.length).toBeLessThan(65000)
-
+    expect(js.length).toBeLessThan(75000)
     const css = await fs.read(
       join(
         paths.tests,


### PR DESCRIPTION
- don't create vendor chunk by default
- users can create a vendor chunk using [bud.bundle](https://bud.js.org/docs/bud.bundle) or async imports
- prevents `@wordpress/*` dependencies from being enqueued by Acorn for multiple entrypoints when they are only utilized in one

## References

- https://discourse.roots.io/t/updating-bud-to-6-14-x-adds-all-wp-includes-scripts-to-front-end/25736

## Type of change

**MINOR: feature**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
