### PR TITLE
🩹 fix(patch): fix emotion plugin resolution (@roots/bud-emotion)

### DIFF
--- a/sources/@roots/bud-cache/test/service.test.ts
+++ b/sources/@roots/bud-cache/test/service.test.ts
@@ -26,7 +26,6 @@ describe(`@roots/bud-cache`, () => {
     expect(cache.register).toBeInstanceOf(Function)
   })
 
-
   it(`should have a buildDependencies accessor interface`, async () => {
     expect(cache.buildDependencies).toBeDefined()
     expect(cache.buildDependencies).toBeInstanceOf(Object)
@@ -43,33 +42,48 @@ describe(`@roots/bud-cache`, () => {
     await cache.register?.(bud)
     await cache.boot?.(bud)
     expect(cache.configuration).toBeDefined()
-    expect(cache.configuration).toMatchInlineSnapshot(`
-      {
-        "allowCollectingMemory": true,
-        "buildDependencies": {
-          "bud": [
-            "${bud.path(`package.json`)}",
-            "${bud.path(`tsconfig.json`)}",
-            "${bud.path(`config/bud.config.js`)}",
-          ],
-          "tailwind": [
-            "${bud.path(`config/tailwind.config.js`)}",
-          ],
-        },
-        "cacheDirectory": "${bud.context.paths?.[`os-cache`]}/@tests/project/cache",
-        "compression": "brotli",
-        "hashAlgorithm": "xxhash64",
-        "idleTimeout": 100,
-        "idleTimeoutForInitialStore": 0,
-        "managedPaths": [
-          "${bud.context.paths?.[`os-cache`]}/@tests/project/cache",
-          "${bud.path(`@modules`)}",
-        ],
-        "name": "production",
-        "profile": false,
-        "store": "pack",
-        "type": "filesystem",
-      }
-    `)
+    expect(cache.configuration).toBeInstanceOf(Object)
+
+    // @ts-ignore
+    expect(cache.configuration?.allowCollectingMemory).toEqual(true)
+    // @ts-ignore
+    expect(cache.configuration?.buildDependencies?.bud).toEqual(
+      expect.arrayContaining([
+        bud.path(`package.json`),
+        bud.path(`config/bud.config.js`),
+        bud.path(`tsconfig.json`),
+      ]),
+    )
+    // @ts-ignore
+    expect(cache.configuration?.buildDependencies?.tailwind).toEqual(
+      expect.arrayContaining([bud.path(`config/tailwind.config.js`)]),
+    )
+    // @ts-ignore
+    expect(cache.configuration?.cacheDirectory).toMatch(
+      /@tests\/project\/cache$/,
+    )
+    // @ts-ignore
+    expect(cache.configuration?.compression).toEqual(`brotli`)
+    // @ts-ignore
+    expect(cache.configuration?.hashAlgorithm).toEqual(`xxhash64`)
+    // @ts-ignore
+    expect(cache.configuration?.idleTimeout).toEqual(100)
+    // @ts-ignore
+    expect(cache.configuration?.idleTimeoutForInitialStore).toEqual(0)
+    // @ts-ignore
+    expect(cache.configuration?.managedPaths).toEqual(
+      expect.arrayContaining([
+        bud.context.paths?.[`os-cache`] + `/@tests/project/cache`,
+        bud.path(`@modules`),
+      ]),
+    )
+    // @ts-ignore
+    expect(cache.configuration?.name).toEqual(`production`)
+    // @ts-ignore
+    expect(cache.configuration?.profile).toEqual(false)
+    // @ts-ignore
+    expect(cache.configuration?.store).toEqual(`pack`)
+    // @ts-ignore
+    expect(cache.configuration?.type).toEqual(`filesystem`)
   })
 })

--- a/sources/@roots/bud-emotion/src/extension.ts
+++ b/sources/@roots/bud-emotion/src/extension.ts
@@ -19,16 +19,18 @@ export class BudEmotion extends Extension<{}, null> {
   @bind
   public override async boot(bud: Bud) {
     if (`babel` in bud) {
-      const babelPlugin = await this.resolve(`@emotion/babel-plugin`)
-      bud.babel.setPlugin(`@emotion/babel-plugin`, babelPlugin)
+      const babelPlugin = await this.resolve(`@emotion/babel-plugin`, import.meta.url)
+      if (typeof babelPlugin === `string`)
+        bud.babel.setPlugin(`@emotion/babel-plugin`, babelPlugin)
     }
 
     if (`swc` in bud) {
-      const swcPlugin = await this.resolve(`@swc/plugin-emotion`)
-      bud.swc.setExperimentalPlugins((plugins = []) => [
-        ...plugins,
-        [swcPlugin, {}],
-      ])
+      const swcPlugin = await this.resolve(`@swc/plugin-emotion`, import.meta.url)
+      if (typeof swcPlugin === `string`)
+        bud.swc.setPlugins((plugins = []) => [
+          ...plugins,
+          [swcPlugin, {}],
+        ])
     }
   }
 }

--- a/sources/@roots/bud-framework/src/extension/index.ts
+++ b/sources/@roots/bud-framework/src/extension/index.ts
@@ -423,7 +423,7 @@ export class Extension<
   @bind
   public async import<T = any>(
     signifier: string,
-    context?: string,
+    context: string,
     options: {bustCache?: boolean; raw?: boolean} = {
       bustCache: false,
       raw: false,
@@ -464,7 +464,7 @@ export class Extension<
   @bind
   public async resolve(
     signifier: string,
-    context?: string,
+    context: string,
   ): Promise<string> {
     try {
       return await this.app.module.resolve(signifier, context)

--- a/yarn.lock
+++ b/yarn.lock
@@ -15449,9 +15449,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001503, caniuse-lite@npm:^1.0.30001517":
-  version: 1.0.30001520
-  resolution: "caniuse-lite@npm:1.0.30001520"
-  checksum: 59991ad8f36cf282f81abbcc6074c3097c21914cdd54bd2b3f73ac9462f57fc74e90371cd22bcdff4d085d09da42a07dcea384cb81e4ac260496e1bd79e1fe7c
+  version: 1.0.30001521
+  resolution: "caniuse-lite@npm:1.0.30001521"
+  checksum: be2a2b2cd3be03401887aaa31b89f3e7c6230289e6ef704e224268389cc136480fca502ac9e5001a65ff1e50459d3d95f8c4b2d39f878ab9843af3d6f372c8bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fix Extension.resolve call for `@roots/bud-emotion` swc/babel plugins.
- Improve test spec for `@roots/bud-cache`. 
  _Snapshot testing is bad for the cache object because of the order of array items being dependent on a race condition._

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
