### PR TITLE
 📕 docs(none): fix community extensions URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Also included in the bud monorepo are packages which are not specific to bud.js 
 
 ## Community extensions
 
-| Package                                                                         | Latest                                                                                  |
-| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| [**bud-embedded**](https://github.com/roots/bud/tree/main/sources/bud-embedded) | ![npm](https://img.shields.io/npm/v/bud-embedded.svg?color=%23525ddc&style=flat-square) |
+| Package                                                     | Latest                                                                                  |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [**bud-embedded**](https://github.com/talss89/bud-embedded) | ![npm](https://img.shields.io/npm/v/bud-embedded.svg?color=%23525ddc&style=flat-square) |
 
 ## Contributing
 

--- a/sources/@repo/markdown-kit/readme/templates/root.md
+++ b/sources/@repo/markdown-kit/readme/templates/root.md
@@ -84,7 +84,7 @@ Also included in the bud monorepo are packages which are not specific to bud.js 
 
 | Package                                                                                                                                         | Latest                                                                                                                  |
 | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| [**bud-embedded**]({{projectConfig.url.web}}/tree/main/sources/bud-embedded)                                                   | ![npm](https://img.shields.io/npm/v/bud-embedded.svg?color=%23525ddc&style=flat-square)                          |
+| [**bud-embedded**](https://github.com/talss89/bud-embedded)                                                   | ![npm](https://img.shields.io/npm/v/bud-embedded.svg?color=%23525ddc&style=flat-square)                          |
 
 ## Contributing
 


### PR DESCRIPTION
URL was relative to roots/bud repo, now absolute.

Not sure how the docs are compiled from the templates in the repo, so have marked this PR as draft.

Thanks a lot for the link back to the extension! 👍 

## Type of change

**NONE: internal change**
