### PR TITLE
Update year from 2021 to 2024 in footer copyright

### DIFF
--- a/sources/@repo/docs/i18n/en/docusaurus-theme-classic/footer.json
+++ b/sources/@repo/docs/i18n/en/docusaurus-theme-classic/footer.json
@@ -40,7 +40,7 @@
     "description": "The label of footer link with label=GitHub linking to https://github.com/roots/bud"
   },
   "copyright": {
-    "message": "Copyright © 2021 Roots Foundation, LLC.",
+    "message": "Copyright © 2024 Roots Foundation, LLC.",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
Updated the copyright year in the "message" field.

## Type of change

**PATCH: backwards compatible change**
