### PR TITLE
🩹 fix(patch): create-bud-app fails when no dependencies are selected

### DIFF
--- a/sources/create-bud-app/src/tasks/install.dev.ts
+++ b/sources/create-bud-app/src/tasks/install.dev.ts
@@ -5,6 +5,10 @@ export default async function installTask(command: CreateCommand) {
   const spinner = command.createSpinner()
   spinner.start(`Installing development dependencies...`)
 
+  if (!command.dependencies?.length) {
+    return spinner.succeed(`No development dependencies to install.`)
+  }
+
   try {
     const formatSignifier = createSignifierFormatter(command)
 

--- a/sources/create-bud-app/src/tasks/install.prod.ts
+++ b/sources/create-bud-app/src/tasks/install.prod.ts
@@ -5,6 +5,10 @@ export default async function installTask(command: CreateCommand) {
   const spinner = command.createSpinner()
   spinner.start(`Installing runtime dependencies...`)
 
+  if (!command.dependencies?.length) {
+    return spinner.succeed(`No runtime dependencies to install.`)
+  }
+
   try {
     switch (command.packageManager) {
       case `npm`:


### PR DESCRIPTION
If no dependencies are selected `create-bud-app` will fail on installation step.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
