### PR TITLE
✨ improve(patch): improve facades

### DIFF
--- a/examples/babel/bud.config.js
+++ b/examples/babel/bud.config.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * @param {import('@roots/bud').Bud} bud
  */

--- a/examples/config-yml/bud.config.yml
+++ b/examples/config-yml/bud.config.yml
@@ -14,11 +14,16 @@ runtime: true
 assets:
   - ['src/**/*.html']
 
-# Inner properties of bud are fair game
+# You can access inner properties
 babel:
   setPluginOptions:
     - '@babel/plugin-transform-runtime'
     - {helpers: true}
+
+# You can use dot notation
+babel.setPluginOptions:
+  - '@babel/plugin-transform-runtime'
+  - {helpers: true}
 
 # prefix bud properties with _
 # to reference the value

--- a/sources/@roots/bud-api/src/index.ts
+++ b/sources/@roots/bud-api/src/index.ts
@@ -162,7 +162,39 @@ declare module '@roots/bud-framework' {
     /**
      * ## bud.hash
      *
+     * Hash output filenames
+     *
      * {@link https://bud.js.org/docs/bud.hash 📕 Documentation}
+     *
+     * @example
+     * Enable:
+     * ```js
+     * bud.hash()
+     * ```
+     *
+     * @example
+     * Disable:
+     * ```js
+     * bud.hash(false)
+     * ```
+     *
+     * @example
+     * Enable with custom format:
+     * ```js
+     * bud.hash('contenthash:8')
+     * ```
+     *
+     * @example
+     * Enable with a bud.js callback:
+     * ```js
+     * bud.when(bud.isProduction, bud.hash)
+     * ```
+     *
+     * @example
+     * Transform the existing value:
+     * ```js
+     * bud.hash((value) => !value)
+     * ```
      */
     hash(...params: Hash.Parameters): Bud
 

--- a/sources/@roots/bud-api/src/methods/config/index.ts
+++ b/sources/@roots/bud-api/src/methods/config/index.ts
@@ -6,6 +6,7 @@ import isFunction from '@roots/bud-support/lodash/isFunction'
 
 export type Parameters = [
   | ((config: Partial<Configuration>) => Partial<Configuration>)
+  | ((config: Partial<Configuration>) => Promise<Partial<Configuration>>)
   | Partial<Configuration>,
 ]
 
@@ -27,7 +28,7 @@ export const config: config = function (this: Bud, input): Bud {
     if (!app) return
 
     app.build.config = isFunction(input)
-      ? input(app.build.config)
+      ? await input(app.build.config)
       : {...app.build.config, ...input}
   })
 

