### PR TITLE
🧪 test(none): improve test cache management

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+APP_STORAGE_PATH=.storage

--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,26 @@
-# secret
-.env
-!tests/unit/bud/context/**/.env
-
+**/*.log
+**/*.tsbuildinfo
+**/.budfiles
+**/.docusaurus
+**/.env
+**/.netlify
+**/.pnp.*
+**/.storage
 **/.swc
+**/.yarn
+**/dist
+**/lib
+**/node_modules
+**/profiles
 
 coverage
+sources/@repo/docs/content/dev/api/**/*
+sources/@repo/docs/build
+sources/@repo/docs/generated/*/*
+sources/@repo/*/compiled
 storage/**/*
 
-# Yarn
-**/*.log
-**/lib
-**/*.tsbuildinfo
-**/profiles
-**/.budfiles
-**/.pnp.*
-**/.yarn
-!/.yarn
-
-# Netlify
-**/.netlify
-
-# Sources
-/sources/@repo/docs/content/dev/api/**/*
-/sources/@repo/docs/build
-/sources/@repo/docs/.docusaurus
-/sources/@repo/docs/generated/*/*
-!/sources/@repo/docs/generated/*/.gitkeep
-/sources/@repo/*/compiled
-
-**/dist
-**/.budfiles
-**/node_modules
+!.env
+!**/.gitkeep
+!.yarn
+!tests/unit/bud/context/**/.env

--- a/sources/@roots/bud-cache/test/service.test.ts
+++ b/sources/@roots/bud-cache/test/service.test.ts
@@ -73,7 +73,7 @@ describe(`@roots/bud-cache`, () => {
     // @ts-ignore
     expect(cache.configuration?.managedPaths).toEqual(
       expect.arrayContaining([
-        bud.context.paths?.[`os-cache`] + `/@tests/project/cache`,
+        bud.path(`.storage/@tests/project/cache`),
         bud.path(`@modules`),
       ]),
     )


### PR DESCRIPTION
Improve cache management for fixtures and examples by setting `APP_STORAGE_PATH=.storage` in repo root .env.

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
