### PR TITLE
🩹 fix(patch): fix macos notifier default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,7 +33,7 @@
     "verdaccio": true,
     "**/pnp.*": true,
     "**/node_modules": true,
-    "**/.budfiles/**/*": true
+    "**/.storage": true
   },
   "prettier.configPath": "config/prettier.config.js",
   "prettier.ignorePath": "config/.prettierignore",

--- a/sources/@roots/bud-framework/src/notifier.ts
+++ b/sources/@roots/bud-framework/src/notifier.ts
@@ -11,6 +11,7 @@ import {fileURLToPath} from 'node:url'
 import isEmpty from '@roots/bud-support/lodash/isEmpty'
 import isString from '@roots/bud-support/lodash/isString'
 import isUndefined from '@roots/bud-support/lodash/isUndefined'
+import logger from '@roots/bud-support/logger'
 import {open, openEditor} from '@roots/bud-support/open'
 
 /**
@@ -139,7 +140,20 @@ export class Notifier {
    * True if notifications are enabled
    */
   public get notificationsEnabled(): boolean {
-    return this.app?.context.notify === true
+    if (this.app?.context.notify === true) {
+      logger.scope(`notifier`).log(`Notifications enabled`)
+      return true
+    }
+
+    if (
+      this.app?.context.notify === undefined &&
+      platform() === `darwin`
+    ) {
+      logger.scope(`notifier`).log(`Notifications enabled (macos default)`)
+      return true
+    }
+
+    return false
   }
 
   /**

--- a/sources/@roots/bud/test/cli-flag-minimize/flag-minimize.test.ts
+++ b/sources/@roots/bud/test/cli-flag-minimize/flag-minimize.test.ts
@@ -1,0 +1,48 @@
+import {path} from '@repo/constants'
+import {execa} from 'execa'
+import fs from 'fs-jetpack'
+import {expect, test} from 'vitest'
+
+test(`--minimize`, async () => {
+  await fs.removeAsync(
+    path(`sources/@roots/bud/test/cli-flag-minimize/project/dist`),
+  )
+
+  await execa(`yarn`, [
+    `workspace`,
+    `@tests/minimize-flag`,
+    `run`,
+    `bud`,
+    `build`,
+    `--no-minimize`,
+  ])
+
+  expect(
+    await fs.readAsync(
+      path(
+        `sources/@roots/bud/test/cli-flag-minimize/project/dist/js/main.js`,
+      ),
+    ),
+  ).toMatch(/\n/)
+
+  await fs.removeAsync(
+    path(`sources/@roots/bud/test/cli-flag-minimize/project/dist`),
+  )
+
+  await execa(`yarn`, [
+    `workspace`,
+    `@tests/minimize-flag`,
+    `run`,
+    `bud`,
+    `build`,
+    `--minimize`,
+  ])
+
+  expect(
+    await fs.readAsync(
+      path(
+        `sources/@roots/bud/test/cli-flag-minimize/project/dist/js/main.js`,
+      ),
+    ),
+  ).not.toMatch(/\n/)
+})

--- a/sources/@roots/bud/test/cli-flag-minimize/project/package.json
+++ b/sources/@roots/bud/test/cli-flag-minimize/project/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@tests/minimize-flag",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@roots/bud": "workspace:*"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11515,6 +11515,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@tests/minimize-flag@workspace:sources/@roots/bud/test/cli-flag-minimize/project":
+  version: 0.0.0-use.local
+  resolution: "@tests/minimize-flag@workspace:sources/@roots/bud/test/cli-flag-minimize/project"
+  dependencies:
+    "@roots/bud": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@tests/project@workspace:tests/util/project":
   version: 0.0.0-use.local
   resolution: "@tests/project@workspace:tests/util/project"


### PR DESCRIPTION
notifier should be enabled by default for macos.

- adds check to `Notifier.notificationsEnabled` getter.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
