### PR TITLE
🩹 fix(patch): fix #2639

### DIFF
--- a/examples/css-module/tailwind.config.ts
+++ b/examples/css-module/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type {Config} from 'tailwindcss'
+
+export default {
+  content: ['./src/**/*.js'],
+  plugins: [],
+} satisfies Config

--- a/sources/@roots/bud-tailwindcss/src/extension/index.ts
+++ b/sources/@roots/bud-tailwindcss/src/extension/index.ts
@@ -79,7 +79,11 @@ class BudTailwindCss extends BudTailwindOptionsApi {
    */
   @bind
   public override async configAfter(bud: Bud) {
-    bud.postcss.setPluginOptions(`tailwindcss`, this.resolveConfig())
+    bud.postcss.setPluginOptions(
+      `tailwindcss`,
+      // @ts-ignore
+      this.editedConfig ? this.resolveConfig() : this.configPath,
+    )
   }
 
   /**


### PR DESCRIPTION
If tailwindcss config is unedited in bud config (no `bud.tailwind` methods called), just pass the config path as a string rather than preprocessing the config. This is to fix compatibility with certain tailwindcss plugins.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
