### PR TITLE
🩹 fix(patch): revert upgrade of figures to 5.0.0

### DIFF
--- a/sources/@roots/bud-preset-wordpress/package.json
+++ b/sources/@roots/bud-preset-wordpress/package.json
@@ -84,8 +84,6 @@
     "@roots/bud-wordpress-externals": "workspace:*",
     "@roots/bud-wordpress-theme-json": "workspace:*",
     "@roots/wordpress-hmr": "workspace:*",
-    "chalk": "5.3.0",
-    "figures": "6.0.1",
     "tslib": "2.6.2"
   },
   "volta": {

--- a/sources/@roots/bud-support/package.json
+++ b/sources/@roots/bud-support/package.json
@@ -326,7 +326,7 @@
     "esbuild-wasm": "0.19.5",
     "execa": "8.0.1",
     "express": "4.18.2",
-    "figures": "6.0.1",
+    "figures": "5.0.0",
     "file-loader": "6.2.0",
     "get-port": "7.0.0",
     "globby": "14.0.0",

--- a/sources/create-bud-app/package.json
+++ b/sources/create-bud-app/package.json
@@ -61,7 +61,7 @@
     "clipanion": "4.0.0-rc.2",
     "enquirer": "2.4.1",
     "execa": "8.0.1",
-    "figures": "6.0.1",
+    "figures": "5.0.0",
     "handlebars": "4.7.8",
     "lodash": "4.17.21",
     "ora": "7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9448,8 +9448,6 @@ __metadata:
     "@roots/wordpress-hmr": "workspace:*"
     "@skypack/package-check": 0.2.2
     "@types/node": 20.9.0
-    chalk: 5.3.0
-    figures: 6.0.1
     tslib: 2.6.2
   languageName: unknown
   linkType: soft
@@ -19311,7 +19309,7 @@ __metadata:
     clipanion: 4.0.0-rc.2
     enquirer: 2.4.1
     execa: 8.0.1
-    figures: 6.0.1
+    figures: 5.0.0
     handlebars: 4.7.8
     lodash: 4.17.21
     ora: 7.0.1
@@ -23030,15 +23028,6 @@ __metadata:
     escape-string-regexp: ^5.0.0
     is-unicode-supported: ^1.2.0
   checksum: e6e8b6d1df2f554d4effae4a5ceff5d796f9449f6d4e912d74dab7d5f25916ecda6c305b9084833157d56485a0c78b37164430ddc5675bcee1330e346710669e
-  languageName: node
-  linkType: hard
-
-"figures@npm:6.0.1":
-  version: 6.0.1
-  resolution: "figures@npm:6.0.1"
-  dependencies:
-    is-unicode-supported: ^2.0.0
-  checksum: 66c2b2d76eff324025181f205e2ad725e1ce50d5a24973282249aed4858878b8aa96d8286541c65564ef38ff447802c1320c6cd07645307211f3abe32458bee4
   languageName: node
   linkType: hard
 
@@ -26833,13 +26822,6 @@ __metadata:
   version: 1.3.0
   resolution: "is-unicode-supported@npm:1.3.0"
   checksum: 20a1fc161afafaf49243551a5ac33b6c4cf0bbcce369fcd8f2951fbdd000c30698ce320de3ee6830497310a8f41880f8066d440aa3eb0a853e2aa4836dd89abc
-  languageName: node
-  linkType: hard
-
-"is-unicode-supported@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-unicode-supported@npm:2.0.0"
-  checksum: 000b80639dedaf59a385f1c0a57f97a4d1435e0723716f24cc19ad94253a7a0a9f838bdc9ac49b10a29ac93b01f52ae9b2ed358a8876caf1eb74d73b4ede92b2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9618,7 +9618,7 @@ __metadata:
     esbuild-wasm: 0.19.5
     execa: 8.0.1
     express: 4.18.2
-    figures: 6.0.1
+    figures: 5.0.0
     file-loader: 6.2.0
     get-port: 7.0.0
     globby: 14.0.0
@@ -23023,6 +23023,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"figures@npm:5.0.0, figures@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "figures@npm:5.0.0"
+  dependencies:
+    escape-string-regexp: ^5.0.0
+    is-unicode-supported: ^1.2.0
+  checksum: e6e8b6d1df2f554d4effae4a5ceff5d796f9449f6d4e912d74dab7d5f25916ecda6c305b9084833157d56485a0c78b37164430ddc5675bcee1330e346710669e
+  languageName: node
+  linkType: hard
+
 "figures@npm:6.0.1":
   version: 6.0.1
   resolution: "figures@npm:6.0.1"
@@ -23067,16 +23077,6 @@ __metadata:
     escape-string-regexp: ^5.0.0
     is-unicode-supported: ^1.2.0
   checksum: 08564c70ec6be8dbd26e24e4f35bacb8d9beb729b3b7faa9cd7ad54f5232b7f9a39f788a847ec45677664d568c86323001d1042482d089c0d0f311e197ad1148
-  languageName: node
-  linkType: hard
-
-"figures@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "figures@npm:5.0.0"
-  dependencies:
-    escape-string-regexp: ^5.0.0
-    is-unicode-supported: ^1.2.0
-  checksum: e6e8b6d1df2f554d4effae4a5ceff5d796f9449f6d4e912d74dab7d5f25916ecda6c305b9084833157d56485a0c78b37164430ddc5675bcee1330e346710669e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts [figures](https://github.com/sindresorhus/figures#readme) to 5.0.0. v6 requires node 18 and I don't want to force the issue of node 16 for projects until `@roots/bud@^7`.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->

## Ref

- Closes #2508 