### PR TITLE
📕 docs(none): wordpress preset code samples

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-preset-wordpress/index.mdx
+++ b/sources/@repo/docs/content/extensions/bud-preset-wordpress/index.mdx
@@ -27,36 +27,22 @@ npm install @roots/bud-preset-wordpress --save-dev
 
 If you are using [roots/sage](https://roots.io/sage) these details are handled for you by Acorn.
 
-Otherwise you will want to do something like this:
+If not, you will want to do something like this:
 
 ```php
 add_action('enqueue_block_editor_assets', function () {
-  // couple helper functions
-  $get_path = fn ($endpoint) => join([get_template_directory(), 'dist', $endpoint], '/');
-  $read = fn ($endpoint) => file_get_contents($dist_path($endpoint));
+  $url = fn ($endpoint) => join("/", [plugin_dir_url(__FILE__), 'dist', $endpoint]);
+  $path = fn ($endpoint) => join("/", [plugin_dir_path(__FILE__), 'dist', $endpoint]);
+  $read = fn ($endpoint) => file_get_contents($path($endpoint));
 
-  // entrypoints.json as an object
   $entrypoints = json_decode($read('entrypoints.json'));
 
   wp_enqueue_script(
-    'my-theme/editor/js',
-    $get_path($entrypoints->editor->js[1]),
+    'my-plugin/js',
+    $url($entrypoints->app->js[0]),
     [],
     null,
     true
-  );
-
-  wp_enqueue_inline_script(
-    'my-theme/editor/js',
-    $read($entrypoints->editor->js[0]),
-    'before',
-  );
-
-  wp_enqueue_style(
-    'my-theme/editor/css',
-    $get_path($entrypoints->editor->css[0]),
-    [],
-    null
   );
 });
 ```
@@ -100,26 +86,23 @@ If you check out `entrypoints.json` you'll see the WordPress dependencies listed
 
 The intent is for you to read this file in your WordPress theme or plugin and enqueue the dependencies dynamically.
 
-For example, building off the previous example code, this is how one might handle enqueues in a WordPress theme:
+Building off the previous example code, this is how one might handle enqueueing dependencies with the WordPress API:
 
 ```php
 add_action('enqueue_block_editor_assets', function () {
-  // couple helper functions
-  $get_path = fn ($endpoint) => join([get_template_directory(), 'dist', $endpoint], '/');
-  $read = fn ($endpoint) => file_get_contents($dist_path($endpoint));
+  $url = fn ($endpoint) => join("/", [plugin_dir_url(__FILE__), 'dist', $endpoint]);
+  $path = fn ($endpoint) => join("/", [plugin_dir_path(__FILE__), 'dist', $endpoint]);
+  $read = fn ($endpoint) => file_get_contents($path($endpoint));
 
-  // entrypoints.json as an object
   $entrypoints = json_decode($read('entrypoints.json'));
 
   wp_enqueue_script(
-    'my-theme/editor/js',
-    $get_path($entrypoints->editor->js[1]),
-    $entrypoints->editor->dependencies,
+    'my-plugin/js',
+    $url($entrypoints->app->js[0]),
+    $entrypoints->app->dependencies,
     null,
     true
   );
-
-  // ...
 });
 ```
 

--- a/sources/@roots/bud/README.md
+++ b/sources/@roots/bud/README.md
@@ -32,7 +32,7 @@ npm install @roots/bud --save-dev
 
 ## Getting started
 
-For helpn getting started consult the [Getting Started guide on bud.js.org](https://bud.js.org/guides/getting-started)
+For help getting started consult the [Getting Started guide on bud.js.org](https://bud.js.org/guides/getting-started)
 
 ## CLI
 

--- a/sources/@roots/bud/docs/01-getting-started.md
+++ b/sources/@roots/bud/docs/01-getting-started.md
@@ -2,4 +2,4 @@
 title: Getting started
 ---
 
-For helpn getting started consult the [Getting Started guide on bud.js.org](https://bud.js.org/guides/getting-started)
+For help getting started consult the [Getting Started guide on bud.js.org](https://bud.js.org/guides/getting-started)

--- a/yarn.lock
+++ b/yarn.lock
@@ -15305,9 +15305,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001503":
-  version: 1.0.30001517
-  resolution: "caniuse-lite@npm:1.0.30001517"
-  checksum: e4e87436ae1c4408cf4438aac22902b31eb03f3f5bad7f33bc518d12ffb35f3fd9395ccf7efc608ee046f90ce324ec6f7f26f8a8172b8c43c26a06ecee612a29
+  version: 1.0.30001520
+  resolution: "caniuse-lite@npm:1.0.30001520"
+  checksum: 59991ad8f36cf282f81abbcc6074c3097c21914cdd54bd2b3f73ac9462f57fc74e90371cd22bcdff4d085d09da42a07dcea384cb81e4ac260496e1bd79e1fe7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fixes/improves wordpress preset code samples.
- Fixes a typo in `@roots/bud` readme.

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
