### PR TITLE
🩹 fix(patch): bud.after sync callback error

### DIFF
--- a/examples/node-api/node-script.js
+++ b/examples/node-api/node-script.js
@@ -19,11 +19,6 @@ const bud = await factory()
 bud.setPath(`@dist`, `dist/build-a`)
 
 /**
- * Add extensions
- */
-await bud.extensions.add([`@roots/bud-swc`])
-
-/**
  * Run build
  */
 await bud.run()

--- a/sources/@roots/bud-framework/src/methods/after/index.ts
+++ b/sources/@roots/bud-framework/src/methods/after/index.ts
@@ -15,14 +15,12 @@ export const after: after = function (
   fn: ((app: Bud) => any) | ((app: Bud) => Promise<any>),
   onError?: (error: Error) => unknown,
 ): Bud {
-  const handleError = onError ?? this.catch
-
   this.hooks.action(`compiler.done`, async bud => {
     try {
       await bud.resolvePromises()
       await fn(bud)
     } catch (error) {
-      handleError(error)
+      onError ? onError(error) : bud.catch(error)
     }
   })
 

--- a/sources/@roots/bud-framework/src/methods/after/index.ts
+++ b/sources/@roots/bud-framework/src/methods/after/index.ts
@@ -15,8 +15,15 @@ export const after: after = function (
   fn: ((app: Bud) => any) | ((app: Bud) => Promise<any>),
   onError?: (error: Error) => unknown,
 ): Bud {
+  const handleError = onError ?? this.catch
+
   this.hooks.action(`compiler.done`, async bud => {
-    await fn(bud).catch(onError ?? bud.catch)
+    try {
+      await bud.resolvePromises()
+      await fn(bud)
+    } catch (error) {
+      handleError(error)
+    }
   })
 
   return this

--- a/sources/@roots/bud-hooks/src/event/event.ts
+++ b/sources/@roots/bud-hooks/src/event/event.ts
@@ -7,10 +7,7 @@ import {BudError} from '@roots/bud-support/errors'
 import {Hooks} from '../base/base.js'
 
 /**
- * Synchronous hooks registry
- *
- * @remarks
- * Supports sync values
+ * Event hooks
  */
 export class EventHooks extends Hooks<EventsStore> {
   @bind
@@ -22,12 +19,13 @@ export class EventHooks extends Hooks<EventsStore> {
 
     for await (const action of this.store[id] as any) {
       this.logger.info(`running ${id}`)
+
       try {
         await action(...value)
         await this.app.resolvePromises()
       } catch (error) {
-        this.logger.error(`problem running ${id} callback`)
-        throw BudError.normalize(error)
+        this.logger.error(`problem running ${id} callback`, error)
+        this.app.catch(error)
       }
     }
 

--- a/sources/@roots/bud-hooks/src/event/event.ts
+++ b/sources/@roots/bud-hooks/src/event/event.ts
@@ -2,7 +2,6 @@ import type {Bud} from '@roots/bud-framework'
 import type {Events, EventsStore} from '@roots/bud-framework/registry'
 
 import {bind} from '@roots/bud-support/decorators/bind'
-import {BudError} from '@roots/bud-support/errors'
 
 import {Hooks} from '../base/base.js'
 
@@ -25,7 +24,7 @@ export class EventHooks extends Hooks<EventsStore> {
         await this.app.resolvePromises()
       } catch (error) {
         this.logger.error(`problem running ${id} callback`, error)
-        this.app.catch(error)
+        throw error
       }
     }
 


### PR DESCRIPTION
Fixes error when [bud.after](https://bud.js.org/reference/bud.after) is provided a synchronous callback function.

```js
bud.after(bud => {
  console.log(`this should work`)
  console.error(`but doesn't`)
}
```

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
