### PR TITLE
🩹 fix(patch): create-bud-app readme template link update

### DIFF
--- a/sources/create-bud-app/templates/README.md.hbs
+++ b/sources/create-bud-app/templates/README.md.hbs
@@ -1,6 +1,6 @@
 # {{name}}
 
-This project was bootstrapped with [Create Bud App](https://github.com/roots/bud/tree/main/sources/@roots/create-bud-app).
+This project was bootstrapped with [Create Bud App](https://github.com/roots/bud/tree/main/sources/create-bud-app).
 
 Consult [the bud.js documentation](https://bud.js.org) for information on configuring and using bud.js.
 


### PR DESCRIPTION
Minor change to create-bud-app readme template fixing broken link back to create-bud-app repo source.

## Type of change

**PATCH: backwards compatible change**