### PR TITLE
🩹 fix(none): fix stylelint violation in project templates #2549

### DIFF
--- a/sources/create-bud-app/src/tasks/write.tsconfig.ts
+++ b/sources/create-bud-app/src/tasks/write.tsconfig.ts
@@ -22,11 +22,12 @@ export default async function writeTsConfig(command: CreateCommand) {
     command.support.includes(`sass`) && types.push(`@roots/bud-sass`)
     command.support.includes(`tailwindcss`) &&
       types.push(`@roots/bud-tailwindcss`)
+
     command.support.includes(`postcss`) && types.push(`@roots/bud-postcss`)
     command.support.includes(`vue`) && types.push(`@roots/bud-vue`)
     command.support.includes(`react`) && types.push(`@roots/bud-react`)
     command.support.includes(`eslint`) && types.push(`@roots/bud-eslint`)
-    command.support.includes(`stylelint`) && types.push(`@roots/stylelint`)
+    command.support.includes(`stylelint`) && types.push(`@roots/bud-stylelint`)
     command.support.includes(`wordpress`) &&
       types.push(`@roots/bud-preset-wordpress`)
 

--- a/sources/create-bud-app/templates/react/index.css.hbs
+++ b/sources/create-bud-app/templates/react/index.css.hbs
@@ -16,7 +16,6 @@ code {
   text-align: center;
   display: flex;
   justify-content: center;
-  align-content: center;
 }
 
 .app .logo {

--- a/sources/create-bud-app/templates/vanilla/index.css.hbs
+++ b/sources/create-bud-app/templates/vanilla/index.css.hbs
@@ -16,7 +16,6 @@ code {
   text-align: center;
   display: flex;
   justify-content: center;
-  align-content: center;
 }
 
 .app .logo {

--- a/sources/create-bud-app/templates/vue/components/app.vue.hbs
+++ b/sources/create-bud-app/templates/vue/components/app.vue.hbs
@@ -32,7 +32,6 @@ code {
   text-align: center;
   display: flex;
   justify-content: center;
-  align-content: center;
   background-color: rgb(4 1 17);
 
   & .logo {


### PR DESCRIPTION
- fix: stylelint violation in project templates
- fix: tsconfig.json `types` field for `@roots/bud-stylelint` is `@roots/stylelint`
- closes #2549

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
