### PR TITLE
📕 docs(none): mention @roots/bud-preset-wordpress/stylelint

### DIFF
--- a/sources/@repo/docs/content/extensions/bud-preset-wordpress/index.mdx
+++ b/sources/@repo/docs/content/extensions/bud-preset-wordpress/index.mdx
@@ -4,9 +4,6 @@ description: 'Recommended extensions and base configuration for WordPress projec
 sidebar_label: '@roots/bud-preset-wordpress'
 ---
 
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
-
 The [@roots/bud-preset-wordpress](/extensions/bud-preset-wordpress) package is a great starting point for WordPress plugins & themes.
 
 If you plan on using it in a WordPress theme you should consider using [@roots/sage](https://github.com/roots/sage).
@@ -34,7 +31,6 @@ The [@roots/bud-preset-wordpress preset](/extensions/bud-preset-wordpress) inclu
 - @roots/bud-wordpress-dependencies
 - @roots/bud-wordpress-externals
 - @roots/bud-wordpress-theme-json
-- @roots/wordpress-hmr
 
 ## Managing WordPress enqueues
 

--- a/sources/@repo/docs/content/extensions/bud-preset-wordpress/stylelint.mdx
+++ b/sources/@repo/docs/content/extensions/bud-preset-wordpress/stylelint.mdx
@@ -1,0 +1,26 @@
+---
+title: Stylelint
+description: 'Setting up stylelint rules'
+sidebar_label: Stylelint
+---
+
+If you are using [stylelint](https://stylelint.io/) you may wish to extend our base configuration:
+
+```js
+module.exports = {
+  extends: [
+    '@roots/bud-wordpress-preset/stylelint'],
+};
+```
+
+This is especially true if you are using the [@roots/bud-sass/stylelint](/extensions/bud-sass) configuration, which conflicts with the WordPress standard naming scheme for css variables.
+
+```js
+module.exports = {
+  extends: [
+    '@roots/bud-stylelint/config',
+    '@roots/bud-sass/stylelint',
+    '@roots/bud-wordpress-preset/stylelint'
+  ]
+}
+```


### PR DESCRIPTION
Mention `@roots/bud-preset-wordpress/stylelint` export.

- Fixes: #2542
- See also: #2538

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
