### PR TITLE
🩹 fix(patch): sass-loader resolve

### DIFF
--- a/sources/@roots/bud-sass/src/extension.ts
+++ b/sources/@roots/bud-sass/src/extension.ts
@@ -41,7 +41,7 @@ export class BudSass extends BudSassOptions {
   @bind
   public override async register({build, hooks}: Bud) {
     /** Source loader */
-    const loader = await this.resolve(`sass-loader`)
+    const loader = await this.resolve(`sass-loader`, import.meta.url)
     if (!loader) return this.logger.error(`sass-loader not found`)
 
     /** Source sass implementation */


### PR DESCRIPTION
Fixes a problem which could prevent sass-loader from resolving correctly.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
