### PR TITLE
🩹 fix(minor): ensure unique compiler name in cache service

### DIFF
--- a/sources/@roots/bud-cache/src/service.ts
+++ b/sources/@roots/bud-cache/src/service.ts
@@ -77,6 +77,7 @@ export default class Cache extends Service implements BudCache {
    */
   public get name(): string {
     const fallback = join(
+      this.app.label,
       this.app.mode,
       ...Object.values(this.app.context._ ?? {}),
     )

--- a/sources/@roots/bud-cache/test/service.test.ts
+++ b/sources/@roots/bud-cache/test/service.test.ts
@@ -69,7 +69,7 @@ describe(`@roots/bud-cache`, () => {
       expect.arrayContaining([bud.path(`@modules`)]),
     )
     // @ts-ignore
-    expect(cache.configuration?.name).toEqual(`production`)
+    expect(cache.configuration?.name).toEqual(`@tests/project/production`)
     // @ts-ignore
     expect(cache.configuration?.profile).toEqual(false)
     // @ts-ignore

--- a/sources/@roots/wordpress-theme-json-webpack-plugin/src/theme.ts
+++ b/sources/@roots/wordpress-theme-json-webpack-plugin/src/theme.ts
@@ -1176,9 +1176,9 @@ export interface RefComplete {
  */
 export interface StylesElementsPropertiesComplete {
   button?: {
-      [k: string]: unknown
-    } &
-    StylesElementsPseudoSelectorsProperties & StylesProperties
+    [k: string]: unknown
+  } & StylesElementsPseudoSelectorsProperties &
+    StylesProperties
   caption?: StylesPropertiesComplete
   cite?: StylesPropertiesComplete
   h1?: StylesPropertiesComplete
@@ -1189,9 +1189,9 @@ export interface StylesElementsPropertiesComplete {
   h6?: StylesPropertiesComplete
   heading?: StylesPropertiesComplete
   link?: {
-      [k: string]: unknown
-    } &
-    StylesElementsPseudoSelectorsProperties & StylesProperties
+    [k: string]: unknown
+  } & StylesElementsPseudoSelectorsProperties &
+    StylesProperties
 }
 export interface StylesElementsPseudoSelectorsProperties {
   ':active'?: StylesPropertiesComplete


### PR DESCRIPTION
Fixes warnings related to child instances not having a unique cache identity.

## Type of change

**PATCH: backwards compatible change**

<!--
**MAJOR: breaking change**
**MINOR: feature**
**PATCH: backwards compatible change**
**NONE: internal change**
-->
