### PR TITLE
🔨 improve(patch): bud.pipe: allow mixed async and sync cbs

### DIFF
--- a/sources/@roots/bud-framework/src/methods/pipe/index.ts
+++ b/sources/@roots/bud-framework/src/methods/pipe/index.ts
@@ -9,7 +9,7 @@ import isUndefined from '@roots/bud-support/isUndefined'
  * The output of this function becomes the input to the next
  */
 interface Callback<T = any> {
-  (input: T): Promise<T>
+  (input: T): Promise<T> | T
 }
 
 export interface pipe {
@@ -38,8 +38,12 @@ export interface pipe {
 export const pipe: pipe = async function (functions, maybeInitialValue) {
   return await functions.reduce(
     async (value, fn) => {
-      const nextValue = await value
-      return await fn(nextValue)
+      try {
+        return await fn(await value)
+      } catch (e) {
+        this.catch(e)
+        return await value
+      }
     },
     Promise.resolve(
       !isUndefined(maybeInitialValue) ? maybeInitialValue : this,

--- a/sources/@roots/bud-framework/test/methods/pipe/pipe.test.ts
+++ b/sources/@roots/bud-framework/test/methods/pipe/pipe.test.ts
@@ -3,38 +3,46 @@ import {beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {pipe as subject} from '../../../src/methods/pipe'
 
-describe(
-  `bud.pipe`,
-  function () {
-    let pipe: subject
-    let bud: Bud
+describe(`bud.pipe`, function () {
+  let pipe: subject
+  let bud: Bud
 
-    beforeEach(async () => {
-      bud = await factory()
-      pipe = subject.bind(bud)
-    })
+  beforeEach(async () => {
+    bud = await factory()
+    pipe = subject.bind(bud)
+  })
 
-    it(`is a function`, () => {
-      expect(pipe).toBeInstanceOf(Function)
-    })
+  it(`should be a function`, () => {
+    expect(pipe).toBeInstanceOf(Function)
+  })
 
-    it(`returns Bud when initial value is \`undefined\``, async () => {
-      const callback = vi.fn(async value => value)
-      const value = await pipe([callback], undefined)
-      expect(callback).toHaveBeenCalledWith(bud)
-      expect(value).toBe(bud)
-    })
+  it(`should use bud when initial value is \`undefined\``, async () => {
+    const callback = vi.fn(async value => value)
+    const value = await pipe([callback], undefined)
+    expect(callback).toHaveBeenCalledWith(bud)
+    expect(value).toBe(bud)
+  })
 
-    it(`pipes value`, async () => {
-      const callback = vi.fn(async v => `${v}!`)
-      const value = await pipe([callback, callback, callback], `test`)
+  it(`should pipe value between callbacks`, async () => {
+    const callback = vi.fn(async v => `${v}!`)
+    const value = await pipe([callback, callback, callback], `test`)
 
-      expect(callback).toHaveBeenNthCalledWith(1, `test`)
-      expect(callback).toHaveBeenNthCalledWith(2, `test!`)
-      expect(callback).toHaveBeenNthCalledWith(3, `test!!`)
+    expect(callback).toHaveBeenNthCalledWith(1, `test`)
+    expect(callback).toHaveBeenNthCalledWith(2, `test!`)
+    expect(callback).toHaveBeenNthCalledWith(3, `test!!`)
 
-      expect(value).toBe(`test!!!`)
-    })
-  },
-  {retry: 2},
-)
+    expect(value).toBe(`test!!!`)
+  })
+
+  it(`should allow mixed use of sync and async callbacks`, async () => {
+    const asyncCallback = vi.fn(async v => `${v}!`)
+    const syncCallback = vi.fn(v => `${v}!`)
+
+    const value = await pipe([asyncCallback, syncCallback], `test`)
+
+    expect(asyncCallback).toHaveBeenCalledWith(`test`)
+    expect(syncCallback).toHaveBeenCalledWith(`test!`)
+
+    expect(value).toBe(`test!!`)
+  })
+})


### PR DESCRIPTION
No reason to not support mixed async and sync functions with [bud.pipe](https://bud.js.org/reference/bud.pipe). Only need to update typings and add a unit test to cover.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
