### PR TITLE
🩹 fix(patch): fix `bud upgrade`

### DIFF
--- a/sources/@roots/bud/src/cli/commands/upgrade/index.tsx
+++ b/sources/@roots/bud/src/cli/commands/upgrade/index.tsx
@@ -112,6 +112,7 @@ export default class BudUpgradeCommand extends BudCommand {
     }
 
     this.command = this.pm === `npm` ? `install` : `add`
+    this.pm = this.pm === `yarn-classic` ? `yarn` : this.pm
 
     if (!this.version) {
       const get = await import(`@roots/bud-support/axios`)


### PR DESCRIPTION
Fix an issue with `bud upgrade` when using yarn (classic).

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
