### PR TITLE
📕 docs(none): add `ConfigExample` component

### DIFF
--- a/sources/@repo/docs/config/index.cjs
+++ b/sources/@repo/docs/config/index.cjs
@@ -60,6 +60,7 @@ module.exports = {
         id: `extensions`,
         include: [`**/*.md`, `**/*.mdx`],
         path: docsPath(`content/extensions`),
+        remarkPlugins,
         routeBasePath: `extensions`,
         sidebarPath: docsPath(`sidebars/sidebar.cjs`),
       },

--- a/sources/@repo/docs/content/extensions/bud-babel.mdx
+++ b/sources/@repo/docs/content/extensions/bud-babel.mdx
@@ -4,13 +4,11 @@ description: Transpile JavaScript with Babel
 sidebar_label: '@roots/bud-babel'
 ---
 
-import CodeBlock from '@theme/CodeBlock'
-
 [Babel](https://babeljs.io) can be added by installing the [@roots/bud-babel](/extensions/bud-babel) extension.
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-babel --save-dev
 ```
 
@@ -25,7 +23,7 @@ npm install @roots/bud-babel --save-dev
 
 Presets are registered to `bud.babel.presets`.
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 console.dir(bud.babel.presets)
 ```
 
@@ -33,7 +31,7 @@ console.dir(bud.babel.presets)
 
 It will be appended to whatever presets are already registered.
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.babel.setPreset('@babel/preset-env')
 ```
 
@@ -41,7 +39,7 @@ bud.babel.setPreset('@babel/preset-env')
 
 Use `bud.babel.unsetPreset` to remove a preset, if present.
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.babel.unsetPreset('@babel/preset-env')
 ```
 
@@ -49,13 +47,13 @@ bud.babel.unsetPreset('@babel/preset-env')
 
 Pass an array of presets to `bud.babel.setPresets` to fully replace the existing presents configuration.
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.babel.setPresets(['@babel/preset-env'])
 ```
 
 ### Set options on a preset
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.babel.setPresetOptions('@babel/preset-env', {
   useBuiltIns: 'entry',
 })
@@ -67,7 +65,7 @@ Managing plugins uses nearly the exact same API.
 
 ### Add a plugin
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.babel.setPlugin('@babel/plugin-transform-runtime')
 ```
 
@@ -85,7 +83,7 @@ bud.babel.unsetPlugin('@babel/plugin-transform-runtime')
 
 ### Override any plugin options
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.babel.setPluginOptions('@babel/plugin-transform-runtime', {
   helpers: false,
 })

--- a/sources/@repo/docs/content/extensions/bud-criticalcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-criticalcss.mdx
@@ -20,7 +20,7 @@ For more information on this technique check out this [web.dev article](https://
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-criticalcss --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-emotion.mdx
+++ b/sources/@repo/docs/content/extensions/bud-emotion.mdx
@@ -14,12 +14,12 @@ import CodeBlock from '@theme/CodeBlock'
 
 With babel:
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-emotion @roots/bud-babel --save-dev
 ```
 
 With swc:
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-emotion @roots/bud-swc --save-dev
 ```

--- a/sources/@repo/docs/content/extensions/bud-entrypoints.mdx
+++ b/sources/@repo/docs/content/extensions/bud-entrypoints.mdx
@@ -4,14 +4,11 @@ description: 'Manifest with assets grouped by entrypoint and filetype'
 sidebar_label: '@roots/bud-entrypoints'
 ---
 
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
-
-**@roots/bud-entrypoints** generates an enhanced asset manifest for usage in server-powered applications like **Laravel** and **WordPress**.
+**@roots/bud-entrypoints** generates a manifest of **compiled assets** to use in your server-side application.
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-entrypoints --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-esbuild.mdx
+++ b/sources/@repo/docs/content/extensions/bud-esbuild.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem'
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-esbuild --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-eslint.mdx
+++ b/sources/@repo/docs/content/extensions/bud-eslint.mdx
@@ -13,8 +13,8 @@ import Configuration from '@site/../../@roots/bud-eslint/docs/01-configuration.m
 
 ## Installation
 
-```npm2yarn
-yarn add @roots/bud-eslint --dev
+```sh npm2yarn
+npm install @roots/bud-eslint --save-dev
 ```
 
 ## Configuration

--- a/sources/@repo/docs/content/extensions/bud-imagemin/index.mdx
+++ b/sources/@repo/docs/content/extensions/bud-imagemin/index.mdx
@@ -2,10 +2,10 @@
 title: '@roots/bud-imagemin'
 description: Image minification for bud.js projects
 sidebar_label: '@roots/bud-imagemin'
+tags:
+  - assets
+  - optimization
 ---
-
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
 
 import Usage from '@site/../../@roots/bud-imagemin/docs/00-usage.md'
 import ConvertingToWebp from '@site/../../@roots/bud-imagemin/docs/01-request-query-parameters.md'
@@ -14,11 +14,11 @@ import SettingEncoderOptions from '@site/../../@roots/bud-imagemin/docs/02-setti
 [@roots/bud-imagemin](/extensions/bud-imagemin) optimizes image filesizes. It works with no configuration beyond installing it
 but also has a robust customization API.
 
-The extension uses [googlechromelabs/squoosh](https://github.com/googlechromelabs/squoosh).
+The extension uses [sharp](https://sharp.pixelplumbing.com).
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-imagemin --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-postcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-postcss.mdx
@@ -8,8 +8,8 @@ This extension adds [PostCSS](https://postcss.org) support.
 
 ## Installation
 
-```npm2yarn
-yarn add @roots/bud-postcss --dev
+```sh npm2yarn
+npm install @roots/bud-postcss --save-dev
 ```
 
 ## Usage
@@ -35,7 +35,7 @@ You can set the PostCSS options directly using `bud.postcss.setPostCssOptions`.
 
 It's best to use this method only if you are comfortable with PostCSS and know what you are doing.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.setPostCssOptions({
   parser: `sugarss`,
   plugins: [`postcss-import`, `postcss-nested`, `postcss-preset-env`],
@@ -54,7 +54,7 @@ Adding a plugin with the API is a two step process:
 
 Let's look at how this is done using `tailwindcss` as an example.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss
   /** Register the tailwindcss/nesting plugin */
   .setPlugin(`tailwindcss/nesting`)
@@ -66,13 +66,13 @@ bud.postcss
 
 ### Step 1. Registration
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.setPlugin(`example-postcss-plugin`)
 ```
 
 If you want to be specific about how to resolve a plugin, you can pass a second parameter.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.setPlugin(
   `example-postcss-plugin`,
   bud.path(`@modules/example-postcss-plugin/lib/index.js`),
@@ -81,7 +81,7 @@ bud.postcss.setPlugin(
 
 If you want to pass along options with the plugin, you can do so by passing an array.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.setPlugin(`example-postcss-plugin`, [
   `example-postcss-plugin`,
   {stage: 1},
@@ -90,7 +90,7 @@ bud.postcss.setPlugin(`example-postcss-plugin`, [
 
 ### Step 2. Add the plugin
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.use([
   `postcss-import`,
   `postcss-nesting`,
@@ -101,7 +101,7 @@ bud.postcss.use([
 
 You can also use a callback:
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.use(plugins => [...plugins, 'example-postcss-plugin'])
 ```
 
@@ -111,7 +111,7 @@ You can modify options for a plugin using **bud.postcss.setPluginOptions**.
 
 The first parameter is the plugin key and the second is the options object.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.setPluginOptions('example-postcss-plugin', {optimize: false})
 ```
 
@@ -121,7 +121,7 @@ You can modify the path for a PostCSS plugin using **bud.postcss.setPluginPath**
 
 The first parameter is the plugin key and the second is the new path to assign.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.setPluginPath(
   'example-postcss-plugin',
   bud.path('./lib/my-plugin.js'),
@@ -132,7 +132,7 @@ bud.postcss.setPluginPath(
 
 You may remove a plugin by calling **bud.postcss.unsetPlugin** with the plugin key.
 
-```ts title=bud.config.js
+```ts title=bud.config.ts
 bud.postcss.unsetPlugin(`import`)
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-preset-recommend.mdx
+++ b/sources/@repo/docs/content/extensions/bud-preset-recommend.mdx
@@ -13,6 +13,6 @@ It includes the following extensions:
 
 ## Installation
 
-```npm2yarn
-yarn add @roots/bud-preset-recommend --dev
+```sh npm2yarn
+npm install @roots/bud-preset-recommend --save-dev
 ```

--- a/sources/@repo/docs/content/extensions/bud-preset-wordpress/index.mdx
+++ b/sources/@repo/docs/content/extensions/bud-preset-wordpress/index.mdx
@@ -22,7 +22,7 @@ To get started with WordPress, install the [@roots/bud-preset-wordpress preset](
 
 We recommend using [@roots/bud-swc](/extensions/bud-swc), which is included in [@roots/bud-preset-recommend](/extensions/bud-preset-recommend):
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-preset-wordpress @roots/bud-preset-recommend --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-purgecss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-purgecss.mdx
@@ -2,22 +2,19 @@
 sidebar_label: '@roots/bud-purgecss'
 ---
 
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
-
 # @roots/bud-purgecss
 
 [PurgeCSS](https://purgecss.com/) support can be added by installing the [@roots/bud-purgecss](/extensions/bud-purgecss) extension.
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-purgecss --save-dev
 ```
 
 [purgecss-with-wordpress](https://purgecss.com/guides/wordpress.html) is optional but recommended when working with WordPress.
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-purgecss purgecss-with-wordpress --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-react.mdx
+++ b/sources/@repo/docs/content/extensions/bud-react.mdx
@@ -11,7 +11,7 @@ import ReactRefresh from '@site/../../@roots/bud-react/docs/01-react-refresh.md'
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-react --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-sass.mdx
+++ b/sources/@repo/docs/content/extensions/bud-sass.mdx
@@ -13,7 +13,7 @@ import URLImports from '@site/../../@roots/bud-sass/docs/04-url-imports.md'
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-sass --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-solid.mdx
+++ b/sources/@repo/docs/content/extensions/bud-solid.mdx
@@ -14,6 +14,6 @@ This extension is experimental.
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-solid --save-dev
 ```

--- a/sources/@repo/docs/content/extensions/bud-stylelint.mdx
+++ b/sources/@repo/docs/content/extensions/bud-stylelint.mdx
@@ -15,8 +15,8 @@ Adds [Stylelint](https://stylelint.io) support to your project.
 
 ## Installation
 
-```npm2yarn
-yarn add @roots/bud-stylelint --dev
+```sh npm2yarn
+npm install @roots/bud-stylelint --save-dev
 ```
 
 ## Usage

--- a/sources/@repo/docs/content/extensions/bud-swc.mdx
+++ b/sources/@repo/docs/content/extensions/bud-swc.mdx
@@ -10,8 +10,8 @@ import Typecheck from '@site/../../@roots/bud-swc/docs/02-typechecking.md'
 
 ## Installation
 
-```bash npm2yarn
-npm install @roots/bud-swc --dev-only
+```sh npm2yarn
+npm install @roots/bud-swc --save-dev
 ```
 
 ## Configuration

--- a/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
+++ b/sources/@repo/docs/content/extensions/bud-tailwindcss.mdx
@@ -11,8 +11,8 @@ import Configuration from '@site/../../@roots/bud-tailwindcss/docs/01-configurat
 
 ## Installation
 
-```npm2yarn
-yarn add @roots/bud-tailwindcss --dev
+```sh npm2yarn
+npm install @roots/bud-tailwindcss --save-dev
 ```
 
 ## Configuration

--- a/sources/@repo/docs/content/extensions/bud-typescript.mdx
+++ b/sources/@repo/docs/content/extensions/bud-typescript.mdx
@@ -13,7 +13,7 @@ import ReactFastRefresh from '@site/../../@roots/bud-typescript/docs/04-react-fa
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-typescript --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/bud-vue/index.mdx
+++ b/sources/@repo/docs/content/extensions/bud-vue/index.mdx
@@ -17,7 +17,7 @@ import Vue2PackageJson from '@site/../../../examples/vue-legacy/package.json'
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/bud-vue --save-dev
 ```
 

--- a/sources/@repo/docs/content/extensions/sage/index.mdx
+++ b/sources/@repo/docs/content/extensions/sage/index.mdx
@@ -17,7 +17,7 @@ import IncludedExtensions from '@site/../../@roots/sage/docs/01-included-extensi
 
 ## Installation
 
-```npm2yarn
+```sh npm2yarn
 npm install @roots/sage --save-dev
 ```
 

--- a/sources/@repo/docs/content/learn/config/assets.mdx
+++ b/sources/@repo/docs/content/learn/config/assets.mdx
@@ -3,6 +3,8 @@ title: Assets
 sidebar_label: Assets
 ---
 
+import ConfigExample from '@site/src/components/example'
+
 :::info No need to copy imported assets
 
 If you are already including assets by importing them in a script or stylesheet, you do not need
@@ -10,7 +12,7 @@ to copy them explicitly.
 
 For example, given this stylesheet, copying `@src/fonts/MyFont.woff2` would be unnecessary:
 
-```js title='index.css'
+```css title=index.css
 @font-face {
   font-family: 'MyFont';
   src: url(@src/fonts/MyFont.woff2) format('woff2');
@@ -23,34 +25,109 @@ The [bud.assets](/reference/bud.assets) function is used to copy files to the ou
 
 The simplest way to use it is to pass an array of directories (relative to [your project `@src` directory](#project-paths)) you would like to copy:
 
-```js title=bud.config.js
-export default async bud => {
+<ConfigExample>
+
+  ```ts title=bud.config.ts
   bud.assets(['images', 'fonts'])
-}
-```
+  ```
+
+  ```js title=bud.config.js
+  bud.assets(['images', 'fonts'])
+  ```
+
+  ```yml title=bud.config.yml
+  assets: [['images', 'fonts']]
+  ```
+
+  ```json title=bud.config.json
+  {
+    "assets": [["images", "fonts"]]
+  }
+  ```
+
+</ConfigExample>
 
 If you want more control over the directory being output to, you can use an array of from/to pairs:
 
-```js title=bud.config.js
-export default async bud => {
+<ConfigExample>
+
+  ```ts title=bud.config.ts
   bud.assets([
     ['images', 'assets/images'], // from `@src/images` to `@dist/assets/images`
     ['fonts', 'assets/fonts'], // from `@src/fonts` to `@dist/assets/fonts`
   ])
-}
-```
+  ```
+
+  ```js title=bud.config.js
+  bud.assets([
+    ['images', 'assets/images'], // from `@src/images` to `@dist/assets/images`
+    ['fonts', 'assets/fonts'], // from `@src/fonts` to `@dist/assets/fonts`
+  ])
+  ```
+
+  ```yml title=bud.config.yml
+  assets: [[['images', 'assets/images'], ['fonts', 'assets/fonts']]]
+  ```
+
+  ```json title=bud.config.json
+  {
+    "assets": [[["images", "assets/images"], ["fonts", "assets/fonts"]]]
+  }
+  ```
+
+</ConfigExample>
 
 For complete control, you can pass an object:
 
-```js title=bud.config.js
-export default async bud => {
-  bud.assets({
-    from: bud.path(`@src`, 'images'),
-    to: bud.path(`@dist`, 'images', `@name`), // `@name` is the filename (including hash if applicable)
-    context: bud.path(`@src`),
-    noErrorOnMissing: true,
-    toType: `template`,
-  })
-```
+<ConfigExample>
+
+  ```ts title=bud.config.ts
+  import type {Bud} from '@roots/bud'
+
+  export default async bud => {
+    bud.assets({
+      from: bud.path(`@src`, 'images'),
+      to: bud.path(`@dist`, 'images', `@name`), // `@name` is the filename (including hash if applicable)
+      context: bud.path(`@src`),
+      noErrorOnMissing: true,
+      toType: `template`,
+    })
+  }
+  ```
+
+  ```js title=bud.config.js
+  export default async bud => {
+    bud.assets({
+      from: bud.path(`@src`, 'images'),
+      to: bud.path(`@dist`, 'images', `@name`), // `@name` is the filename (including hash if applicable)
+      context: bud.path(`@src`),
+      noErrorOnMissing: true,
+      toType: `template`,
+    })
+  }
+  ```
+
+  ```yml title=bud.config.yml
+  assets:
+    from: bud => bud.path('@src', 'images')
+    to: bud => bud.path('@dist', 'images', '@name')
+    context: bud => bud.path('@src')
+    noErrorOnMissing: true
+    toType: template
+  ```
+
+  ```json title=bud.config.json
+  {
+    "assets": {
+      "from": "bud => bud.path('@src', 'images')",
+      "to": "bud => bud.path('@dist', 'images', '@name')",
+      "context": "bud => bud.path('@src')",
+      "noErrorOnMissing": true,
+      "toType": "template"
+    }
+  }
+  ```
+
+</ConfigExample>
 
 You can learn more about this and other details in the [bud.assets documentation](/reference/bud.assets).

--- a/sources/@repo/docs/content/learn/config/entrypoints.mdx
+++ b/sources/@repo/docs/content/learn/config/entrypoints.mdx
@@ -3,6 +3,8 @@ title: Entrypoints
 sidebar_label: Entrypoints
 ---
 
+import ConfigExample from '@site/src/components/example';
+
 bud.js uses the concept of "entrypoints" to group application scripts and styles. Entrypoints are defined using [bud.entry](/reference/bud.entry).
 
 You can think of an entrypoint as a "page" in your application. Each entrypoint will have its own output file.
@@ -16,32 +18,89 @@ detect this and create an entrypoint for you.
 
 If you only have a single entrypoint then it is enough to just pass the filename:
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.entry('app') // src/app.js
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  bud.entry('app') // src/app.js
+bud.entry('app') // src/app.js
+```
+
+```yml title=bud.config.yml
+entry: app # src/app.js
+```
+
+```json title=bud.config.json
+{
+  "entry": "app" // src/app.js
 }
 ```
+
+</ConfigExample>
 
 If you have more than one file to include in the bundle, you can use an array:
 
-```js title=bud.config.js
-export default async bud => {
+<ConfigExample>
+
+  ```ts title=bud.config.ts
   bud.entry(['app.js', 'global.css'])
-}
-```
+  ```
+
+  ```js title=bud.config.js
+  bud.entry(['app.js', 'global.css'])
+  ```
+
+  ```yml title=bud.config.yml
+  entry:
+    - ['app.js', 'global.css']
+  ```
+
+  ```json title=bud.config.json
+  {
+    "entry": [["app.js", "global.css"]]
+  }
+  ```
+
+</ConfigExample>
 
 If you have additional entrypoints you may call [bud.entry](/reference/bud.entry) multiple times.
 
 But, it might be preferable to use an object:
 
-```js title=bud.config.js
-export default async bud => {
+<ConfigExample>
+
+  ```ts title=bud.config.ts
   bud.entry({
     app: ['app.js', 'global.css'],
     landing: ['landing.js', 'landing.css'],
   })
-}
-```
+  ```
+
+  ```js title=bud.config.js
+  bud.entry({
+    app: ['app.js', 'global.css'],
+    landing: ['landing.js', 'landing.css'],
+  })
+  ```
+
+  ```yml title=bud.config.yml
+  entry:
+    app: ['app.js', 'global.css']
+    landing: ['landing.js', 'landing.css']
+  ```
+
+  ```json title=bud.config.json
+  {
+    "entry": {
+      "app": ["app.js", "global.css"],
+      "landing": ["landing.js", "landing.css"]
+    }
+  }
+  ```
+
+</ConfigExample>
 
 There is still more that this function can do, but for our overview this is more than enough. You can learn more about this and
 other details in the [bud.entry documentation](/reference/bud.entry).

--- a/sources/@repo/docs/content/learn/config/files/bud.config.mdx
+++ b/sources/@repo/docs/content/learn/config/files/bud.config.mdx
@@ -1,11 +1,11 @@
 ---
 title: bud.config
-sidebar_label: bud.config.ts
+sidebar_label: bud.config
 description: Used to configure bud.js
 ---
 
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
+import ConfigExample from '@site/src/components/example'
+import MultiLanguage from '@site/src/components/multi-language'
 
 bud.js config files are the most straight forward way of interfacing with bud.js.
 
@@ -26,39 +26,21 @@ The esbuild team advises that using esbuild is faster than esbuild-wasm, but the
 
 ## Example configurations
 
-<Tabs>
-<TabItem value="bud.config.ts">
+<ConfigExample>
 
 ```ts title=bud.config.ts
-import type {Bud} from '@roots/bud'
-
-export default async (bud: Bud) => {
-  bud.entry(`app`, [`app.js`, `app.css`])
-}
+bud.entry(`app`, [`app.js`, `app.css`])
 ```
 
-</TabItem>
-
-<TabItem value="bud.config.js">
-
-```ts title=bud.config.js
-/** @param {import('@roots/bud').Bud} bud */
-export default async bud => {
-  bud.entry(`app`, [`app.js`, `app.css`])
-}
+```js title=bud.config.js
+bud.entry(`app`, [`app.js`, `app.css`])
 ```
-
-</TabItem>
-
-<TabItem value="bud.config.yml">
 
 ```yml title=bud.config.yml
-entry: ['app', ['app.js', 'app.css']]
+entry:
+  - app
+  - ['app.js', 'app.css']
 ```
-
-</TabItem>
-
-<TabItem value="bud.config.json">
 
 ```json title=bud.config.json
 {
@@ -66,18 +48,27 @@ entry: ['app', ['app.js', 'app.css']]
 }
 ```
 
-</TabItem>
-</Tabs>
+</ConfigExample>
 
 ## Importing bud.js directly
 
-As mentioned above, you can also elect to import bud.js directly and use it in your configuration.
+You can import bud.js directly and use it in your configuration.
+
+<MultiLanguage>
 
 ```ts title=bud.config.ts
 import {bud} from '@roots/bud'
 
 bud.entry(`app`, [`app.js`, `app.css`])
 ```
+
+```js title=bud.config.js
+import {bud} from '@roots/bud'
+
+bud.entry(`app`, [`app.js`, `app.css`])
+```
+
+</MultiLanguage>
 
 ## Using multiple configuration files
 
@@ -93,7 +84,7 @@ When more than one configuration file is present they are execuetd in the follow
 You may want to add `bud.local.*` to your `.gitignore` file. This way contributors to your project can make specific overrides using `bud.local.*` files
 without affecting the base configuration kept in source control.
 
-## Configuring bud.js with YML
+## Configuring bud.js with JSON and YML
 
 Each key is a reference to a bud.js call. The supplied values are the arguments to that call, expressed as an array.
 
@@ -101,9 +92,21 @@ Each key is a reference to a bud.js call. The supplied values are the arguments 
 
 For example, the following bud.js configuration:
 
+<MultiLanguage>
+
 ```yml title=bud.config.yml
-entry: ['app', 'app.js']
+entry:
+  - app
+  - app.js
 ```
+
+```json title=bud.config.json
+{
+  "entry": ["app", "app.js"]
+}
+```
+
+</MultiLanguage>
 
 is equivalent to:
 
@@ -113,34 +116,43 @@ bud.entry('app', 'app.js')
 
 There is some flexibility here if you are passing a single value and it is NOT an array. So, this is okay:
 
-```yml
+```yml title=bud.config.yml
 entry:
   app: app.js
 ```
+
+Since it can easily be interpreted by bud.js as:
+
+```yml title=bud.config.yml
+entry:
+  - app: app.js
+```
+
+Which is equivalent to a single item in array of arguments, containing an object.
 
 ```ts title=bud.config.ts
 bud.entry({app: 'app.js'})
 ```
 
-But, since [bud.assets](/reference/bud.assets) expects an array, the following yml would cause an error:
+Conversely, since [bud.assets](/reference/bud.assets) expects an array, the following yml would cause an error:
 
 ```yml title=bud.config.yml
 # This is incorrect
 assets: ['src/**/*.html', 'app/**/*.html']
 ```
 
-Since it will be interpreted as a call to [bud.assets](/reference/bud.assets) with two arguments:
+How is bud.js to know whether you intended to pass multiple parameters or a single array? It can't, and so this is the result:
 
-```ts title=bud.config.ts
-bud.assets('src/**/*.html', 'app/**/*.html')
-
+```js title=bud.config.js
+bud.assets('src/**/*.html', 'app/**/*.html') // wrong
 // what we wanted: bud.assets(['src/**/*.html', 'app/**/*.html'])
 ```
 
-To fix it, we must remember that we are passing an array of values, and wrap our argument in an array:
+To fix it, we must remember that we are passing _an array of the function parameters_, and wrap our argument in an array:
 
 ```yml title=bud.config.yml
-assets: [['src/**/*.html', 'app/**/*.html']]
+assets:
+  - ['src/**/*.html', 'app/**/*.html']
 ```
 
 ### Accessing nested values
@@ -225,17 +237,18 @@ If you're doing a lot of this remember that you can create JS configurations in 
 
 ## Configuring bud.js with JSON
 
-JSON uses the same rules as yml. You can use JSON5 syntax (comments, non-quoted keys) similar to what is supported in `tsconfig.json`.
+You can use [JSON5 syntax](https://json5.org), similar to what is supported in `tsconfig.json`.
 
 ```json title=bud.config.json
 {
-  "entry": ["app", ["app.js"]],
-  "runtime": [true],
-  "assets": [["src/**/*.html"]],
-  "babel": {
-    "setPluginOptions": [
+  /** Comments are fine */
+  entry: ["app", ["app.js"]],
+  runtime: true,
+  copyDir: "assets",
+  babel: {
+    setPluginOptions: [
       "@babel/plugin-transform-runtime",
-      {"helpers": false, "regenerator": false}
+      {helpers: false, regenerator: false}
     ]
   }
 }

--- a/sources/@repo/docs/content/learn/config/files/bud.config.mdx
+++ b/sources/@repo/docs/content/learn/config/files/bud.config.mdx
@@ -29,7 +29,7 @@ The esbuild team advises that using esbuild is faster than esbuild-wasm, but the
 <Tabs>
 <TabItem value="bud.config.ts">
 
-```js title=bud.config.ts
+```ts title=bud.config.ts
 import type {Bud} from '@roots/bud'
 
 export default async (bud: Bud) => {
@@ -41,7 +41,7 @@ export default async (bud: Bud) => {
 
 <TabItem value="bud.config.js">
 
-```js title=bud.config.js
+```ts title=bud.config.js
 /** @param {import('@roots/bud').Bud} bud */
 export default async bud => {
   bud.entry(`app`, [`app.js`, `app.css`])
@@ -95,18 +95,20 @@ without affecting the base configuration kept in source control.
 
 ## Configuring bud.js with YML
 
-Each key is a reference to a `Bud` call. The supplied values are the arguments to that call.
+Each key is a reference to a bud.js call. The supplied values are the arguments to that call, expressed as an array.
 
-For instance, the equivalent of the following call to [bud.entry](/reference/bud.entry):
+### Calling functions
 
-```js
-bud.entry('app', 'app.js')
+For example, the following bud.js configuration:
+
+```yml title=bud.config.yml
+entry: ['app', 'app.js']
 ```
 
-Would be:
+is equivalent to:
 
-```yml
-entry: ['app', 'app.js']
+```ts title=bud.config.ts
+bud.entry('app', 'app.js')
 ```
 
 There is some flexibility here if you are passing a single value and it is NOT an array. So, this is okay:
@@ -116,45 +118,79 @@ entry:
   app: app.js
 ```
 
-But, this would cause an error. it will be parsed as if it were a multi-parameter call:
+```ts title=bud.config.ts
+bud.entry({app: 'app.js'})
+```
 
-```yml
+But, since [bud.assets](/reference/bud.assets) expects an array, the following yml would cause an error:
+
+```yml title=bud.config.yml
 # This is incorrect
 assets: ['src/**/*.html', 'app/**/*.html']
 ```
 
-You can access nested properties no problem.
+Since it will be interpreted as a call to [bud.assets](/reference/bud.assets) with two arguments:
 
-```yml
+```ts title=bud.config.ts
+bud.assets('src/**/*.html', 'app/**/*.html')
+
+// what we wanted: bud.assets(['src/**/*.html', 'app/**/*.html'])
+```
+
+To fix it, we must remember that we are passing an array of values, and wrap our argument in an array:
+
+```yml title=bud.config.yml
+assets: [['src/**/*.html', 'app/**/*.html']]
+```
+
+### Accessing nested values
+
+You can access nested properties with standard yml indentation:
+
+```yml title=bud.config.yml
 babel:
   setPluginOptions:
     - '@babel/plugin-transform-runtime'
     - {helpers: true}
 ```
 
-### Referencing bud.js values
+You can also use dot notation:
+
+```yml title=bud.config.yml
+babel.setPluginOptions:
+  - '@babel/plugin-transform-runtime'
+  - {helpers: true}
+```
+
+### Accessing bud values
 
 You can make reference to the `bud` object with `_bud`.
 
-```yml
+```yml title=bud.config.yml
 splitChunks: _bud.isProduction
 ```
 
 You can tap `bud` with an arrow fn if needed. These functions will be called
 as they are encountered and supplied with the bud.js instance.
 
-```yml
+```yml title=bud.config.yml
 minimize: bud => bud.isProduction
+```
+
+This is the equivalent of:
+
+```ts title=bud.config.ts
+bud.tap('minimize', bud.isProduction)
 ```
 
 ### Treating a value as a function
 
-You can prefix a string with `=>` to indicate that it should be treated as a function. These functions will be called
+If you need to execute some code but don't need the bud object, you can prefix a string with `=>` to indicate that it should be treated as a function. These functions will be called
 as they are encountered.
 
 This will log `4`:
 
-```yml
+```yml title=bud.config.yml
 log: => 2 + 2
 ```
 
@@ -163,14 +199,14 @@ log: => 2 + 2
 Some functions accept functions as a value. In cases like these wrap the function in an additional `=>` so that the
 config parser does not call the function itself.
 
-```yml
+```yml title=bud.config.yml
 webpackConfig: >
   => config => ({...config, parallelism: 1})
 ```
 
 [bud.tap](/reference/bud.tap) and [bud.tapAsync](/reference/bud.tapAsync) can be helpful for dynamic configuration and work like this:
 
-```yml
+```yml title=bud.config.yml
 tap: >
   => bud => {
     // this is a very flexible
@@ -191,7 +227,7 @@ If you're doing a lot of this remember that you can create JS configurations in 
 
 JSON uses the same rules as yml. You can use JSON5 syntax (comments, non-quoted keys) similar to what is supported in `tsconfig.json`.
 
-```json
+```json title=bud.config.json
 {
   "entry": ["app", ["app.js"]],
   "runtime": [true],

--- a/sources/@repo/docs/content/learn/config/files/env.mdx
+++ b/sources/@repo/docs/content/learn/config/files/env.mdx
@@ -15,7 +15,7 @@ So, if you have an `.env` file in your project root and another in the parent di
 
 bud.js supports expansion of environment variables. For example:
 
-```bash
+```sh title=.env
 PUBLIC_API_ORIGIN=https://api.example.com
 PUBLIC_API_URL=${PUBLIC_API_URL}/endpoint
 ```
@@ -27,7 +27,7 @@ must remove the `PUBLIC_` prefix.
 
 For example, setting `PUBLIC_API_URL`:
 
-```bash
+```sh title=.env
 PUBLIC_API_URL=https://api.example.com
 ```
 
@@ -75,6 +75,6 @@ API_URL = 'https://api.example.com'
 
 You can verify what environment variables are available to bud.js using the `bud env` command:
 
-```bash npm2yarn
+```sh npm2yarn
 npm run bud env
 ```

--- a/sources/@repo/docs/content/learn/config/optimization.mdx
+++ b/sources/@repo/docs/content/learn/config/optimization.mdx
@@ -3,46 +3,120 @@ title: Optimization
 sidebar_label: Optimization
 ---
 
+import ConfigExample from '@site/src/components/example'
+
 ## File hashing
 
 Use the [bud.hash](/reference/bud.hash) function to generate a hash for each file in the bundle. This hash will be added to outputted files.
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.hash()
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  bud.hash()
+bud.hash()
+```
+
+```yml title=bud.config.yml
+hash: true
+```
+
+```json title=bud.config.json
+{
+  "hash": true
 }
 ```
+
+</ConfigExample>
+
 
 ## Minimizing code
 
 Use the [bud.minimize](/reference/bud.minimize) function to run your application code through a minifier.
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.minimize()
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  bud.minimize()
+bud.minimize()
+```
+
+```yml title=bud.config.yml
+minimize: true
+```
+
+```json title=bud.config.json
+{
+  "minimize": true
 }
 ```
+
+</ConfigExample>
 
 ## Creating a runtime
 
 You may create an application runtime using [bud.runtime](/reference/bud.runtime). Using the `single` option is probably
-the simplest and best solution for most applications:
+the simplest and best solution for most applications (and is also the default):
+
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.runtime()
+```
 
 ```js title=bud.config.js
-export default async bud => {
-  bud.runtime('single')
+bud.runtime()
+```
+
+```yml title=bud.config.yml
+runtime: true
+```
+
+```json title=bud.config.json
+{
+  "runtime": true
 }
 ```
+
+</ConfigExample>
 
 ## Creating a vendor chunk
 
+:::tip Use dynamic imports
+
+You should use dynamic imports to split your code into chunks that can be loaded on demand. This gives you more control
+over how your code is loaded and can improve performance.
+
+:::
+
 You can perform general code splitting with [bud.splitChunks](/reference/bud.splitChunks).
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.splitChunks()
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  bud.splitChunks()
+bud.splitChunks()
+```
+
+```yml title=bud.config.yml
+splitChunks: true
+```
+
+```json title=bud.config.json
+{
+  "splitChunks": true
 }
 ```
+
+</ConfigExample>
 
 ## Optimizing images
 

--- a/sources/@repo/docs/content/learn/config/paths.mdx
+++ b/sources/@repo/docs/content/learn/config/paths.mdx
@@ -3,18 +3,41 @@ title: Paths
 sidebar_label: Paths
 ---
 
+import ConfigExample from '@site/src/components/example'
+
 ## Setting application paths
 
 [bud.setPath](/reference/bud.setPath) is used to set project source and output paths.
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+/* Set the source path.*/
+bud.setPath('@src', 'source')
+/* Set the output path.*/
+bud.setPath('@dist', 'build')
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  /* Set the source path.*/
-  bud.setPath('@src', 'source')
-  /* Set the output path.*/
-  bud.setPath('@dist', 'build')
+/* Set the source path.*/
+bud.setPath('@src', 'source')
+/* Set the output path.*/
+bud.setPath('@dist', 'build')
+```
+
+```yml title=bud.config.yml
+setPath:
+  - '@src'
+  - 'source'
+```
+
+```json title=bud.config.json
+{
+  "setPath": ["@src", "source"]
 }
 ```
+
+</ConfigExample>
 
 The `@src` and `@dist` handles are special handles associated with the input and output base directories.
 
@@ -22,12 +45,19 @@ The `@src` and `@dist` handles are special handles associated with the input and
 
 Once set, paths can be referenced using [bud.path](/reference/bud.path).
 
-```js title=bud.config.js
-export default async bud => {
-  bud.path('@src') // absolute path to source directory
-  bud.path('@dist') // absolute path to output directory
-}
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.path('@src') // absolute path to source directory
+bud.path('@dist') // absolute path to output directory
 ```
+
+```js title=bud.config.js
+bud.path('@src') // absolute path to source directory
+bud.path('@dist') // absolute path to output directory
+```
+
+</ConfigExample>
 
 ## Globbing
 
@@ -35,16 +65,28 @@ export default async bud => {
 
 This function is asychronous.
 
-```js title=bud.config.js
-export default async bud => {
-  await bud.glob('@src', '**/*.js') // returns an array of absolute paths
-}
+<ConfigExample>
+
+```ts title=bud.config.ts
+await bud.glob('@src', '**/*.js') // returns an array of absolute paths
 ```
+
+```js title=bud.config.js
+await bud.glob('@src', '**/*.js') // returns an array of absolute paths
+```
+
+</ConfigExample>
 
 There is a synchronous version available as well: [bud.globSync](/reference/bud.globSync).
 
-```js title=bud.config.js
-export default async bud => {
-  bud.globSync('@src', '**/*.js') // returns an array of absolute paths
-}
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.globSync('@src', '**/*.js') // returns an array of absolute paths
 ```
+
+```js title=bud.config.js
+bud.globSync('@src', '**/*.js') // returns an array of absolute paths
+```
+
+</ConfigExample>

--- a/sources/@repo/docs/content/learn/config/server.mdx
+++ b/sources/@repo/docs/content/learn/config/server.mdx
@@ -5,25 +5,59 @@ slug: dev-server
 sidebar_label: Development server
 ---
 
+import ConfigExample from '@site/src/components/example'
+
 ## Setting the dev URL
 
 Use [bud.setUrl](/reference/bud.setUrl) to set the development server URL.
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.setUrl(3030) // Deltron zero hero not no small feat
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  bud.setUrl(3030) // Deltron zero hero not no small feat
+bud.setUrl(3030) // Deltron zero hero not no small feat
+```
+
+```yml title=bud.config.yml
+setUrl: 3030 # Deltron zero hero not no small feat
+```
+
+```json title=bud.config.json
+{
+  "setUrl": 3030
 }
 ```
+
+</ConfigExample>
 
 ## Setting the proxy URL
 
 Use [bud.setProxyUrl](/reference/bud.setProxyUrl) to set the development server proxy URL.
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.setProxyUrl(`http://example.test`)
+```
+
 ```js title=bud.config.js
-export default async bud => {
-  bud.setProxyUrl(`http://example.test`)
+bud.setProxyUrl(`http://example.test`)
+```
+
+```yml title=bud.config.yml
+setProxyUrl: http://example.test
+```
+
+```json title=bud.config.json
+{
+  "setProxyUrl": "http://example.test"
 }
 ```
+
+</ConfigExample>
 
 ## Setting public URLs
 
@@ -33,6 +67,16 @@ This is useful in containerized development environments like Docker where the i
 
 Here is an example of what this might look like, but it is going to depend heavily on your setup:
 
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud
+  .setUrl(3000)
+  .setPublicUrl(`http://example.test:3000`)
+  .setProxyUrl(8080)
+  .setPublicProxyUrl(`http://example.test`)
+```
+
 ```js title=bud.config.js
 bud
   .setUrl(3000)
@@ -41,18 +85,94 @@ bud
   .setPublicProxyUrl(`http://example.test`)
 ```
 
+```yml title=bud.config.yml
+setUrl: 3000
+setPublicUrl: http://example.test:3000
+setProxyUrl: 8080
+setPublicProxyUrl: http://example.test
+```
+
+```json title=bud.config.json
+{
+  "setUrl": 3000,
+  "setPublicUrl": "http://example.test:3000",
+  "setProxyUrl": 8080,
+  "setPublicProxyUrl": "http://example.test"
+}
+```
+
+</ConfigExample>
+
 ## Advanced configuration
 
 The development server can be configured with [bud.serve](/reference/bud.serve). This is primarily used to handle
-configuring bud.js to use an [SSL certificate](/reference/bud.serve#ssl), but it exposes all node options so the possibilities
-are really only limited by the runtime.
+configuring bud.js to use an [SSL certificate](/reference/bud.serve#ssl). It exposes all node options so the possibilities
+are really open, for better and worse.
+
+<ConfigExample>
+
+```ts title=bud.config.ts
+bud.serve({
+  url: new URL(`https://example.test`),
+  cert: `/path/to/example.test.crt`,
+  key: `/path/to/example.test.key`,
+})
+```
 
 ```js title=bud.config.js
-export default async bud => {
-  bud.serve({
-    url: new URL(`https://example.test`)
-    cert: `/path/to/example.test.crt`,
-    key: `/path/to/example.test.key`,
-  })
+bud.serve({
+  url: new URL(`https://example.test`),
+  cert: `/path/to/example.test.crt`,
+  key: `/path/to/example.test.key`,
+})
+```
+
+```yml title=bud.config.yml
+serve:
+  url: https://example.test
+  cert: /path/to/example.test.crt
+  key: /path/to/example.test.key
+```
+
+```json title=bud.config.json
+{
+  "serve": {
+    "url": "https://example.test",
+    "cert": "/path/to/example.test.crt",
+    "key": "/path/to/example.test.key"
+  }
 }
 ```
+
+</ConfigExample>
+
+## Consider a separate config
+
+Consider better organizing your configuration by [using a separate config file for development](/learn/config/files/bud.config#using-multiple-configuration-files).
+
+Just add `.development` to your `bud.config.*` file name to scope it to development only.
+
+Or, load a separate file entirely using [bud.addConfig](/reference/bud.addConfig).
+
+<ConfigExample>
+
+```ts title=bud.config.development.ts
+bud.setUrl(3030)
+```
+
+```js title=bud.config.development.js
+bud.setUrl(3030)
+```
+
+```yml title=bud.config.development.yml
+setUrl: 3030
+```
+
+```json title=bud.config.development.json
+{
+  "setUrl": 3030
+}
+```
+
+</ConfigExample>
+

--- a/sources/@repo/docs/content/learn/extending/index.mdx
+++ b/sources/@repo/docs/content/learn/extending/index.mdx
@@ -10,7 +10,7 @@ You can add additional functionality to **bud.js** by writing a bud.js extension
 
 Extensions can be provided as either a plain JS object or a class.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 const MyExtension = {
   register: async(bud) {}
 }
@@ -18,7 +18,7 @@ const MyExtension = {
 
 Extensions writen using JS classes should extend the `Extension` base class (exported from `@roots/bud-framework/extension`).
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Extension} from '@roots/bud-framework/extension'
 
 class MyExtension extends Extension {
@@ -36,7 +36,7 @@ The extension `label` serves as a handle for other extensions or the user config
 
 For instance if your extension is published to npm as `bud-extension-name` then the `label` should match:
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Extension} from '@roots/bud-framework/extension'
 
 export default class MyExtension extends Extension {
@@ -51,7 +51,7 @@ depends on the presence of `@roots/bud-postcss`. To ensure dependencies are avai
 
 The `dependsOn` property is expressed as a `Set`:
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Extension} from '@roots/bud-framework/extension'
 
 export default class MyExtension extends Extension {
@@ -65,7 +65,7 @@ export default class MyExtension extends Extension {
 
 Extensions may depend on other extensions on an optional basis. **bud.js** will attempt to register the extension if it is available. Otherwise, it will silently proceed.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Extension} from '@roots/bud-framework/extension'
 
 export default class MyExtension extends Extension {
@@ -79,7 +79,7 @@ export default class MyExtension extends Extension {
 
 Any extension options can be set in the `options` property.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Extension} from '@roots/bud-framework/extension'
 
 export default class MyExtension extends Extension {
@@ -97,7 +97,7 @@ Each option value can be expressed as either the literal value itself or a funct
 
 This is useful when you can't know the value up front (as is the case with user paths):
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -115,7 +115,7 @@ Now, if the user makes a change to the `@src` path, the reference will be update
 The only "gotcha" here is that if you have an extension option which is itself a function. Since **bud.js** will try to call the function to resolve the option value you
 may need to wrap it in another function:
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -141,13 +141,13 @@ There are some additional methods available for working with extension options:
 
 #### setOption
 
-```ts title="extension.ts"
+```ts title=extension.ts
 extension.setOption('foo', value)
 ```
 
 #### setOptions
 
-```ts title="extension.ts"
+```ts title=extension.ts
 extension.setOptions({
   foo: `literal`,
   bar: (bud: Bud) => () => `callback`.
@@ -158,7 +158,7 @@ extension.setOptions({
 
 Async callback. Called first. Useful to avoid needing to deal with `super` and the constructor.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -175,7 +175,7 @@ export default class MyExtension extends Extension {
 
 Async callback. Try to do things in this method, when possible.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -193,7 +193,7 @@ export default class MyExtension extends Extension {
 Async callback. Called after `register`. Good for business which requires another
 extension to have already had `register` called on it.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -210,7 +210,7 @@ export default class MyExtension extends Extension {
 
 Async callback. Called after user configuration has been processed.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -227,7 +227,7 @@ export default class MyExtension extends Extension {
 
 Async callback. Called directly before configuration is constructed and passed to the compiler).
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -242,7 +242,7 @@ export default class MyExtension extends Extension {
 
 ### make
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import {bind} from '@roots/bud-framework/extension/decorators'
@@ -297,7 +297,7 @@ export interface ApplyPluginConstructor {
 
 And here is how you might use it:
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import Plugin from 'some-webpack-plugin'
@@ -317,7 +317,7 @@ export default class MyExtension extends Extension {
 
 An `apply` method indicates to **bud.js** that the extension is doing double duty as a compiler plugin and a **bud.js** extension.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import Plugin from 'some-webpack-plugin'
@@ -340,7 +340,7 @@ will not be called if this function returns `false`.
 
 This function is passed the **bud.js** instance.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -353,7 +353,7 @@ export default class MyExtension extends Extension {
 }
 ```
 
-If `Extension.when` returns `false` the following methods will be discarded:
+If `Extension.when` returns `false` the following methods will not be called:
 
 - [buildBefore](#buildBefore)
 - [buildAfter](#buildafter)
@@ -362,7 +362,7 @@ If `Extension.when` returns `false` the following methods will be discarded:
 
 `Extension.enabled` (a simple `boolean`) will always take precedence over `Extension.when` if it is set.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 

--- a/sources/@repo/docs/content/learn/extending/lifecycle.mdx
+++ b/sources/@repo/docs/content/learn/extending/lifecycle.mdx
@@ -8,7 +8,7 @@ sidebar_label: Lifecycle
 
 Async callback. Called first. Useful to avoid needing to deal with `super` and the constructor.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -25,7 +25,7 @@ export default class MyExtension extends Extension {
 
 Async callback. Try to do things in this method, when possible.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -43,7 +43,7 @@ export default class MyExtension extends Extension {
 Async callback. Called after `register`. Good for business which requires another
 extension to have already had `register` called on it.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -62,7 +62,7 @@ Async callback. Called after user configuration has been processed.
 
 This function is not called if either the value of `Extension.enabled` is `false` or `Extension.when` returns `false`.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -81,7 +81,7 @@ Async callback. Called directly before configuration is constructed and passed t
 
 This function is not called if either the value of `Extension.enabled` is `false` or `Extension.when` returns `false`.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 
@@ -100,7 +100,7 @@ Async callback. Called directly after configuration is produced.
 
 This function is not called if either the value of `Extension.enabled` is `false` or `Extension.when` returns `false`.
 
-```ts title="extension.ts"
+```ts title=extension.ts
 import {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 

--- a/sources/@repo/docs/content/learn/extending/packaging.mdx
+++ b/sources/@repo/docs/content/learn/extending/packaging.mdx
@@ -6,13 +6,13 @@ sidebar_label: Packaging
 
 Your package's name should begin with `bud-`. This is important for discoverability.
 
-```json title="package.json"
+```json title=package.json
 {"name": "bud-extension"}
 ```
 
 The extension should be the package's `default` export:
 
-```json title="package.json"
+```json title=package.json
 {
   "name": "bud-extension",
   "type": "module",

--- a/sources/@repo/docs/content/learn/general-use/compiler-sources.mdx
+++ b/sources/@repo/docs/content/learn/general-use/compiler-sources.mdx
@@ -6,6 +6,8 @@ sidebar_label: Adding compiler sources
 sidebar_position: 5
 ---
 
+import ConfigExample from '@site/src/components/example';
+
 By default, **bud.js** only resolves source code from [the `@src` directory](/reference/bud.path).
 
 Nearly all of the modules you install will have been compiled before they are published. It's almost always a waste to run this code through Babel or whatever other compiler you may be using.
@@ -21,41 +23,37 @@ Common examples:
 
 ## Adding sources
 
-:::info bud.compilePaths
+Use [bud.compilePaths](/reference/bud.compilePaths) to add additional directories to the list of sources that will be compiled.
 
-There is a function to simplify this available in bud@6.9.0: [bud.compilePaths](/reference/bud.compilePaths).
+As a quick example, let's say we have a project that needs to source modules from the swiper package.:
 
-:::
+<ConfigExample>
 
-You should make modifications to compiler sources within a `build.before` action.
-Some extensions may not register build rules until after the config file is processed;
-using this hook will guarantee that your customization takes precedence.
-
-```ts
-bud.hooks.action(`build.before`, async bud => {
-  bud.build.rules.js.setInclude([
-    bud.path('@src'),
-    bud.path('@modules/some-untranspiled-pkg'),
-  ])
-})
+```ts title=bud.config.ts
+bud.compilePaths([
+  bud.path(`@src`),
+  bud.path(`@modules/swiper`)
+])
 ```
 
-Or, you can be broad:
-
-```ts
-bud.hooks.action(`build.before`, async bud => {
-  bud.build.rules.js.setInclude([bud.path('@src'), bud.path('@modules')])
-})
+```js title=bud.config.js
+bud.compilePaths([
+  bud.path(`@src`),
+  bud.path(`@modules/swiper`)
+])
 ```
 
-Apply the above change to all registered rules:
-
-```ts
-bud.hooks.action(`build.before`, async bud => {
-  Object.values(bud.build.rules).map(rule =>
-    rule.setInclude([bud.path('@src'), bud.path('@modules')]),
-  )
-})
+```yml title=bud.config.yml
+compilePaths:
+  - ['src', 'node_modules/swiper']
 ```
 
-In general, we would advise being as restrictive as possible when it comes to whitelisting transpiler sources.
+```json title=bud.config.json
+{
+  "compilePaths": [
+    ["src", "node_modules/swiper"]
+  ]
+}
+```
+
+</ConfigExample>

--- a/sources/@repo/docs/content/learn/getting-started/adding-emotion.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/adding-emotion.mdx
@@ -13,7 +13,7 @@ To get started with Emotion, install the [@roots/bud-emotion](/extensions/bud-em
 
 We recommend using [@roots/bud-swc](/extensions/bud-swc):
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-swc @roots/bud-emotion --save-dev
 ```
 
@@ -23,7 +23,7 @@ Emotion requires the several packages to be installed in your project.
 
 We will try and resolve them for you but it is a good idea to install them as explicit dependencies:
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @emotion/css @emotion/react @emotion/styled --save
 ```
 

--- a/sources/@repo/docs/content/learn/getting-started/adding-eslint.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/adding-eslint.mdx
@@ -8,13 +8,13 @@ sidebar_label: Adding Eslint
 
 To get started with Eslint, install the [@roots/bud-eslint](/extensions/bud-eslint) extension to your project.
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-eslint --save-dev
 ```
 
 If you want to extend one of our first party configurations, you'll also want to install `@roots/eslint-config`:
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/eslint-config --save-dev
 ```
 

--- a/sources/@repo/docs/content/learn/getting-started/adding-react.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/adding-react.mdx
@@ -15,7 +15,7 @@ To get started with React, install the [@roots/bud-react](/extensions/bud-react)
 
 We recommend using [@roots/bud-swc](/extensions/bud-swc):
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-swc @roots/bud-typescript --save-dev
 ```
 
@@ -27,7 +27,7 @@ React requires installing `react` and `react-dom` as production dependencies.
 
 We will try and resolve them for you but it is a good idea to install them as explicit dependencies:
 
-```bash npm2yarn
+```sh npm2yarn
 npm install react react-dom --save
 ```
 

--- a/sources/@repo/docs/content/learn/getting-started/adding-stylelint.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/adding-stylelint.mdx
@@ -8,7 +8,7 @@ sidebar_label: Adding Stylelint
 
 To get started with Stylelint, install the [@roots/bud-stylelint](/extensions/bud-stylelint) extension to your project.
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-stylelint --save-dev
 ```
 

--- a/sources/@repo/docs/content/learn/getting-started/adding-vue.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/adding-vue.mdx
@@ -8,7 +8,7 @@ sidebar_label: Adding Vue
 
 To get started with Vue, install the [@roots/bud-vue](/extensions/bud-vue) extension to your project.
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-vue --save-dev
 ```
 
@@ -20,7 +20,7 @@ Vue requires installing `vue` as production dependencies.
 
 We will try and resolve this for you but it is a good idea to install it as an explicit dependency:
 
-```bash npm2yarn
+```sh npm2yarn
 npm install vue --save
 ```
 

--- a/sources/@repo/docs/content/learn/getting-started/adding-wordpress-support.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/adding-wordpress-support.mdx
@@ -15,7 +15,7 @@ To get started with WordPress, install the [@roots/bud-preset-wordpress preset](
 
 We recommend using [@roots/bud-swc](/extensions/bud-swc):
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud-preset-wordpress @roots/bud-swc --save-dev
 ```
 

--- a/sources/@repo/docs/content/learn/getting-started/index.mdx
+++ b/sources/@repo/docs/content/learn/getting-started/index.mdx
@@ -22,7 +22,7 @@ sidebar_label: Installation
 
 The easiest way to get started with bud.js is to use the [create-bud-app command](/learn/getting-started/create-bud-app).
 
-```bash
+```sh
 npx create-bud-app my-app
 ```
 
@@ -30,7 +30,7 @@ npx create-bud-app my-app
 
 Add **@roots/bud** as a development dependency using your choice of package manager.
 
-```bash npm2yarn
+```sh npm2yarn
 npm install @roots/bud --save-dev
 ```
 
@@ -44,7 +44,7 @@ If you are using pnpm add `--public-hoist-pattern=*` to the installation command
 
 If your project's entrypoint is located at `./src/index.js` you can now compile it using the [bud build](/cli/build/index.mdx) command.
 
-```bash npm2yarn
+```sh npm2yarn
 npm run bud build
 ```
 
@@ -58,6 +58,6 @@ In general, all dependencies with the `@roots/*` namespace should share the same
 
 To make it easy to keep versions in sync you can use the [bud upgrade](/cli/upgrade.mdx) command.
 
-```bash npm2yarn
+```sh npm2yarn
 npm run bud upgrade
 ```

--- a/sources/@repo/docs/content/learn/modules/css-modules.mdx
+++ b/sources/@repo/docs/content/learn/modules/css-modules.mdx
@@ -17,8 +17,8 @@ However, support for CSS preprocessors can be added via extensions.
 
 Support for [PostCSS](https://postcss.org/) can be added to **bud.js** by installing the [@roots/bud-postcss](/extensions/bud-postcss) extension.
 
-```npm2yarn
-yarn add @roots/bud-postcss --dev
+```sh npm2yarn
+npm install @roots/bud-postcss --save-dev
 ```
 
 Once installed your stylesheets will be processed with postcss. The default configuration supports nested syntax, postcss-imports and autoprefixer.
@@ -29,8 +29,8 @@ Refer to the [@roots/bud-postcss](/extensions/bud-postcss) documentation for mor
 
 Support for [Sass](https://sass-lang.com/) can be added to **bud.js** by installing the [@roots/bud-sass](/extensions/bud-sass) extension.
 
-```npm2yarn
-yarn add @roots/bud-sass --dev
+```sh npm2yarn
+npm install @roots/bud-sass --save-dev
 ```
 
 Once installed your `.scss` and `.sass` files will be processed with dart-sass.

--- a/sources/@repo/docs/content/learn/modules/js-modules.mdx
+++ b/sources/@repo/docs/content/learn/modules/js-modules.mdx
@@ -189,8 +189,8 @@ Our recommended extension is [@roots/bud-swc](/extensions/bud-swc).
 
 [@roots/bud-swc](/extensions/bud-swc) is a [swc](https://swc.rs/) extension for **bud.js**.
 
-```npm2yarn
-yarn add @roots/bud-swc --dev
+```sh npm2yarn
+npm install @roots/bud-swc --save-dev
 ```
 
 It is a very fast and modern transpiler. The extension supports JavaScript and TypeScript with zero configuration.
@@ -199,8 +199,8 @@ It is a very fast and modern transpiler. The extension supports JavaScript and T
 
 [@roots/bud-babel](/extensions/bud-babel) is a [babel](https://babeljs.io/) extension for **bud.js**.
 
-```npm2yarn
-yarn add @roots/bud-babel --dev
+```sh npm2yarn
+npm install @roots/bud-babel --save-dev
 ```
 
 It is a very popular transpiler. It is also very configurable.
@@ -209,8 +209,8 @@ It is a very popular transpiler. It is also very configurable.
 
 [@roots/bud-typescript](/extensions/bud-typescript) is a [typescript](https://www.typescriptlang.org/) extension for **bud.js**.
 
-```npm2yarn
-yarn add @roots/bud-typescript --dev
+```sh npm2yarn
+npm install @roots/bud-typescript --save-dev
 ```
 
 It is a very popular transpiler. The extension supports JavaScript and TypeScript with zero configuration.
@@ -219,8 +219,8 @@ It is a very popular transpiler. The extension supports JavaScript and TypeScrip
 
 [@roots/bud-esbuild](/extensions/bud-esbuild) is a [esbuild](https://esbuild.github.io/) extension for **bud.js**.
 
-```npm2yarn
-yarn add @roots/bud-esbuild --dev
+```sh npm2yarn
+npm install @roots/bud-esbuild --save-dev
 ```
 
 It is a very fast and modern transpiler. The extension supports JavaScript and TypeScript with zero configuration. This extension
@@ -232,8 +232,8 @@ should be considered experimental.
 
 You can add React support to your project by installing the [@roots/bud-react](/extensions/bud-react) extension.
 
-```npm2yarn
-yarn add @roots/bud-react --dev
+```sh npm2yarn
+npm install @roots/bud-react --save-dev
 ```
 
 This extension is compatible with [any of the transpilers mentioned above](#transpiling). A transpiler is required to use React.
@@ -242,8 +242,8 @@ This extension is compatible with [any of the transpilers mentioned above](#tran
 
 You can add Vue support to your project by installing the [@roots/bud-vue](/extensions/bud-vue) extension.
 
-```npm2yarn
-yarn add @roots/bud-vue --dev
+```sh npm2yarn
+npm install @roots/bud-vue --save-dev
 ```
 
 By default the extension comes configured to use with Vue 3 SFCs. If you want to use Vue 2 refer to the [extension docs](/extensions/bud-vue).

--- a/sources/@repo/docs/content/reference/bud.bundle.mdx
+++ b/sources/@repo/docs/content/reference/bud.bundle.mdx
@@ -12,7 +12,7 @@ Split specified modules into a separate chunk
 
 The simplest usage is the name of the directory to create the chunk from:
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.bundle('alpine')
 ```
 
@@ -20,6 +20,6 @@ This produces a chunk named `js/bundle/alpine.js`
 
 You can specify a set of modules to include in the chunk:
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.bundle('vendor', ['react', 'react-dom'])
 ```

--- a/sources/@repo/docs/content/reference/bud.devtool.mdx
+++ b/sources/@repo/docs/content/reference/bud.devtool.mdx
@@ -39,3 +39,8 @@ bud.when(bud.isDevelopment, bud.devtool)
 ```ts title=bud.config.ts
 bud.tap(bud.devtool)
 ```
+
+## Related
+
+- [bud.when](/reference/bud.when)
+- [bud.tap](/reference/bud.tap)

--- a/sources/@repo/docs/content/reference/bud.relPath.mdx
+++ b/sources/@repo/docs/content/reference/bud.relPath.mdx
@@ -1,12 +1,12 @@
 ---
 title: bud.relPath
-description: Returns an absolute path to a directory or file.
+description: Get a path relative to the project's base directory.
 tags:
   - helpers
   - filesystem
 ---
 
-You can use **bud.relPath** to get a path relative to the project's base directory.
+Get a path relative to the project's base directory.
 
 ## Usage
 

--- a/sources/@repo/docs/content/reference/bud.use.mdx
+++ b/sources/@repo/docs/content/reference/bud.use.mdx
@@ -12,7 +12,7 @@ Register an extension or set of extensions.
 
 Add extensions:
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 import swc from '@roots/bud-swc'
 
 export default async bud => {
@@ -22,7 +22,7 @@ export default async bud => {
 
 You can register multiple extensions at once by passing an array of extensions.
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 import swc from '@roots/bud-swc'
 import react from '@roots/bud-react'
 
@@ -33,7 +33,7 @@ export default async bud => {
 
 Add an extension inline (also works with an array of extensions):
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.use({
   name: 'my-webpack-plugin',
   make: () => new MyWebpackPlugin(),
@@ -42,13 +42,13 @@ bud.use({
 
 Add a webpack plugin inline (also work with an array of plugins):
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.use(new MyWebpackPlugin())
 ```
 
 Add an extension or plugin from its signifier (must be the default export):
 
-```js title=bud.config.js
+```ts title=bud.config.ts
 bud.use(`my-webpack-plugin`)
 ```
 

--- a/sources/@repo/docs/content/reference/bud.when.mdx
+++ b/sources/@repo/docs/content/reference/bud.when.mdx
@@ -1,6 +1,8 @@
 ---
 title: bud.when
 description: Conditionally execute a function based on conditions
+tags:
+  - helpers
 ---
 
 Executes a function if a given test is `true`.

--- a/sources/@repo/docs/src/components/example.jsx
+++ b/sources/@repo/docs/src/components/example.jsx
@@ -1,0 +1,59 @@
+import CodeBlock from '@theme/CodeBlock'
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
+import React from 'react'
+
+export default function ExampleConfig({children, js, json, ts, yml}) {
+  if (!children) return null
+
+  const values = []
+
+  children = Array.isArray(children) ? children : [children]
+
+  children = children
+    .filter(child => child?.props?.children?.props)
+    .map(child => child.props.children.props)
+    .map(child => {
+      return {
+        code: child.children,
+        language: child.className
+          .split(`language-`)
+          .pop(),
+        title: child.title,
+      }
+    })
+
+  if (children.find(child => [`ts`, `tsx`].includes(child.language))) {
+    values.push({label: `TS`, value: `ts`})
+  }
+  if (children.find(child => [`js`, `jsx`].includes(child.language))) {
+    values.push({label: `JS`, value: `js`})
+  }
+  if (children.find(child => [`yml`].includes(child.language))) {
+    values.push({label: `YML`, value: `yml`})
+  }
+  if (children.find(child => [`json`].includes(child.language))) {
+    values.push({label: `JSON`, value: `json`})
+  }
+
+  return (
+    <Tabs groupId="language" values={values}>
+      {children.map((child, id) => {
+        return (
+          <TabItem key={id} value={child.language}>
+            <CodeBlock
+              language={child.language}
+              showLineNumbers
+              title={`${child.title}`}
+            >
+              {child.language === `ts` ? `import type {Bud} from '@roots/bud'\n\nexport default async (bud: Bud) => {\n` : ``}
+              {child.language === `js` ? `/** @param {import('@roots/bud').Bud} bud */\nexport default async (bud) => {\n` : ``}
+              {[`js`, `ts`].includes(child.language) ? child.code.split(`\n`).map((line, id) => id + 1 === child.code.split(`\n`).length ? `` : `  ${line}`).join(`\n`) : child.code}
+              {[`js`, `ts`].includes(child.language) ? `}` : ``}
+            </CodeBlock>
+          </TabItem>
+        )
+      })}
+    </Tabs>
+  )
+}

--- a/sources/@repo/docs/src/components/multi-language.jsx
+++ b/sources/@repo/docs/src/components/multi-language.jsx
@@ -1,0 +1,56 @@
+import CodeBlock from '@theme/CodeBlock'
+import TabItem from '@theme/TabItem'
+import Tabs from '@theme/Tabs'
+import React from 'react'
+
+export default function MultiLanguage({children, js, json, ts, yml}) {
+  if (!children) return null
+
+  const values = []
+
+  children = Array.isArray(children) ? children : [children]
+
+  children = children
+    .filter(child => child?.props?.children?.props)
+    .map(child => child.props.children.props)
+    .map(child => {
+      return {
+        code: child.children,
+        language: child.className
+          .split(`language-`)
+          .pop(),
+        title: child.title,
+      }
+    })
+
+  if (children.find(child => [`ts`, `tsx`].includes(child.language))) {
+    values.push({label: `TS`, value: `ts`})
+  }
+  if (children.find(child => [`js`, `jsx`].includes(child.language))) {
+    values.push({label: `JS`, value: `js`})
+  }
+  if (children.find(child => [`yml`].includes(child.language))) {
+    values.push({label: `YML`, value: `yml`})
+  }
+  if (children.find(child => [`json`].includes(child.language))) {
+    values.push({label: `JSON`, value: `json`})
+  }
+
+  return (
+    <Tabs groupId="language" values={values}>
+      {children.map((child, id) => {
+        return (
+          <TabItem key={id} value={child.language}>
+            <CodeBlock
+              language={child.language}
+              showLineNumbers
+              title={child.title}
+            >
+              {child.code}
+            </CodeBlock>
+          </TabItem>
+        )
+      })}
+    </Tabs>
+  )
+}

--- a/sources/@roots/bud-api/docs/entry/globbing.md
+++ b/sources/@roots/bud-api/docs/entry/globbing.md
@@ -4,6 +4,7 @@ title: Globbing
 
 **bud.entry** can be used with [bud.glob](/reference/bud.glob) to find matching files.
 
+```ts title=bud.config.ts
 export default async bud => {
   bud.entry({
     app: await bud.glob('./src/*.{css,js}'),

--- a/sources/@roots/bud-eslint/README.md
+++ b/sources/@roots/bud-eslint/README.md
@@ -112,8 +112,8 @@ bud.eslint.setFix(true);
 
 There is a recommended eslint configuration available for you to use as a starting point.
 
-```npm2yarn
-npm install @roots/eslint-config --dev-only
+```bash npm2yarn
+npm install @roots/eslint-config --save-dev
 ```
 
 Once installed you can add it to the `extends` array in your eslint config:

--- a/sources/@roots/bud-eslint/docs/01-configuration.md
+++ b/sources/@roots/bud-eslint/docs/01-configuration.md
@@ -82,8 +82,8 @@ bud.eslint.setFix(true)
 
 There is a recommended eslint configuration available for you to use as a starting point.
 
-```npm2yarn
-npm install @roots/eslint-config --dev-only
+```bash npm2yarn
+npm install @roots/eslint-config --save-dev
 ```
 
 Once installed you can add it to the `extends` array in your eslint config:

--- a/sources/@roots/bud-stylelint/README.md
+++ b/sources/@roots/bud-stylelint/README.md
@@ -66,7 +66,7 @@ The `bud.stylelint` API provides several methods for interacting with these opti
 
 Here's an example of how you can use the `bud.stylelint` API in your Bud configuration:
 
-```ts
+```ts title=bud.config.ts
 import { type Bud } from "@roots/bud";
 
 export default async (bud: Bud) => {

--- a/sources/@roots/bud-stylelint/docs/03-usage.md
+++ b/sources/@roots/bud-stylelint/docs/03-usage.md
@@ -4,7 +4,7 @@ title: Example usage
 
 Here's an example of how you can use the `bud.stylelint` API in your Bud configuration:
 
-```ts
+```ts title=bud.config.ts
 import {type Bud} from '@roots/bud'
 
 export default async (bud: Bud) => {

--- a/sources/@roots/bud-tailwindcss/README.md
+++ b/sources/@roots/bud-tailwindcss/README.md
@@ -116,7 +116,7 @@ bud.js can be configured to allow for you to import tailwind theme values using 
 
 An example:
 
-```typescript
+```ts title=bud.config.ts
 import { black } from "@tailwind/colors";
 import { sans } from "@tailwind/fontFamily";
 
@@ -128,13 +128,13 @@ export const main = () => {
 
 Generating the imports can be memory intensive and increase build times, so it is opt-in.
 
-```ts
+```ts title=bud.config.ts
 bud.tailwind.generateImports();
 ```
 
 Better to generate imports only for specific keys:
 
-```ts
+```ts title=bud.config.ts
 bud.tailwind.generateImports([`colors`, `fontFamily`]);
 ```
 

--- a/sources/@roots/bud-tailwindcss/docs/01-configuration.md
+++ b/sources/@roots/bud-tailwindcss/docs/01-configuration.md
@@ -84,7 +84,7 @@ bud.js can be configured to allow for you to import tailwind theme values using 
 
 An example:
 
-```typescript
+```ts title=bud.config.ts
 import {black} from '@tailwind/colors'
 import {sans} from '@tailwind/fontFamily'
 
@@ -96,13 +96,13 @@ export const main = () => {
 
 Generating the imports can be memory intensive and increase build times, so it is opt-in.
 
-```ts
+```ts title=bud.config.ts
 bud.tailwind.generateImports()
 ```
 
 Better to generate imports only for specific keys:
 
-```ts
+```ts title=bud.config.ts
 bud.tailwind.generateImports([`colors`, `fontFamily`])
 ```
 


### PR DESCRIPTION
Adds `ConfigExample` component to make it easier to provide support for multiple languages in our code samples.

Already deployed this branch to the live docs site. Here's an example page that uses it:

https://bud.js.org/learn/config/entrypoints

Example usage:

````mdx
---
title: Entrypoints
sidebar_label: Entrypoints
---

import ConfigExample from '@site/src/components/example';

bud.js uses the concept of "entrypoints" to group application scripts and styles. Entrypoints are defined using [bud.entry](/reference/bud.entry).

You can think of an entrypoint as a "page" in your application. Each entrypoint will have its own output file.

:::info

If your application's entrypoint is located at '@src/index.js' then you don't need to do anything. bud.js will automatically detect this and create an entrypoint for you.

:::

If you only have a single entrypoint then it is enough to just pass the filename:

<ConfigExample>

```ts title=bud.config.ts
bud.entry('app') // src/app.js
```

```js title=bud.config.js
bud.entry('app') // src/app.js
```

```yml title=bud.config.yml
entry: app # src/app.js
```

```json title=bud.config.json
{
  "entry": "app" // src/app.js
}
```

</ConfigExample>
````


## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
