### PR TITLE
🔨 improve(patch): safer module resolution

### DIFF
--- a/sources/@roots/bud-framework/test/module.test.ts
+++ b/sources/@roots/bud-framework/test/module.test.ts
@@ -107,7 +107,7 @@ describe(`@roots/bud-framework`, () => {
 
     instance.cache.sha1 = `bar`
 
-    const resetSpy = vi.spyOn(instance, `resetCache`)
+    const resetSpy = vi.spyOn(instance, `removeCachedResolutions`)
     await instance.bootstrap(bud)
 
     expect(resetSpy).toHaveBeenCalled()
@@ -129,7 +129,7 @@ describe(`@roots/bud-framework`, () => {
 
     instance.cache.sha1 = `foo`
 
-    const resetSpy = vi.spyOn(instance, `resetCache`)
+    const resetSpy = vi.spyOn(instance, `removeCachedResolutions`)
     await instance.bootstrap(bud)
 
     expect(resetSpy).not.toHaveBeenCalled()
@@ -147,7 +147,7 @@ describe(`@roots/bud-framework`, () => {
       },
     })
 
-    const resetSpy = vi.spyOn(instance, `resetCache`)
+    const resetSpy = vi.spyOn(instance, `removeCachedResolutions`)
     await instance.bootstrap(bud)
     expect(resetSpy).toHaveBeenCalled()
   })
@@ -164,7 +164,7 @@ describe(`@roots/bud-framework`, () => {
       },
     })
 
-    const resetSpy = vi.spyOn(instance, `resetCache`)
+    const resetSpy = vi.spyOn(instance, `removeCachedResolutions`)
     await instance.bootstrap(bud)
     expect(resetSpy).toHaveBeenCalled()
   })


### PR DESCRIPTION
- clear `bud.module` fs cache whenever a resolve or import error occurs
- write `bud.error.resolutions.yml` with cached state, timestamp and error data for debugging
- typechecking improvements
- add methods to de-mess the interface (a bit)

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
