### PR TITLE
🩹 fix(stylelint): `Unexpected invalid media query "screen(x)"` for Tailwind

### DIFF
--- a/sources/@roots/bud-tailwindcss/config/stylelint/common.cjs
+++ b/sources/@roots/bud-tailwindcss/config/stylelint/common.cjs
@@ -4,4 +4,5 @@
 module.exports = {
   'function-no-unknown': [true, {ignoreFunctions: [`theme`]}],
   'import-notation': null,
+  'media-query-no-invalid': null,
 }


### PR DESCRIPTION
<!--
  Short description of the problem being addressed or the reason for the proposed feature.

  If there is not an associated issue please consider creating one
-->

Fixes #2557 

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
