### PR TITLE
docs: `--target` becomes `--filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Quickly scaffold a new project with `create-bud-app`:
 
 > npx create-bud-app
 
-If you want to add bud.js to an existing project or want to further customize the scaffolded app check out the [Getting Started guide](https://bud.js.org/guides/getting-started).
+If you want to add bud.js to an existing project or want to further customize the scaffolded app check out the [Getting Started guide](https://bud.js.org/learn/getting-started).
 
 There are [many example implementations available](https://github.com/roots/bud/tree/master/examples).
 
@@ -93,7 +93,7 @@ There are [many example implementations available](https://github.com/roots/bud/
 
 Have you produced a bud.js extension and want to share it here? Please, create an issue sharing information about your project.
 
-For more information on authoring your own extension [consult the documentation](https://bud.js.org/guides/extending/) and the source code of the extensions in this repository.
+For more information on authoring your own extension [consult the documentation](https://bud.js.org/learn/extending/) and the source code of the extensions in this repository.
 
 ### Packages
 

--- a/sources/@repo/docs/content/learn/general-use/multi-instance.mdx
+++ b/sources/@repo/docs/content/learn/general-use/multi-instance.mdx
@@ -40,21 +40,21 @@ export default async bud => {
 
 See the [bud.make](/reference/bud.make) documentation for more information.
 
-## Using the `--target` flag
+## Using the `--filter` flag
 
 The other benefit is a potentially massive workflow improvement. Let's say that we have to work on the `theme` more often than the `plugin`.
 With the above config we don't have to rebuild the `plugin` code again just to work on our `theme` code.
 
-We can use the `bud` cli to only run the compiler we need using [the `--target` flag](/learn/cli/build).
+We can use the `bud` cli to only run the compiler we need using [the `--filter` flag](/learn/cli/build).
 
 ```sh
-$ yarn bud build --target theme
+$ yarn bud build --filter theme
 ```
 
-If you had more than two instances it might make sense to want to target more than one compiler, and `--target` supports that:
+If you had more than two instances it might make sense to want to target more than one compiler, and `--filter` supports that:
 
 ```sh
-$ yarn bud build --target theme --target plugin
+$ yarn bud build --filter theme --filter plugin
 ```
 
 ## Configuring unique extensions per compiler


### PR DESCRIPTION
@mikespainhower on Discord pointed out that `--target` seems to have been removed.

It looks like to me that the same functionality is now provided by `--filter`. Have tested `--filter` on a multi-instance setup and it targets the instance with the matching `bud.context.label`.

This PR is a search-replace on the docs page, `--target` becomes `--filter`.

Still haven't got a working Bud-dev setup running, so these will need compiling too (sorry).

## Type of change

**NONE: internal change**
