### PR TITLE
✨ feat(minor): add bud.wp.json.removeDefaultSuffix

### DIFF
--- a/sources/@roots/bud-tailwindcss-theme-json/src/extension/index.ts
+++ b/sources/@roots/bud-tailwindcss-theme-json/src/extension/index.ts
@@ -16,6 +16,7 @@ interface Options {
   color?: `extend` | boolean
   fontFamily?: `extend` | boolean
   fontSize?: `extend` | boolean
+  removeDefaultSuffix: boolean
   spacing?: `extend` | boolean
 }
 
@@ -27,6 +28,7 @@ interface Options {
   color: false,
   fontFamily: false,
   fontSize: false,
+  removeDefaultSuffix: false,
   spacing: false,
 })
 export class TailwindThemeJSON extends Extension {
@@ -82,16 +84,31 @@ export class TailwindThemeJSON extends Extension {
     bud.wpjson.useTailwindFontFamily = this.useTailwindFontFamily
     bud.wpjson.useTailwindFontSize = this.useTailwindFontSize
     bud.wpjson.useTailwindSpacing = this.useTailwindSpacing
+    bud.wpjson.removeDefaultSuffix = this.removeDefaultSuffix
+  }
+
+  @bind
+  public removeDefaultSuffix(value: boolean = true) {
+    this.set(`removeDefaultSuffix`, value)
+    return this.app.wpjson
   }
 
   @bind
   public tapTailwindColor(options: SettingsAndStyles): SettingsAndStyles {
-    const palette = tailwindAdapter.palette.transform({
+    const values = tailwindAdapter.palette.transform({
       ...this.app.tailwind.resolveThemeValue(
         `colors`,
         this.options.color === `extend`,
       ),
     })
+
+    const palette = this.get(`removeDefaultSuffix`)
+      ? values.map(({color, name, slug}) => ({
+          color,
+          name: name.replace(/ default$/i, ``),
+          slug: slug.replace(/-default$/i, ``),
+        }))
+      : values
 
     return {
       ...(options ?? {}),

--- a/sources/@roots/bud-wordpress-theme-json/src/extension.ts
+++ b/sources/@roots/bud-wordpress-theme-json/src/extension.ts
@@ -131,6 +131,21 @@ class WordPressThemeJson extends Extension<
   >
 
   /**
+   * ## bud.wp.json.removeDefaultSuffix
+   *
+   * Remove the `-default` suffix from color slugs and ` Default` from color names
+   *
+   * @example
+   * ```ts
+   * bud.wp.json.removeDefaultSuffix()
+   * bud.wp.json.removeDefaultSuffix(true)
+   * ```
+   */
+  public declare removeDefaultSuffix?: (
+    value?: boolean,
+  ) => WordPressThemeJson
+
+  /**
    * ## bud.wp.json.useTailwindColors
    *
    * Source settings.color.palette values from tailwind config


### PR DESCRIPTION
Add: `bud.wp.json.removeDefaultSuffix` method.

Tailwind uses `DEFAULT` to define a color value without a shade (e.g. `.blue` instead of `.blue-500`). This ends up in generated `theme.json` files.

Example:

```ts
{
  "color": "#f7fafc",
  "name": "Gray Default",
  "slug": "gray-default"
}
```

If the method is called, the generated value looks like this:

```ts
{
  "color": "#f7fafc",
  "name": "Gray",
  "slug": "gray"
}
```

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
