### PR TITLE
`custom-property-pattern` rule changed for compatibility with WP naming

### DIFF
--- a/sources/@roots/bud-preset-wordpress/config/stylelint.cjs
+++ b/sources/@roots/bud-preset-wordpress/config/stylelint.cjs
@@ -3,6 +3,11 @@
  */
 module.exports = {
   rules: {
-    'custom-property-pattern': null,
+    'custom-property-pattern': [
+      '^([a-z][a-z0-9]*)(-{1,2}[a-z0-9]+)*$',
+      {
+        message: name => `Expected custom property name "${name}" to be kebab-case`,
+      },
+    ],
   },
 }

--- a/sources/@roots/bud-preset-wordpress/config/stylelint.cjs
+++ b/sources/@roots/bud-preset-wordpress/config/stylelint.cjs
@@ -4,7 +4,7 @@
 module.exports = {
   rules: {
     'custom-property-pattern': [
-      '^([a-z][a-z0-9]*)(-{1,2}[a-z0-9]+)*$',
+      `^([a-z][a-z0-9]*)(-{1,2}[a-z0-9]+)*$`,
       {
         message: name => `Expected custom property name "${name}" to be kebab-case`,
       },

--- a/sources/@roots/bud-preset-wordpress/test/stylelint-config.test.ts
+++ b/sources/@roots/bud-preset-wordpress/test/stylelint-config.test.ts
@@ -1,0 +1,39 @@
+import * as stylelint from 'stylelint'
+import {describe, expect, it} from 'vitest'
+
+describe(`@roots/bud-preset-wordpress/stylelint`, () => {
+  it(`should error without rule`, async () => {
+    const result = await stylelint.lint({
+      code: `
+        .foo {
+          color: var(--wp--preset--color--primary);
+        }
+      `,
+      config: {
+        extends: [
+          `@roots/bud-sass/stylelint-config`,
+        ],
+      },
+    })
+
+    expect(result.errored).toBe(true)
+  })
+
+  it(`should not error with rule`, async () => {
+    const result = await stylelint.lint({
+      code: `
+        .foo {
+          color: var(--wp--preset--color--primary);
+        }
+      `,
+      config: {
+        extends: [
+          `@roots/bud-sass/stylelint-config`,
+          `@roots/bud-preset-wordpress/stylelint`,
+        ],
+      },
+    })
+
+    expect(result.errored).toBe(false)
+  })
+})

--- a/sources/@roots/bud-sass/config/stylelint.cjs
+++ b/sources/@roots/bud-sass/config/stylelint.cjs
@@ -3,12 +3,4 @@ module.exports = {
     `@roots/bud-stylelint/config`,
     `stylelint-config-recommended-scss`,
   ],
-  rules: {
-    'custom-property-pattern': [
-      '^([a-z][a-z0-9]*)(-{1,2}[a-z0-9]+)*$',
-      {
-        message: name => `Expected custom property name "${name}" to be kebab-case`,
-      },
-    ],
-  },
 }

--- a/sources/@roots/bud-sass/config/stylelint.cjs
+++ b/sources/@roots/bud-sass/config/stylelint.cjs
@@ -3,4 +3,12 @@ module.exports = {
     `@roots/bud-stylelint/config`,
     `stylelint-config-recommended-scss`,
   ],
+  rules: {
+    'custom-property-pattern': [
+      '^([a-z][a-z0-9]*)(-{1,2}[a-z0-9]+)*$',
+      {
+        message: name => `Expected custom property name "${name}" to be kebab-case`,
+      },
+    ],
+  },
 }


### PR DESCRIPTION
<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

## Type of change

**MAJOR: breaking change**
fix #2538 
<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