--- a/sources/@roots/bud-api/src/methods/devtool/index.ts
+++ b/sources/@roots/bud-api/src/methods/devtool/index.ts
@@ -22,7 +22,7 @@ export const devtool: devtool = async function (
   if (input instanceof Bud) {
     this.hooks.on(`build.devtool`, FALLBACK_SOURCEMAP)
 
-    this.api.logger.success(`bud.devtool`, `devtool set to`, input)
+    this.api.logger.success(`bud.devtool:`, `devtool set to`, input)
 
     return this
   }

--- a/sources/@roots/bud-api/src/methods/minimize/index.ts
+++ b/sources/@roots/bud-api/src/methods/minimize/index.ts
@@ -14,35 +14,52 @@ export interface minimize {
 
 export const minimize: minimize = function (this: Bud, value = true) {
   if (value instanceof Bud) {
-    this.minimizers.enable(true)
-    this.minimizers.js.enable(true)
-    this.minimizers.css.enable(true)
+    ;[this.minimizers, this.minimizers.js, this.minimizers.css].map(
+      minimizer => minimizer.enable(true),
+    )
     return this
   }
 
   if (typeof value == `boolean`) {
-    this.minimizers.enable(value)
-    this.minimizers.js.enable(value)
-    this.minimizers.css.enable(value)
+    ;[this.minimizers, this.minimizers.js, this.minimizers.css].map(
+      minimizer => minimizer.enable(value),
+    )
     return this
   }
 
+  this.minimizers.enable(true)
+  this.minimizers.js.enable(false)
+  this.minimizers.css.enable(false)
+
   if (typeof value == `string`) {
-    this.minimizers.enable(true)
+    if (!(value in this.minimizers)) {
+      throw throwUndefinedMinimizer()
+    }
+
     this.minimizers[value].enable(true)
     return this
   }
 
   if (Array.isArray(value)) {
-    this.minimizers.enable(true)
-    value.map(key => {
-      this.minimizers[key].enable(true)
+    if (value.some(prop => !(prop in this.minimizers))) {
+      throw throwUndefinedMinimizer()
+    }
+    value.map(prop => {
+      this.minimizers[prop].enable(true)
     })
     return this
   }
 
   throw ConfigError.normalize(`Error in bud.minimize`, {
     details: `Invalid argument passed to bud.minimize. Value must be a boolean, string, or array of strings.`,
+    docs: new URL(`https://bud.js.org/reference/bud.minimize`),
+    thrownBy: `@roots/bud-api/methods/minimize`,
+  })
+}
+
+const throwUndefinedMinimizer = (): never => {
+  throw ConfigError.normalize(`Error in bud.minimize`, {
+    details: `Invalid argument passed to bud.minimize. Minimizer does not exist.`,
     docs: new URL(`https://bud.js.org/reference/bud.minimize`),
     thrownBy: `@roots/bud-api/methods/minimize`,
   })

--- a/sources/@roots/bud-api/src/methods/minimize/index.ts
+++ b/sources/@roots/bud-api/src/methods/minimize/index.ts
@@ -13,6 +13,9 @@ export interface minimize {
 }
 
 export const minimize: minimize = function (this: Bud, value = true) {
+  /**
+   * Handle {@link Bud} instances (when used as a callback for something like bud.tap, bud.promise, etc)
+   */
   if (value instanceof Bud) {
     ;[this.minimizers, this.minimizers.js, this.minimizers.css].map(
       minimizer => minimizer.enable(true),
@@ -20,6 +23,9 @@ export const minimize: minimize = function (this: Bud, value = true) {
     return this
   }
 
+  /**
+   * Handle true, false
+   */
   if (typeof value == `boolean`) {
     ;[this.minimizers, this.minimizers.js, this.minimizers.css].map(
       minimizer => minimizer.enable(value),
@@ -27,22 +33,31 @@ export const minimize: minimize = function (this: Bud, value = true) {
     return this
   }
 
+  /**
+   * For everything else, enable minimization and reset any state by disabling all minimizers
+   */
   this.minimizers.enable(true)
   this.minimizers.js.enable(false)
   this.minimizers.css.enable(false)
 
+  /**
+   * Handle string (`css`, `js`)
+   */
   if (typeof value == `string`) {
     if (!(value in this.minimizers)) {
-      throw throwUndefinedMinimizer()
+      throwUndefinedMinimizer()
     }
 
     this.minimizers[value].enable(true)
     return this
   }
 
+  /**
+   * Handle array of strings ([`css`, `js`])
+   */
   if (Array.isArray(value)) {
     if (value.some(prop => !(prop in this.minimizers))) {
-      throw throwUndefinedMinimizer()
+      throwUndefinedMinimizer()
     }
     value.map(prop => {
       this.minimizers[prop].enable(true)

--- a/sources/@roots/bud-api/src/methods/persist/index.ts
+++ b/sources/@roots/bud-api/src/methods/persist/index.ts
@@ -8,12 +8,6 @@ export interface persist {
 }
 
 export const persist: persist = function (this: Bud, type = `filesystem`) {
-  if (type instanceof Bud) {
-    this.cache.enabled = true
-    this.api.logger.success(`bud.cache:`, `set to`, type.cache.type)
-    return this
-  }
-
   if (type === false) {
     this.cache.enabled = false
     this.api.logger.success(`bud.cache:`, `disabled`)

--- a/sources/@roots/bud-api/src/methods/runtime/index.ts
+++ b/sources/@roots/bud-api/src/methods/runtime/index.ts
@@ -5,8 +5,8 @@ export type Parameters = [
   | ((
       runtime: Optimization.RuntimeChunk | undefined,
     ) => Optimization.RuntimeChunk)
+  | Bud
   | Optimization.RuntimeChunk
-  | undefined,
 ]
 
 export interface runtime {
@@ -17,8 +17,14 @@ export const runtime: runtime = async function (
   this: Bud,
   runtime = `single`,
 ) {
-  return this.hooks.on(
+  const value = runtime instanceof this.constructor ? `single` : runtime
+
+  this.hooks.on(
     `build.optimization.runtimeChunk`,
-    runtime === true ? `single` : runtime,
+    value,
   )
+
+  this.api.logger.success(`bud.runtime:`, `set to`, value)
+
+  return this
 }

--- a/sources/@roots/bud-api/src/methods/runtime/index.ts
+++ b/sources/@roots/bud-api/src/methods/runtime/index.ts
@@ -1,5 +1,6 @@
-import type {Bud} from '@roots/bud-framework'
 import type {Optimization} from '@roots/bud-framework/config'
+
+import {Bud} from '@roots/bud-framework'
 
 export type Parameters = [
   | ((
@@ -17,7 +18,7 @@ export const runtime: runtime = async function (
   this: Bud,
   runtime = `single`,
 ) {
-  const value = runtime instanceof this.constructor ? `single` : runtime
+  const value = runtime instanceof Bud || runtime === true  ? `single` : runtime
 
   this.hooks.on(
     `build.optimization.runtimeChunk`,

--- a/sources/@roots/bud-api/test/minimize.test.ts
+++ b/sources/@roots/bud-api/test/minimize.test.ts
@@ -48,7 +48,7 @@ describe(`bud.minimize`, () => {
     minimize(value)
 
     expect(spies.pop()).toHaveBeenCalledWith(true)
-    expect(spies.pop()).not.toHaveBeenCalled()
+    expect(spies.pop()).toHaveBeenCalledWith(false)
     expect(spies.pop()).toHaveBeenCalledWith(true)
   })
 
@@ -64,7 +64,7 @@ describe(`bud.minimize`, () => {
 
     expect(spies.pop()).toHaveBeenCalledWith(true)
     expect(spies.pop()).toHaveBeenCalledWith(true)
-    expect(spies.pop()).not.toHaveBeenCalled()
+    expect(spies.pop()).toHaveBeenCalledWith(false)
   })
 
   it(`should return bud`, () => {

--- a/sources/@roots/bud-framework/src/bud/index.ts
+++ b/sources/@roots/bud-framework/src/bud/index.ts
@@ -338,8 +338,9 @@ export class Bud {
    * Await all promised tasks
    */
   @bind
-  public promise(promise: (bud: Bud) => Promise<unknown>) {
+  public promise(promise: (bud: Bud) => Promise<unknown>): Bud {
     this.promised.push(promise)
+    return this
   }
 
   @bind

--- a/sources/@roots/bud-framework/src/configuration/index.ts
+++ b/sources/@roots/bud-framework/src/configuration/index.ts
@@ -41,8 +41,6 @@ class Configuration {
       })
     })
 
-    this.bud.log(`config`, config)
-
     if (!config) {
       throw ConfigError.normalize(`No configuration found`, {
         file: source,

--- a/sources/@roots/bud-framework/src/methods/sequence.ts
+++ b/sources/@roots/bud-framework/src/methods/sequence.ts
@@ -3,6 +3,9 @@ import type {Bud} from '../index.js'
 export interface Callback {
   (value?: Bud): Promise<unknown>
 }
+export interface Callback {
+  (value?: Bud): unknown
+}
 
 export interface sequence<T = Bud> {
   (fns: Array<Callback>): Promise<Bud>

--- a/sources/@roots/bud-minify/src/minify-css/index.ts
+++ b/sources/@roots/bud-minify/src/minify-css/index.ts
@@ -21,13 +21,17 @@ class BudMinimizeCSS extends BudMinimizeCSSPublicApi {
    * {@link Extension.buildBefore}
    */
   @bind
-  public override async buildBefore({extensions, hooks}: Bud) {
+  public override async buildBefore({extensions, hooks, module}: Bud) {
     const {
       default: Minimizer,
       esbuildMinify,
       lightningCssMinify,
       swcMinify,
-    } = await import(`css-minimizer-webpack-plugin`)
+    } = await module.import(
+      `css-minimizer-webpack-plugin`,
+      import.meta.url,
+      {raw: true},
+    )
 
     if (!this.minify && extensions.has(`@roots/bud-swc`))
       this.setMinify(() => swcMinify)

--- a/sources/@roots/bud-minify/src/minify-js/index.ts
+++ b/sources/@roots/bud-minify/src/minify-js/index.ts
@@ -20,13 +20,15 @@ class BudMinimizeJS extends BudMinimizeJSPublicApi {
    * {@link Extension.buildBefore}
    */
   @bind
-  public override async buildBefore({extensions, hooks}: Bud) {
+  public override async buildBefore({extensions, hooks, module}: Bud) {
     const {
       default: Minimizer,
       esbuildMinify,
       swcMinify,
       terserMinify,
-    } = await import(`terser-webpack-plugin`)
+    } = await module.import(`terser-webpack-plugin`, import.meta.url, {
+      raw: true,
+    })
 
     if (!this.minify && extensions.has(`@roots/bud-swc`))
       this.setMinify(() => swcMinify)

--- a/sources/@roots/bud/src/cli/commands/build/index.tsx
+++ b/sources/@roots/bud/src/cli/commands/build/index.tsx
@@ -143,7 +143,7 @@ export default class BudBuildCommand extends BudCommand {
           this.hash,
           `BUD_HASH`,
           b => async value => b.hash(value),
-        ] satisfies Override<boolean>,
+        ] satisfies Override<boolean | string>,
         [
           this.hot,
           `BUD_HOT`,
@@ -180,7 +180,7 @@ export default class BudBuildCommand extends BudCommand {
           this.minimize,
           `BUD_MINIMIZE`,
           b => async v => b.minimize(v),
-        ] satisfies Override<boolean>,
+        ] satisfies Override<`css` | `js` | boolean>,
         [
           this.output,
           `BUD_PATH_OUTPUT`,

--- a/sources/@roots/bud/src/cli/flags/hash.ts
+++ b/sources/@roots/bud/src/cli/flags/hash.ts
@@ -1,5 +1,6 @@
 import {Option} from '@roots/bud-support/clipanion'
 
-export default Option.Boolean(`--hash`, undefined, {
+export default Option.String(`--hash`, undefined, {
   description: `Hash compiled filenames`,
+  tolerateBoolean: true,
 })

--- a/sources/@roots/bud/src/cli/flags/minimize.ts
+++ b/sources/@roots/bud/src/cli/flags/minimize.ts
@@ -1,5 +1,13 @@
 import {Option} from '@roots/bud-support/clipanion'
+import {isLiteral, isOneOf} from '@roots/bud-support/typanion'
 
-export default Option.Boolean(`--minimize`, undefined, {
+export default Option.String(`--minimize`, undefined, {
   description: `Minimize compiled assets`,
+  tolerateBoolean: true,
+  validator: isOneOf([
+    isLiteral(`js`),
+    isLiteral(`css`),
+    isLiteral(true),
+    isLiteral(false),
+  ]),
 })

--- a/sources/@roots/bud/test/cli-flag-runtime/project/bud.config.ts
+++ b/sources/@roots/bud/test/cli-flag-runtime/project/bud.config.ts
@@ -1,0 +1,8 @@
+import {bud} from '@roots/bud'
+
+bud.after(async () => {
+  await bud.fs.write(
+    bud.path(`@storage`, `config.yml`),
+    bud.compiler?.config ?? {},
+  )
+})


### PR DESCRIPTION
- feat: `--hash` flag now accepts string for setting hashing algorithm (eg: `--hash=contenthash:4`)
- feat: `--minimize` flag now accepts string for only applying a single minimizer (eg: `--minimize=js` and `--minimize=css`
- improve: `bud.hash`
- improve: `bud.runtime`
- improve: facade logging
- performance: lazy load `terser-webpack-plugin` and `css-minimizer-webpack-plugin` minimizers

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
