### PR TITLE
📕 docs(none): fix eslint docs url for config files

### DIFF
--- a/sources/@roots/bud-eslint/docs/01-configuration.md
+++ b/sources/@roots/bud-eslint/docs/01-configuration.md
@@ -11,7 +11,7 @@ You can configure Stylelint in two ways:
 
 ### Using an eslint config file
 
-You can configure eslint [using a eslint config file](https://eslint.io/user-guide/configure).
+You can configure eslint [using a eslint config file](https://eslint.org/docs/latest/use/configure/configuration-files).
 
 bud.js allows for you to write your eslint config in CommonJS, ESM, TypeScript, JSON or YML. This file should be placed in the root of your project or the project `./config` directory.
 


### PR DESCRIPTION
Domain `eslint.io` isn't available anymore and docs url changed to `eslint.org`.