### PR TITLE
🔨 improve(none): @roots/bud-mdx

### DIFF
--- a/sources/@roots/bud-mdx/src/extension.ts
+++ b/sources/@roots/bud-mdx/src/extension.ts
@@ -3,6 +3,7 @@ import type {Bud} from '@roots/bud-framework'
 import {Extension} from '@roots/bud-framework/extension'
 import {
   bind,
+  expose,
   label,
   options,
 } from '@roots/bud-framework/extension/decorators'
@@ -20,25 +21,16 @@ interface Options {
   rehypePlugins: {},
   remarkPlugins: {},
 })
+@expose(`mdx`)
 class BudMDX extends Extension<Options> {
-  /**
-   * Get rehype plugins
-   */
-  public declare getRehypePlugins: () => Options[`rehypePlugins`]
-
-  /**
-   * Get remark plugins
-   */
-  public declare getRemarkPlugins: () => Options[`remarkPlugins`]
-
   /**
    * Rehype plugins
    */
   public declare rehypePlugins: Options[`rehypePlugins`]
   /**
-   * Remark plugins
+   * Get rehype plugins
    */
-  public declare remarkPlugins: Options[`remarkPlugins`]
+  public declare getRehypePlugins: () => Options[`rehypePlugins`]
   /**
    * Set rehype plugins
    */
@@ -47,11 +39,45 @@ class BudMDX extends Extension<Options> {
   ) => this
 
   /**
+   * Remark plugins
+   */
+  public declare remarkPlugins: Options[`remarkPlugins`]
+  /**
+   * Get remark plugins
+   */
+  public declare getRemarkPlugins: () => Options[`remarkPlugins`]
+  /**
    * Set remark plugins
    */
   public declare setRemarkPlugins: (
     plugins: Options[`remarkPlugins`],
   ) => this
+
+  /**
+   * {@link Extension.register}
+   */
+  @bind
+  public override async register({build, hooks}: Bud) {
+    const loader = await this.resolve(`@mdx-js/loader`, import.meta.url)
+    if (!loader) return this.logger.error(`MDX loader not found`)
+
+    build.setLoader(`mdx`, `@mdx-js/loader`).setItem(`mdx`, {
+      loader: `mdx`,
+      options: () => ({
+        rehypePlugins: Object.values(this.get(`rehypePlugins`)),
+        remarkPlugins: Object.values(this.get(`remarkPlugins`)),
+      }),
+    })
+
+    hooks.on(`pattern.mdx`, /mdx?$/)
+    hooks.on(`build.resolve.extensions`, (ext = new Set()) =>
+      ext.add(`.md`).add(`.mdx`),
+    )
+    hooks.on(`build.resolveLoader.alias`, (aliases = {}) => ({
+      ...aliases,
+      [`@mdx-js/loader`]: loader,
+    }))
+  }
 
   /**
    * {@link Extension.boot}
@@ -62,35 +88,6 @@ class BudMDX extends Extension<Options> {
       include: [({path}) => path(`@src`)],
       test: /\.mdx?$/,
       use: [...(build.rules.js.use ?? []), `mdx`],
-    })
-  }
-
-  /**
-   * {@link Extension.register}
-   */
-  @bind
-  public override async register({build, hooks}: Bud) {
-    const loader = await this.resolve(`@mdx-js/loader`, import.meta.url)
-    if (!loader) return this.logger.error(`MDX loader not found`)
-
-    hooks.on(`build.resolve.extensions`, (ext = new Set()) =>
-      ext.add(`.md`).add(`.mdx`),
-    )
-    hooks.on(`build.resolveLoader.alias`, (aliases = {}) => ({
-      ...aliases,
-      [`@mdx-js/loader`]: loader,
-    }))
-
-    build.setLoader(`mdx`, `@mdx-js/loader`).setItem(`mdx`, {
-      loader: `mdx`,
-      options: () => ({
-        rehypePlugins: this.get(`rehypePlugins`)
-          ? Object.values(this.get(`rehypePlugins`))
-          : [],
-        remarkPlugins: this.get(`remarkPlugins`)
-          ? Object.values(this.get(`remarkPlugins`))
-          : [],
-      }),
     })
   }
 }

--- a/sources/@roots/bud-mdx/src/index.ts
+++ b/sources/@roots/bud-mdx/src/index.ts
@@ -15,12 +15,7 @@ import {default as BudMDX} from '@roots/bud-mdx/extension'
 
 declare module '@roots/bud-framework' {
   interface Bud {
-    mdx: {
-      get: BudMDX[`get`]
-      getOptions: BudMDX[`getOptions`]
-      set: BudMDX[`set`]
-      setOptions: BudMDX[`setOptions`]
-    }
+    mdx: BudMDX
   }
 
   interface Loaders {
@@ -35,8 +30,10 @@ declare module '@roots/bud-framework' {
     mdx: Rule
   }
 
-  interface Patterns {
-    mdx: RegExp
+  namespace Registry {
+    interface SyncRegistry {
+      'pattern.mdx': RegExp
+    }
   }
 
   interface Modules {


### PR DESCRIPTION
- expose `bud.mdx`
- formatting

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
