### PR TITLE
🧹 chore(none): group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,46 @@ updates:
       prefix: '📦 deps'
     labels:
       - dependencies
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+      aws:
+        patterns:
+          - '@aws*'
+      babel:
+        patterns:
+          - '@babel*'
+          - 'babel-*'
+      eslint:
+        patterns:
+          - 'eslint*'
+          - '@eslint*'
+      lodash:
+        patterns:
+          - 'lodash*'
+      postcss:
+        patterns:
+          - 'postcss*'
+      stylelint:
+        patterns:
+          - 'stylelint*'
+      swc:
+        patterns:
+          - '@swc*'
+      vitest:
+        patterns:
+          - '@vitest*'
+      vue:
+        patterns:
+          - '@vue*'
+          - 'vue*'
+      webpack:
+        patterns:
+          - 'webpack*'
+          - '@webpack*'
+      wordpress:
+        patterns:
+          - '@wordpress*'
 
   - package-ecosystem: github-actions
     assignees:


### PR DESCRIPTION
Update dependabot to group common dependency updates by organization or convention/schema (eg: `@eslint*` and `postcss*`). 

## Type of change

**NONE: internal change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
